### PR TITLE
Give docbook IDs unique names

### DIFF
--- a/docs/adk15ProgGuideDB/generics.xml
+++ b/docs/adk15ProgGuideDB/generics.xml
@@ -994,7 +994,7 @@
       
       </sect2>
  
-      <sect2 id="declare-parents" xreflabel="declare-parents">
+      <sect2 id="declare-parents-java5" xreflabel="declare-parents-java5">
           <title>Declare Parents</title>
           
           <para>Both generic and parameterized types can be used as the parent type in a <literal>declare parents</literal>

--- a/docs/adk15ProgGuideDB/miscellaneous.xml
+++ b/docs/adk15ProgGuideDB/miscellaneous.xml
@@ -2,7 +2,7 @@
 
   <title>Other Changes in AspectJ 5</title>
   
-  <sect1 id="pointcuts">
+  <sect1 id="pointcuts-change">
       <title>Pointcuts</title>
       
           <para>
@@ -26,7 +26,7 @@
            
   </sect1>
   
-  <sect1 id="declare-soft">
+  <sect1 id="declare-soft-change">
       <title>Declare Soft</title>
       <para>
           The semantics of the <literal>declare soft</literal> statement have been 

--- a/docs/progGuideDB/gettingstarted.xml
+++ b/docs/progGuideDB/gettingstarted.xml
@@ -217,7 +217,7 @@
 
 <!-- ============================== -->
 
-    <sect2 id="pointcuts" xreflabel="pointcuts">
+    <sect2 id="pointcuts-starting" xreflabel="pointcuts-starting">
       <title>Pointcuts</title>
 
       <para>
@@ -350,7 +350,7 @@ cflow(move())
 
 <!-- ============================== -->
 
-    <sect2 id="advice" xreflabel="advice">
+    <sect2 id="advice-starting" xreflabel="advice-starting">
       <title>Advice</title>
 
       <para>

--- a/docs/progGuideDB/semantics.xml
+++ b/docs/progGuideDB/semantics.xml
@@ -2748,7 +2748,7 @@ ModifiersPattern =
 
     </sect2>
 
-    <sect2 id="advice-precedence" xreflabel="advice-precedence">
+    <sect2 id="advice-precedence-cross" xreflabel="advice-precedence-cross">
       <title>Advice Precedence</title>
 
       <para>


### PR DESCRIPTION
I am trying to bootstrap aspectj for the Fedora Linux distribution.  I'm using xsltproc for now, like Debian does, until saxon becomes available.  Xsltproc complains about duplicate IDs.  This patch changes one of each duplicate to make them unique.  The duplicates are:

- pointcuts in adk15ProgGuideDB/ataspectj.xml and adk15ProgGuideDB/miscellaneous.xml
- declare-parents in adk15ProgGuideDB/annotations.xml and adk15ProgGuideDB/generics.xml
- declare-soft in adk15ProgGuideDB/generics.xml and adk15ProgGuideDB/miscellaneous.xml
- pointcuts in progGuideDB/gettingstarted.xml and progGuideDB/language.xml
- advice in progGuideDB/gettingstarted.xml and progGuideDB/language.xml
- advice-precedence twice in progGuideDB/semantics.xml

I did not find any references to any of these IDs (which is good, because such a reference would have been ambiguous!), so nothing else needs to be fixed.