### PR TITLE
Fix javadoc errors

### DIFF
--- a/ajbrowser/src/main/java/org/aspectj/tools/ajbrowser/ui/EditorManager.java
+++ b/ajbrowser/src/main/java/org/aspectj/tools/ajbrowser/ui/EditorManager.java
@@ -32,7 +32,7 @@ import org.aspectj.tools.ajbrowser.core.BrowserErrorHandler;
 /**
  * Responsible for controlling the editor.
  * 
- * @todo remove coupling to <CODE>BasicEditor</CODE>
+ * <p><b>TODO:</b> remove coupling to <CODE>BasicEditor</CODE></p>
  * @author Mik Kersten
  */
 public class EditorManager {
@@ -117,7 +117,7 @@ public class EditorManager {
 	}
 
 	/**
-	 * @todo remove "instanceof AjdeManager" hack
+	 * <b>TODO</b>: remove "instanceof AjdeManager" hack
 	 */
 	public void showSourceLine(String filePath, int lineNumber, boolean highlight) {
 		if (editors.size() > 1) {

--- a/ajde.core/src/main/java/org/aspectj/ajde/core/IOutputLocationManager.java
+++ b/ajde.core/src/main/java/org/aspectj/ajde/core/IOutputLocationManager.java
@@ -55,7 +55,7 @@ public interface IOutputLocationManager {
 	List<File> getAllOutputLocations();
 
 	/**
-	 * Return the default output location (for example, <my_project>/bin). This is where classes which are on the inpath will be
+	 * Return the default output location (for example, &lt;my_project&gt;/bin). This is where classes which are on the inpath will be
 	 * placed.
 	 */
 	File getDefaultOutputLocation();
@@ -70,7 +70,7 @@ public interface IOutputLocationManager {
 	void reportFileWrite(String outputfile, int fileType);
 
 	/**
-	 * @return a Map<File,String> from inpath absolute paths to handle components
+	 * @return a Map&lt;File,String&gt; from inpath absolute paths to handle components
 	 */
 	Map<File, String> getInpathMap();
 

--- a/ajde/src/main/java/org/aspectj/ajde/Ajde.java
+++ b/ajde/src/main/java/org/aspectj/ajde/Ajde.java
@@ -160,7 +160,6 @@ public class Ajde {
 	 * Utility to run the project main class from the project properties in the same VM using a class loader populated with the
 	 * classpath and output path or jar. Errors are logged to the ErrorHandler.
 	 * 
-	 * @param project the ProjectPropertiesAdapter specifying the main class, classpath, and executable arguments.
 	 * @return Thread running with process, or null if unable to start
 	 */
 	public Thread runInSameVM() {

--- a/ajde/src/main/java/org/aspectj/ajde/internal/BuildConfigManager.java
+++ b/ajde/src/main/java/org/aspectj/ajde/internal/BuildConfigManager.java
@@ -39,7 +39,7 @@ public interface BuildConfigManager {
 	/**
 	 * Sets the currently active build configuration file.
 	 *
-	 * @param	full path to the file
+	 * @param currConfigFilePath	full path to the file
 	 */
 	void setActiveConfigFile(String currConfigFilePath);
 
@@ -56,7 +56,7 @@ public interface BuildConfigManager {
 	/**
 	 * Build a model for the corresponding configuration file.
 	 *
-	 * @param	full path to the file
+	 * @param configFilePath	full path to the file
 	 */
 	BuildConfigModel buildModel(String configFilePath);
 

--- a/ajde/src/main/java/org/aspectj/ajde/internal/StructureUtilities.java
+++ b/ajde/src/main/java/org/aspectj/ajde/internal/StructureUtilities.java
@@ -20,7 +20,7 @@ package org.aspectj.ajde.internal;
 
 /**
  * Utility class for building a structure model for a given compile. Typical command-line usage: <BR>
- * &nbsp;&nbsp;&gt; <TT>java org.aspectj.tools.ajde.StructureManager @&lt;config-file&gt;.lst</TT>
+ * &nbsp;&nbsp;&gt; {@code java org.aspectj.tools.ajde.StructureManager @&lt;config-file&gt;.lst}
  */
 public class StructureUtilities {
 

--- a/ajde/src/main/java/org/aspectj/ajde/ui/BuildConfigEditor.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/BuildConfigEditor.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 public interface BuildConfigEditor {
 
 	/**
-	 * @param	the full path to the file resource to be opened
+	 * @param filePath	the full path to the file resource to be opened
 	 */
 	void openFile(String filePath) throws IOException, InvalidResourceException;
 }

--- a/ajde/src/main/java/org/aspectj/ajde/ui/InvalidResourceException.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/InvalidResourceException.java
@@ -18,7 +18,7 @@ package org.aspectj.ajde.ui;
  * @author Mik Kersten
  *
  * To change this generated comment edit the template variable "typecomment":
- * Window>Preferences>Java>Templates.
+ * Window&gt;Preferences&gt;Java&gt;Templates.
  */
 public class InvalidResourceException extends Exception {
 

--- a/ajde/src/main/java/org/aspectj/ajde/ui/StructureViewManager.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/StructureViewManager.java
@@ -93,9 +93,6 @@ public class StructureViewManager {
 		}
 	}
 
-	/**
-	 * History is recorded for {@link LinkNode} navigations.
-	 */
 	public void fireNavigationAction(IProgramElement pe, boolean isLink) {
 		navigationAction(pe, isLink);
 	}

--- a/ajde/src/main/java/org/aspectj/ajde/ui/internal/TreeStructureViewBuilder.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/internal/TreeStructureViewBuilder.java
@@ -43,7 +43,7 @@ public class TreeStructureViewBuilder {
 	}
 
 	/**
-	 * @todo	get rid of instanceof tests
+	 * <b>TODO</b>:	get rid of instanceof tests
 	 */
 	public void buildView(StructureView view, IHierarchy model) {
 		//		StructureViewProperties properties = view.getViewProperties();

--- a/ajde/src/main/java/org/aspectj/ajde/ui/swing/BuildProgressPanel.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/swing/BuildProgressPanel.java
@@ -45,10 +45,6 @@ public class BuildProgressPanel extends JPanel {
 
     private boolean buildIsCancelled = false;
 	
-	/**
-	 * @param   maxVal          the value to which value to which the progress bar will
-	 *                          count up to (in seconds)
-	 */
 	public BuildProgressPanel() {
 		try {
 			jbInit();
@@ -83,6 +79,10 @@ public class BuildProgressPanel extends JPanel {
 		compile_progressBar.setValue(newVal);
 	}
 
+	/**
+	 * @param   maxVal          the value to which value to which the progress bar will
+	 *                          count up to (in seconds)
+	 */
 	public void setProgressBarMax(int maxVal) {
 		compile_progressBar.setMaximum(maxVal);
 	}

--- a/ajde/testdata/examples/spacewar/spacewar/Game.java
+++ b/ajde/testdata/examples/spacewar/spacewar/Game.java
@@ -68,7 +68,7 @@ public class Game extends Thread {
      * thread.  You can instantiate multiple games at once.  For the time being
      * the only way to end the game is to exit from the Java VM.
      *
-     * @param isDemo Controls whether the game runs in demo mode or not.  True
+     * @param mode Controls whether the game runs in demo mode or not.  True
      *   means it is a demo, false means it runs in normal 2 player mode.
      */
     public Game(String mode) {

--- a/ajdoc/src/main/java/org/aspectj/tools/ajdoc/Main.java
+++ b/ajdoc/src/main/java/org/aspectj/tools/ajdoc/Main.java
@@ -794,7 +794,7 @@ public class Main implements Config {
 	}
 
 	/**
-	 * Sets the output working dir to be <fullyQualifiedOutputDir>\ajdocworkingdir Useful in testing to redirect the ajdocworkingdir
+	 * Sets the output working dir to be &lt;fullyQualifiedOutputDir&gt;\ajdocworkingdir. Useful in testing to redirect the ajdocworkingdir
 	 * to the sandbox
 	 */
 	public static void setOutputWorkingDir(String fullyQulifiedOutputDir) {
@@ -806,7 +806,7 @@ public class Main implements Config {
 	}
 
 	/**
-	 * Resets the output working dir to be the default which is <the current directory>\ajdocworkingdir
+	 * Resets the output working dir to be the default which is &lt;the current directory&gt;\ajdocworkingdir
 	 */
 	public static void resetOutputWorkingDir() {
 		outputWorkingDir = Config.WORKING_DIR;

--- a/ajdoc/testdata/spacewar/spacewar/Game.java
+++ b/ajdoc/testdata/spacewar/spacewar/Game.java
@@ -68,7 +68,7 @@ public class Game extends Thread {
      * thread.  You can instantiate multiple games at once.  For the time being
      * the only way to end the game is to exit from the Java VM.
      *
-     * @param isDemo Controls whether the game runs in demo mode or not.  True
+     * @param mode Controls whether the game runs in demo mode or not.  True
      *   means it is a demo, false means it runs in normal 2 player mode.
      */
     public Game(String mode) {

--- a/asm/src/main/java/org/aspectj/asm/IHierarchy.java
+++ b/asm/src/main/java/org/aspectj/asm/IHierarchy.java
@@ -75,12 +75,12 @@ public interface IHierarchy extends Serializable {
 
 	/**
 	 * @param packageName if null default package is searched
-	 * @param className can't be null
+	 * @param typeName can't be null
 	 */
 	IProgramElement findElementForType(String packageName, String typeName);
 
 	/**
-	 * @param sourceFilePath modified to '/' delimited path for consistency
+	 * @param sourceFile modified to '/' delimited path for consistency
 	 * @return a new structure node for the file if it was not found in the model
 	 */
 	IProgramElement findElementForSourceFile(String sourceFile);

--- a/asm/src/main/java/org/aspectj/asm/IModelFilter.java
+++ b/asm/src/main/java/org/aspectj/asm/IModelFilter.java
@@ -21,7 +21,7 @@ public interface IModelFilter {
 
 	/**
 	 * Called when about to dump out an absolute file location, enabling it to be altered (eg.
-	 * c:/temp/ajcsSandbox/foo/ajctemp.12323/<BLAH> could become TEST_SANDBOX/<BLAH>
+	 * c:/temp/ajcsSandbox/foo/ajctemp.12323/&lt;BLAH&gt; could become TEST_SANDBOX/&lt;BLAH&gt;
 	 */
 	String processFilelocation(String loc);
 

--- a/asm/src/main/java/org/aspectj/asm/IProgramElement.java
+++ b/asm/src/main/java/org/aspectj/asm/IProgramElement.java
@@ -95,7 +95,7 @@ public interface IProgramElement extends Serializable {
 	String getPackageName();
 
 	/**
-	 * @param method
+	 * @param returnType
 	 *            return types or field types
 	 */
 	void setCorrespondingType(String returnType);

--- a/asm/src/main/java/org/aspectj/asm/IRelationshipMap.java
+++ b/asm/src/main/java/org/aspectj/asm/IRelationshipMap.java
@@ -21,15 +21,16 @@ import java.util.Set;
  * the list or relationships is uniquely identified by a kind and a relationship name. For example, the advice affecting a
  * particular shadow (e.g. method call) can be retrieved by calling <CODE>get</CODE> on the handle for that method. Symmetrically
  * the method call shadows that an advice affects can be retrieved.
- * <p>
  *
  * <p>
  * The elements can be stored and looked up as IProgramElement(s), in which cases the element corresponding to the handle is looked
  * up in the containment hierarchy.
+ * </p>
  *
  * <p>
  * put/get methods taking IProgramElement as a parameter are for convenience only. They work identically to calling their
  * counterparts with IProgramElement.getIdentifierHandle()
+ * </p>
  *
  * @author Mik Kersten
  * @author Andy Clement

--- a/asm/src/main/java/org/aspectj/asm/internal/AspectJElementHierarchy.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/AspectJElementHierarchy.java
@@ -321,7 +321,7 @@ public class AspectJElementHierarchy implements IHierarchy {
 	}
 
 	/**
-	 * @param sourceFilePath modified to '/' delimited path for consistency
+	 * @param sourceFile modified to '/' delimited path for consistency
 	 * @return a new structure node for the file if it was not found in the model
 	 */
 	public IProgramElement findElementForSourceFile(String sourceFile) {

--- a/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
@@ -21,9 +21,9 @@ import org.aspectj.bridge.ISourceLocation;
 /**
  * Creates JDT-like handles, for example
  * 
- * method with string argument: <tjp{Demo.java[Demo~main~\[QString; method with generic argument:
- * <pkg{MyClass.java[MyClass~myMethod~QList\<QString;>; an aspect: <pkg*A1.aj}A1 advice with Integer arg:
- * <pkg*A8.aj}A8&afterReturning&QInteger; method call: <pkg*A10.aj[C~m1?method-call(void pkg.C.m2())
+ * method with string argument: &lt;tjp{Demo.java[Demo~main~\[QString; method with generic argument:
+ * &lt;pkg{MyClass.java[MyClass~myMethod~QList\&lt;QString;&gt;; an aspect: &lt;pkg*A1.aj}A1 advice with Integer arg:
+ * &lt;pkg*A8.aj}A8&amp;afterReturning&amp;QInteger; method call: &lt;pkg*A10.aj[C~m1?method-call(void pkg.C.m2())
  * 
  */
 public class JDTLikeHandleProvider implements IElementHandleProvider {

--- a/asm/src/main/java/org/aspectj/asm/internal/NameConvertor.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/NameConvertor.java
@@ -44,7 +44,7 @@ public class NameConvertor {
 
 	/**
 	 * Creates a readable name from the given char array, for example, given 'I' returns 'int'. Moreover, given
-	 * 'Ljava/lang/String;<Ljava/lang/String;>' returns 'java.lang.String<java.lang.String>'
+	 * 'Ljava/lang/String;&lt;Ljava/lang/String;&gt;' returns 'java.lang.String&lt;java.lang.String&gt;'
 	 */
 	public static char[] convertFromSignature(char[] c) {
 		int lt = CharOperation.indexOf('<', c);
@@ -138,7 +138,7 @@ public class NameConvertor {
 	// }
 
 	/**
-	 * Given 'Ppkg/MyGenericClass<Ljava/lang/String;Ljava/lang/Integer;>;' will return 'QMyGenericClass<QString;QInteger;>;'
+	 * Given 'Ppkg/MyGenericClass&lt;Ljava/lang/String;Ljava/lang/Integer;&gt;;' will return 'QMyGenericClass&lt;QString;QInteger;&gt;;'
 	 */
 	public static char[] createShortName(char[] c, boolean haveFullyQualifiedAtLeastOneThing, boolean needsFullyQualifiedFirstEntry) {
 		if (c[0] == '[') {

--- a/asm/src/main/java/org/aspectj/asm/internal/ProgramElement.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/ProgramElement.java
@@ -497,7 +497,7 @@ public class ProgramElement implements IProgramElement {
 	}
 
 	/**
-	 * Trim down fully qualified types to their short form (e.g. a.b.c.D<e.f.G> becomes D<G>)
+	 * Trim down fully qualified types to their short form (e.g., a.b.c.D&lt;e.f.G&gt; becomes D&lt;G&gt;)
 	 */
 	public static String trim(String fqname) {
 		int i = fqname.indexOf("<");
@@ -655,7 +655,7 @@ public class ProgramElement implements IProgramElement {
 	}
 
 	/**
-	 * TODO: move the "parent != null"==>injar heuristic to more explicit
+	 * TODO: move the "parent != null"&rarr;injar heuristic to more explicit
 	 */
 	public String toLinkLabelString() {
 		return toLinkLabelString(true);

--- a/bridge/src/main/java/org/aspectj/bridge/CountingMessageHandler.java
+++ b/bridge/src/main/java/org/aspectj/bridge/CountingMessageHandler.java
@@ -90,9 +90,9 @@ public class CountingMessageHandler implements IMessageHandler {
 	 * Return count of messages seen through this interface.
 	 * 
 	 * @param kind the IMessage.Kind of the messages to count (if null, count all)
-	 * @param orGreater if true, then count this kind and any considered greater by the ordering of IMessage.Kind.COMPARATOR
+	 * @param orGreater if true, then count this kind and any considered greater by the ordering of IMessage.Kind#COMPARATOR
 	 * @return number of messages of this kind (optionally or greater)
-	 * @see IMessage.Kind.COMPARATOR
+	 * @see IMessage.Kind#COMPARATOR
 	 */
 	public int numMessages(IMessage.Kind kind, boolean orGreater) {
 		if (null != proxy) {

--- a/bridge/src/main/java/org/aspectj/bridge/IMessage.java
+++ b/bridge/src/main/java/org/aspectj/bridge/IMessage.java
@@ -146,5 +146,18 @@ public interface IMessage {
 	 * being based on a subtype of a defining type.
 	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=41952">AspectJ bug 41952</a>
 	 */
+	/**
+	 * Return a List of <code>ISourceLocation</code> instances that indicate additional source locations relevent to this message as
+	 *         specified by the message creator. The list should not include the primary source location associated with the message
+	 *         which can be obtained from <code>getSourceLocation()<code>.
+	 * <p>
+	 * An example of using extra locations would be in a warning message that
+	 * flags all shadow locations that will go unmatched due to a pointcut definition
+	 * being based on a subtype of a defining type.
+	 * </p>
+	 *
+	 * @return a list of additional source locations
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=41952">AspectJ bug 41952</a>
+	 */
 	List<ISourceLocation> getExtraSourceLocations();
 }

--- a/bridge/src/main/java/org/aspectj/bridge/IMessage.java
+++ b/bridge/src/main/java/org/aspectj/bridge/IMessage.java
@@ -40,7 +40,7 @@ public interface IMessage {
 	// public static final Kind ANY = new Kind("any-selector", 0);
 
 	/**
-	 * list of Kind in precedence order. 0 is less than IMessage.Kind.COMPARATOR.compareTo(KINDS.get(i), KINDS.get(i + 1))
+	 * list of Kind in precedence order. 0 is less than IMessage.Kind#COMPARATOR.compareTo(KINDS.get(i), KINDS.get(i + 1))
 	 */
 	List<Kind> KINDS = Collections.unmodifiableList(Arrays.asList(new Kind[] { WEAVEINFO, INFO, DEBUG, TASKTAG,
 			WARNING, ERROR, FAIL, ABORT }));

--- a/bridge/src/main/java/org/aspectj/bridge/ISourceLocation.java
+++ b/bridge/src/main/java/org/aspectj/bridge/ISourceLocation.java
@@ -20,9 +20,6 @@ import java.io.File;
  * why?
  *
  * @see org.aspectj.lang.reflect.SourceLocation
- * @see org.aspectj.compiler.base.parser.SourceInfo
- * @see org.aspectj.tools.ide.SourceLine
- * @see org.aspectj.testing.harness.ErrorLine
  */
 public interface ISourceLocation extends java.io.Serializable {
 	int MAX_LINE = Integer.MAX_VALUE / 2;

--- a/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
+++ b/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
@@ -260,7 +260,7 @@ public class MessageUtil {
 	/**
 	 * Print all message to the print stream, starting each on a new line, with a prefix.
 	 *
-	 * @param messageHolder
+	 * @param holder
 	 * @param out
 	 * @see #print(PrintStream, String, IMessageHolder, IMessageRenderer, IMessageHandler)
 	 */
@@ -271,7 +271,7 @@ public class MessageUtil {
 	/**
 	 * Print all message to the print stream, starting each on a new line, with a prefix and using a renderer.
 	 *
-	 * @param messageHolder
+	 * @param holder
 	 * @param out
 	 * @param renderer IMessageRender to render result - use MESSAGE_LINE if null
 	 * @see #print(PrintStream, String, IMessageHolder, IMessageRenderer, IMessageHandler)
@@ -292,7 +292,8 @@ public class MessageUtil {
 	 * are free to render multi-line output.
 	 *
 	 * @param out the PrintStream sink - return silently if null
-	 * @param messageHolder the IMessageHolder with the messages to print
+	 * @param holder the IMessageHolder with the messages to print
+	 * @param prefix the prefix for each line
 	 * @param renderer IMessageRender to render result - use MESSAGE_ALL if null
 	 * @param selector IMessageHandler to select messages to render - if null, do all non-null
 	 */
@@ -1038,8 +1039,8 @@ public class MessageUtil {
 	/**
 	 * Handle all messages in the second handler using the first
 	 *
-	 * @param handler the IMessageHandler sink for all messages in source
-	 * @param holder the IMessageHolder source for all messages to handle
+	 * @param sink the IMessageHandler sink for all messages in source
+	 * @param source the IMessageHolder source for all messages to handle
 	 * @param fastFail if true, stop on first failure
 	 * @return false if any sink.handleMessage(..) failed
 	 */
@@ -1050,8 +1051,8 @@ public class MessageUtil {
 	/**
 	 * Handle messages in the second handler using the first
 	 *
-	 * @param handler the IMessageHandler sink for all messages in source
-	 * @param holder the IMessageHolder source for all messages to handle
+	 * @param sink the IMessageHandler sink for all messages in source
+	 * @param source the IMessageHolder source for all messages to handle
 	 * @param kind the IMessage.Kind to select, if not null
 	 * @param orGreater if true, also accept greater kinds
 	 * @param fastFail if true, stop on first failure
@@ -1068,8 +1069,8 @@ public class MessageUtil {
 	 * Handle messages in the second handler using the first if they are NOT of this kind (optionally, or greater). If you pass null
 	 * as the kind, then all messages are ignored and this returns true.
 	 *
-	 * @param handler the IMessageHandler sink for all messages in source
-	 * @param holder the IMessageHolder source for all messages to handle
+	 * @param sink the IMessageHandler sink for all messages in source
+	 * @param source the IMessageHolder source for all messages to handle
 	 * @param kind the IMessage.Kind to reject, if not null
 	 * @param orGreater if true, also reject greater kinds
 	 * @param fastFail if true, stop on first failure
@@ -1089,7 +1090,7 @@ public class MessageUtil {
 	/**
 	 * Handle messages in the sink.
 	 *
-	 * @param handler the IMessageHandler sink for all messages in source
+	 * @param sink the IMessageHandler sink for all messages in source
 	 * @param sources the IMessage[] messages to handle
 	 * @param fastFail if true, stop on first failure
 	 * @return false if any sink.handleMessage(..) failed

--- a/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
+++ b/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
@@ -251,7 +251,7 @@ public class MessageUtil {
 	 *
 	 * @param messageHolder
 	 * @param out
-	 * @see #print(PrintStream, String, IMessageHolder, IMessageRenderer, IMessageHandler)
+	 * @see #print(PrintStream, IMessageHolder, String, IMessageRenderer, IMessageHandler)
 	 */
 	public static void print(PrintStream out, IMessageHolder messageHolder) {
 		print(out, messageHolder, (String) null, (IMessageRenderer) null, (IMessageHandler) null);
@@ -262,7 +262,7 @@ public class MessageUtil {
 	 *
 	 * @param holder
 	 * @param out
-	 * @see #print(PrintStream, String, IMessageHolder, IMessageRenderer, IMessageHandler)
+	 * @see #print(PrintStream, IMessageHolder, String, IMessageRenderer, IMessageHandler)
 	 */
 	public static void print(PrintStream out, IMessageHolder holder, String prefix) {
 		print(out, holder, prefix, (IMessageRenderer) null, (IMessageHandler) null);
@@ -274,7 +274,7 @@ public class MessageUtil {
 	 * @param holder
 	 * @param out
 	 * @param renderer IMessageRender to render result - use MESSAGE_LINE if null
-	 * @see #print(PrintStream, String, IMessageHolder, IMessageRenderer, IMessageHandler)
+	 * @see #print(PrintStream, IMessageHolder, String, IMessageRenderer, IMessageHandler)
 	 */
 	public static void print(PrintStream out, IMessageHolder holder, String prefix, IMessageRenderer renderer) {
 		print(out, holder, prefix, renderer, (IMessageHandler) null);
@@ -401,7 +401,7 @@ public class MessageUtil {
 	 *
 	 * @param messages if null, return EMPTY_LIST
 	 * @param kind if null, return messages
-	 * @see MessageHandler#getMessages(Kind)
+	 * @see MessageHandler#getMessages(Kind, boolean)
 	 */
 	public static List<IMessage> getMessages(List<IMessage> messages, IMessage.Kind kind) {
 		if (null == messages) {

--- a/bridge/src/main/java/org/aspectj/bridge/SourceLocation.java
+++ b/bridge/src/main/java/org/aspectj/bridge/SourceLocation.java
@@ -22,9 +22,6 @@ import org.aspectj.util.LangUtil;
  * endLine.
  * 
  * @see org.aspectj.lang.reflect.SourceLocation
- * @see org.aspectj.compiler.base.parser.SourceInfo
- * @see org.aspectj.tools.ide.SourceLine
- * @see org.aspectj.testing.harness.ErrorLine
  */
 public class SourceLocation implements ISourceLocation {
 

--- a/bridge/src/main/java/org/aspectj/bridge/SourceLocation.java
+++ b/bridge/src/main/java/org/aspectj/bridge/SourceLocation.java
@@ -18,7 +18,7 @@ import java.io.File;
 import org.aspectj.util.LangUtil;
 
 /**
- * Immutable source location. This guarantees that the source file is not null and that the numeric values are positive and line <=
+ * Immutable source location. This guarantees that the source file is not null and that the numeric values are positive and line &le;
  * endLine.
  * 
  * @see org.aspectj.lang.reflect.SourceLocation
@@ -77,7 +77,7 @@ public class SourceLocation implements ISourceLocation {
 	/**
 	 * @param file File of the source; if null, use ISourceLocation.NO_FILE, not null
 	 * @param line int starting line of the location - positive number
-	 * @param endLine int ending line of the location - <= starting line
+	 * @param endLine int ending line of the location - &le; starting line
 	 * @param column int character position of starting location - positive number
 	 */
 	public SourceLocation(File file, int line, int endLine, int column) {

--- a/docs/dist/doc/examples/spacewar/Game.java
+++ b/docs/dist/doc/examples/spacewar/Game.java
@@ -68,7 +68,7 @@ public class Game extends Thread {
      * thread.  You can instantiate multiple games at once.  For the time being
      * the only way to end the game is to exit from the Java VM.
      *
-     * @param isDemo Controls whether the game runs in demo mode or not.  True
+     * @param mode Controls whether the game runs in demo mode or not.  True
      *   means it is a demo, false means it runs in normal 2 player mode.
      */
     public Game(String mode) {

--- a/docs/teaching/demos/spacewar/src/spacewar/Game.java
+++ b/docs/teaching/demos/spacewar/src/spacewar/Game.java
@@ -68,7 +68,7 @@ public class Game extends Thread {
      * thread.  You can instantiate multiple games at once.  For the time being
      * the only way to end the game is to exit from the Java VM.
      *
-     * @param isDemo Controls whether the game runs in demo mode or not.  True
+     * @param mode Controls whether the game runs in demo mode or not.  True
      *   means it is a demo, false means it runs in normal 2 player mode.
      */
     public Game(String mode) {

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/Aj.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/Aj.java
@@ -34,7 +34,7 @@ import org.aspectj.weaver.tools.cache.SimpleCacheFactory;
  * Adapter between the generic class pre processor interface and the AspectJ weaver Load time weaving consistency relies on
  * Bcel.setRepository
  * 
- * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+ * @author Alexandre Vasseur (alex AT gnilux DOT com)
  */
 public class Aj implements ClassPreProcessor {
 

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/Aj.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/Aj.java
@@ -43,7 +43,7 @@ public class Aj implements ClassPreProcessor {
 
 	/**
 	 * References are added to this queue when their associated classloader is removed, and once on here that indicates that we
-	 * should tidy up the adaptor map and remove the adaptor (weaver) from the map we are maintaining from adaptorkey > adaptor
+	 * should tidy up the adaptor map and remove the adaptor (weaver) from the map we are maintaining from adaptorkey &gt; adaptor
 	 * (weaver)
 	 */
 	private static ReferenceQueue adaptorQueue = new ReferenceQueue();

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/DefaultMessageHandler.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/DefaultMessageHandler.java
@@ -16,7 +16,7 @@ import org.aspectj.bridge.IMessage;
 import org.aspectj.bridge.IMessageHandler;
 
 /**
- * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+ * @author Alexandre Vasseur (alex AT gnilux DOT com)
  */
 public class DefaultMessageHandler implements IMessageHandler {
 

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/DefaultWeavingContext.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/DefaultWeavingContext.java
@@ -119,7 +119,7 @@ public class DefaultWeavingContext implements IWeavingContext {
 	/**
 	 * Simply call weaving adaptor back to parse aop.xml
 	 * 
-	 * @param weaver
+	 * @param adaptor
 	 * @param loader
 	 */
 	public List<Definition> getDefinitions(final ClassLoader loader, final WeavingAdaptor adaptor) {

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/Options.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/Options.java
@@ -23,7 +23,7 @@ import org.aspectj.util.LangUtil;
  * A class that hanldes LTW options. Note: AV - I choosed to not reuse AjCompilerOptions and alike since those implies too many
  * dependancies on jdt and ajdt modules.
  *
- * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+ * @author Alexandre Vasseur (alex AT gnilux DOT com)
  */
 public class Options {
 

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/ajc/BuildArgParser.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/ajc/BuildArgParser.java
@@ -333,7 +333,7 @@ public class BuildArgParser extends Main {
 	 *
 	 * @param flush if true, empty errors
 	 * @return null if none, String otherwise
-	 * @see BuildArgParser()
+	 * @see #BuildArgParser(IMessageHandler)
 	 */
 	public String getOtherMessages(boolean flush) {
 		if (null == errorSink) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjCompilerAdapter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjCompilerAdapter.java
@@ -76,8 +76,8 @@ public class AjCompilerAdapter extends AbstractCompilerAdapter {
 	 * @param weaver the weaver
 	 * @param intRequestor recipient of interim compilation results from compiler (pre-weave)
 	 * @param outputFileNameProvider implementor of a strategy providing output file names for results
-	 * @param binarySourceEntries binary source that we didn't compile, but that we need to weave
-	 * @param resultSetForFullWeave if we are doing an incremental build, and the weaver determines that we need to weave the world,
+	 * @param binarySourceProvider binary source that we didn't compile, but that we need to weave
+	 * @param incrementalCompilationState if we are doing an incremental build, and the weaver determines that we need to weave the world,
 	 *        this is the set of intermediate results that will be passed to the weaver.
 	 */
 	public AjCompilerAdapter(Compiler compiler, boolean isBatchCompile, BcelWorld world, BcelWeaver weaver,

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjPipeliningCompilerAdapter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjPipeliningCompilerAdapter.java
@@ -64,28 +64,28 @@ import org.aspectj.weaver.bcel.UnwovenClassFile;
  * Here is the compiler loop difference when pipelining.
  * 
  * the old way: Finished diet parsing [C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java] Finished diet parsing
- * [C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java] > AjLookupEnvironment.completeTypeBindings() <
+ * [C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java] &gt; AjLookupEnvironment.completeTypeBindings() &lt;
  * AjLookupEnvironment.completeTypeBindings() compiling C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java
- * >Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java)
- * <Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java) compiling
+ * &gt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java)
+ * &lt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java) compiling
  * C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java
- * >Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java)
- * <Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java) >AjCompilerAdapter.weave()
- * >BcelWeaver.prepareForWeave <BcelWeaver.prepareForWeave woven class ClassOne (from
+ * &gt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java)
+ * &lt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java) &gt;AjCompilerAdapter.weave()
+ * &gt;BcelWeaver.prepareForWeave &lt;BcelWeaver.prepareForWeave woven class ClassOne (from
  * C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java) woven class ClassTwo (from
- * C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java) <AjCompilerAdapter.weave()
+ * C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java) &lt;AjCompilerAdapter.weave()
  * 
  * the new way (see the compiling/weaving mixed up): Finished diet parsing
  * [C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java] Finished diet parsing
- * [C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java] >AjLookupEnvironment.completeTypeBindings()
- * <AjLookupEnvironment.completeTypeBindings() compiling C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java
- * >Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java)
- * <Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java) >AjCompilerAdapter.weave()
- * >BcelWeaver.prepareForWeave <BcelWeaver.prepareForWeave woven class ClassOne (from
- * C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java) <AjCompilerAdapter.weave() compiling
+ * [C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java] &gt;AjLookupEnvironment.completeTypeBindings()
+ * &lt;AjLookupEnvironment.completeTypeBindings() compiling C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java
+ * &gt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java)
+ * &lt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java) &gt;AjCompilerAdapter.weave()
+ * &gt;BcelWeaver.prepareForWeave &lt;BcelWeaver.prepareForWeave woven class ClassOne (from
+ * C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassOne.java) &lt;AjCompilerAdapter.weave() compiling
  * C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java
- * >Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java)
- * <Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java) >AjCompilerAdapter.weave() woven class ClassTwo
+ * &gt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java)
+ * &lt;Compiler.process(C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java) &gt;AjCompilerAdapter.weave() woven class ClassTwo
  * (from C:\temp\ajcSandbox\aspectjhead\ajcTest23160.tmp\ClassTwo.java) <AjCompilerAdapter.weave()
  * 
  * 

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjPipeliningCompilerAdapter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjPipeliningCompilerAdapter.java
@@ -135,8 +135,8 @@ public class AjPipeliningCompilerAdapter extends AbstractCompilerAdapter {
 	 * @param weaver the weaver
 	 * @param intRequestor recipient of interim compilation results from compiler (pre-weave)
 	 * @param outputFileNameProvider implementor of a strategy providing output file names for results
-	 * @param binarySourceEntries binary source that we didn't compile, but that we need to weave
-	 * @param resultSetForFullWeave if we are doing an incremental build, and the weaver determines that we need to weave the world,
+	 * @param binarySourceProvider binary source that we didn't compile, but that we need to weave
+	 * @param incrementalCompilationState if we are doing an incremental build, and the weaver determines that we need to weave the world,
 	 *        this is the set of intermediate results that will be passed to the weaver.
 	 */
 	public AjPipeliningCompilerAdapter(Compiler compiler, boolean isBatchCompile, BcelWorld world, BcelWeaver weaver,

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/CompilationResultDestinationManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/CompilationResultDestinationManager.java
@@ -57,7 +57,7 @@ public interface CompilationResultDestinationManager {
 	List /* File */getAllOutputLocations();
 
 	/**
-	 * Return the default output location (for example, <my_project>/bin). This is where classes which are on the inpath will be
+	 * Return the default output location (for example, &lt;my_project&gt;/bin). This is where classes which are on the inpath will be
 	 * placed.
 	 */
 	File getDefaultOutputLocation();

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/IfPseudoToken.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/IfPseudoToken.java
@@ -46,7 +46,7 @@ import org.aspectj.weaver.patterns.Pointcut;
  * generates the following: public static final boolean ajc$if_N(formals*,
  * [thisJoinPoints as needed]) { return expr; }
  * 
- * Here's the complicated bit, it deals with cflow: (a): ... this(a) && cflow(if
+ * Here's the complicated bit, it deals with cflow: (a): ... this(a) &amp;&amp; cflow(if
  * (a == foo)) is an error. The way we capture this is: We generate the ajc$if
  * method with an (a) parameter, we let eclipse do the proper name binding. We
  * then, as a post pass (that we need to do anyway) look for the used

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/InterTypeDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/InterTypeDeclaration.java
@@ -347,7 +347,7 @@ public abstract class InterTypeDeclaration extends AjMethodDeclaration {
 
 	/** 
 	 * Create the list of aliases based on what was supplied as parameters for the ontype.
-	 * For example, if the declaration is 'List<N>  SomeType<N>.foo' then the alias list
+	 * For example, if the declaration is 'List&lt;N&gt;  SomeType&lt;N&gt;.foo' then the alias list
 	 * will simply contain 'N' and 'N' will mean 'the first type variable declared for
 	 * type SomeType'
 	 */

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseResolvedMember.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseResolvedMember.java
@@ -46,7 +46,7 @@ import org.aspectj.weaver.bcel.BcelObjectType;
 /**
  * In the pipeline world, we can be weaving before all types have come through from compilation. In some cases this means the weaver
  * will want to ask questions of eclipse types and this subtype of ResolvedMemberImpl is here to answer some of those questions - it
- * is backed by the real eclipse MethodBinding object and can translate from Eclipse -> Weaver information.
+ * is backed by the real eclipse MethodBinding object and can translate from Eclipse &rarr; Weaver information.
  */
 public class EclipseResolvedMember extends ResolvedMemberImpl {
 

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PointcutBinding.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PointcutBinding.java
@@ -20,14 +20,14 @@ import org.aspectj.org.eclipse.jdt.internal.compiler.lookup.Binding;
  */
 public class PointcutBinding extends Binding {
 
-	/**
+	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.internal.compiler.lookup.BindingPattern#bindingType()
 	 */
 	public int bindingType() {
 		return 0;
 	}
 
-	/**
+	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.internal.compiler.lookup.BindingPattern#readableName()
 	 */
 	public char[] readableName() {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
@@ -448,8 +448,8 @@ public class AjBuildConfig implements CompilerConfigurationChangeFlags {
 	 * <li>Collections are unioned</li>
 	 * <li>values takes local value unless default and global set</li>
 	 * <li>this only sets one of outputDir and outputJar as needed</li>
-	 * <ul>
-	 * This also configures super if javaOptions change.
+	 * </ul>
+	 * <p>This also configures super if javaOptions change.</p>
 	 *
 	 * @param global the AjBuildConfig to read globals from
 	 */

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/IncrementalStateManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/IncrementalStateManager.java
@@ -28,7 +28,7 @@ import org.aspectj.weaver.CompressingDataOutputStream;
  * Central point for all things incremental... - keeps track of the state recorded for each different config file - allows limited
  * interaction with these states
  * 
- * - records dependency/change info for particular classpaths &gt; this will become what JDT keeps in its 'State' object when its
+ * - records dependency/change info for particular classpaths &gt; this will become what JDT keeps in its 'State' object when it's
  * finished
  */
 public class IncrementalStateManager {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/IncrementalStateManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/IncrementalStateManager.java
@@ -28,7 +28,7 @@ import org.aspectj.weaver.CompressingDataOutputStream;
  * Central point for all things incremental... - keeps track of the state recorded for each different config file - allows limited
  * interaction with these states
  * 
- * - records dependency/change info for particular classpaths > this will become what JDT keeps in its 'State' object when its
+ * - records dependency/change info for particular classpaths &gt; this will become what JDT keeps in its 'State' object when its
  * finished
  */
 public class IncrementalStateManager {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTConverter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTConverter.java
@@ -3584,7 +3584,7 @@ public class AjASTConverter extends ASTConverter {
 
 	/**
 	 * This method is used to retrieve the ending position for a type declaration when the dimension is right after the type name.
-	 * For example: int[] i; => return 5, but int i[] => return -1;
+	 * For example: int[] i; &rarr; return 5, but int i[] &rarr; return -1;
 	 * 
 	 * @return int the dimension found
 	 */

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTMatcher.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTMatcher.java
@@ -16,8 +16,8 @@ public class AjASTMatcher extends ASTMatcher {
 	/**
 	 * Creates a new AST matcher instance.
 	 * <p>
-	 * For backwards compatibility, the matcher ignores tag elements below doc comments by default. Use {@link #ASTMatcher(boolean)
-	 * ASTMatcher(true)} for a matcher that compares doc tags by default.
+	 * For backwards compatibility, the matcher ignores tag elements below doc comments by default. Use {@link #AjASTMatcher(boolean)
+	 * AjASTMatcher(true)} for a matcher that compares doc tags by default.
 	 * </p>
 	 */
 	public AjASTMatcher() {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjNaiveASTFlattener.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjNaiveASTFlattener.java
@@ -23,13 +23,15 @@ import java.util.List;
  * fine for generating debug print strings.
  * <p>
  * Example usage:
- * <code>
+ * </p>
  * <pre>
+ * <code>
  *    NaiveASTFlattener p = new NaiveASTFlattener();
  *    node.accept(p);
  *    String result = p.getResult();
- * </pre>
  * </code>
+ * </pre>
+ * <p>
  * Call the <code>reset</code> method to clear the previous result before reusing an
  * existing instance.
  * </p>

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
@@ -218,7 +218,7 @@ public class Main {
 	 * 
 	 * @param args the String[] command line for the compiler
 	 * @param useSystemExit if true, use System.exit(int) to complete unless one of the args is -noExit. and signal result (0 no
-	 *        exceptions/error, <0 exceptions, >0 compiler errors).
+	 *        exceptions/error, &lt;0 exceptions, &gt;0 compiler errors).
 	 */
 	public void runMain(String[] args, boolean useSystemExit) {
 		// Urk - default no check for AJDT, enabled here for Ant, command-line

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
@@ -483,7 +483,6 @@ public class Main {
 	 * 
 	 * @param pass true result of the command
 	 * @param holder IMessageHolder with messages from the command
-	 * @see reportCommandResults(IMessageHolder)
 	 * @return false if the process should abort
 	 */
 	protected boolean report(boolean pass, IMessageHolder holder) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
@@ -87,15 +87,15 @@ public class Main {
 	/**
 	 * Convenience method to run ajc and collect String lists of messages. This can be reflectively invoked with the List collecting
 	 * parameters supplied by a parent class loader. The String messages take the same form as command-line messages.
+	 * This method does not catch unchecked exceptions thrown by the compiler.
 	 * 
 	 * @param args the String[] args to pass to the compiler
 	 * @param useSystemExit if true and errors, return System.exit(errs)
 	 * @param fails the List sink, if any, for String failure (or worse) messages
 	 * @param errors the List sink, if any, for String error messages
 	 * @param warnings the List sink, if any, for String warning messages
-	 * @param info the List sink, if any, for String info messages
+	 * @param infos the List sink, if any, for String info messages
 	 * @return number of messages reported with level ERROR or above
-	 * @throws any unchecked exceptions the compiler does
 	 */
 	public static int bareMain(String[] args, boolean useSystemExit, List fails, List errors, List warnings, List infos) {
 		Main main = new Main();
@@ -453,7 +453,6 @@ public class Main {
 	 * Call System.exit(int) with values derived from the number of failures/aborts or errors in messages.
 	 * 
 	 * @param messages the IMessageHolder to interrogate.
-	 * @param messages
 	 */
 	protected void systemExit(IMessageHolder messages) {
 		int num = lastFails; // messages.numMessages(IMessage.FAIL, true);
@@ -725,7 +724,7 @@ public class Main {
 		}
 
 		/**
-		 * @param argList read and strip incremental args from this
+		 * @param args read and strip incremental args from this
 		 * @param sink IMessageHandler for error messages
 		 * @return String[] remainder of args
 		 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjAttribute.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjAttribute.java
@@ -68,7 +68,7 @@ public abstract class AjAttribute {
 	/**
 	 * Writes the full attribute, i.e. name_index, length, and contents
 	 * 
-	 * @param constantPool
+	 * @param dataCompressor
 	 */
 	public byte[] getAllBytes(short nameIndex, ConstantPoolWriter dataCompressor) {
 		try {
@@ -525,7 +525,7 @@ public abstract class AjAttribute {
 		private UnresolvedType[] declaredExceptions;
 
 		/**
-		 * @param lexicalPosition must be greater than the lexicalPosition of any advice declared before this one in an aspect,
+		 * @param start must be greater than the start of any advice declared before this one in an aspect,
 		 *        otherwise, it can be any value.
 		 */
 		public AdviceAttribute(AdviceKind kind, Pointcut pointcut, int extraArgumentFlags, int start, int end,

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjcMemberMaker.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjcMemberMaker.java
@@ -238,7 +238,7 @@ public class AjcMemberMaker {
 	}
 
 	/**
-	 * Return a resolvedmember representing the synthetic getter for the field. The old style (<1.6.9) is a heavyweight static
+	 * Return a resolvedmember representing the synthetic getter for the field. The old style (&lt;1.6.9) is a heavyweight static
 	 * method with a long name. The new style (1.6.9 and later) is short, and reusable across aspects.
 	 * 
 	 * @param aspectType the aspect attempting the access
@@ -272,7 +272,7 @@ public class AjcMemberMaker {
 	}
 
 	/**
-	 * Return a resolvedmember representing the synthetic setter for the field. The old style (<1.6.9) is a heavyweight static
+	 * Return a resolvedmember representing the synthetic setter for the field. The old style (&lt;1.6.9) is a heavyweight static
 	 * method with a long name. The new style (1.6.9 and later) is short, not always static, and reusable across aspects.
 	 * 
 	 * @param aspectType the aspect attempting the access
@@ -566,8 +566,8 @@ public class AjcMemberMaker {
 	}
 
 	/**
-	 * Sometimes the intertyped method requires a bridge method alongside it. For example if the method 'N SomeI<N>.m()' is put onto
-	 * an interface 'interface I<N extends Number>' and then a concrete implementation is 'class C implements I<Float>' then the ITD
+	 * Sometimes the intertyped method requires a bridge method alongside it. For example if the method 'N SomeI&lt;N&gt;.m()' is put onto
+	 * an interface 'interface I&lt;N extends Number&gt;' and then a concrete implementation is 'class C implements I&lt;Float&gt;' then the ITD
 	 * on the interface will be 'Number m()', whereas the ITD on the 'topmostimplementor' will be 'Float m()'. A bridge method needs
 	 * to be created in the topmostimplementor 'Number m()' that delegates to 'Float m()'
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ConcreteTypeMunger.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ConcreteTypeMunger.java
@@ -107,16 +107,16 @@ public abstract class ConcreteTypeMunger implements PartialOrder.PartialComparab
 	}
 
 	/**
-	 * returns true if the ITD target type used type variables, for example I<T>. When they are specified like this, the ITDs
+	 * returns true if the ITD target type used type variables, for example I&lt;T&gt;. When they are specified like this, the ITDs
 	 * 'share' type variables with the generic type. Usually this method is called because we need to know whether to tailor the
 	 * munger for addition to a particular type. For example: <code>
-	 *   interface I<T> {}
+	 *   interface I&lt;T&gt; {}
 	 *   
-	 *   aspect X implements I<String> {
-	 *     List<T> I<T>.foo { return null; }
+	 *   aspect X implements I&lt;String&gt; {
+	 *     List&lt;T&gt; I&lt;T&gt;.foo { return null; }
 	 *   }
 	 * </code> In this case the munger matches X but it matches with the form <code>
-	 *   List<String> foo() { return null; }
+	 *   List&lt;String&gt; foo() { return null; }
 	 * </code>
 	 */
 	public boolean isTargetTypeParameterized() {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ConcreteTypeMunger.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ConcreteTypeMunger.java
@@ -109,13 +109,13 @@ public abstract class ConcreteTypeMunger implements PartialOrder.PartialComparab
 	/**
 	 * returns true if the ITD target type used type variables, for example I&lt;T&gt;. When they are specified like this, the ITDs
 	 * 'share' type variables with the generic type. Usually this method is called because we need to know whether to tailor the
-	 * munger for addition to a particular type. For example: <code>
+	 * munger for addition to a particular type. For example: <pre><code>
 	 *   interface I&lt;T&gt; {}
 	 *   
 	 *   aspect X implements I&lt;String&gt; {
 	 *     List&lt;T&gt; I&lt;T&gt;.foo { return null; }
 	 *   }
-	 * </code> In this case the munger matches X but it matches with the form <code>
+	 * </code></pre> In this case the munger matches X but it matches with the form <code>
 	 *   List&lt;String&gt; foo() { return null; }
 	 * </code>
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/IWeavingSupport.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/IWeavingSupport.java
@@ -17,7 +17,7 @@ import org.aspectj.weaver.patterns.Pointcut;
 
 /**
  * Encapsulates operations that a world will need to support if it is actually going to modify bytecode rather than just match
- * against it. {@see BcelWeavingSupport}
+ * against it. @see BcelWeavingSupport
  *
  * @author Andy Clement
  */
@@ -31,7 +31,7 @@ public interface IWeavingSupport {
 	ConcreteTypeMunger makeCflowCounterFieldAdder(ResolvedMember cflowField);
 
 	/**
-	 * Register a munger for perclause @AJ aspect so that we add aspectOf(..) to them as needed
+	 * Register a munger for perclause {@literal @}AJ aspect so that we add aspectOf(..) to them as needed
 	 *
 	 * @see org.aspectj.weaver.bcel.BcelWorld#makePerClauseAspect(ResolvedType, org.aspectj.weaver.patterns.PerClause.Kind)
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/IWeavingSupport.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/IWeavingSupport.java
@@ -33,7 +33,7 @@ public interface IWeavingSupport {
 	/**
 	 * Register a munger for perclause {@literal @}AJ aspect so that we add aspectOf(..) to them as needed
 	 *
-	 * @see org.aspectj.weaver.bcel.BcelWorld#makePerClauseAspect(ResolvedType, org.aspectj.weaver.patterns.PerClause.Kind)
+	 * @see org.aspectj.weaver.bcel.BcelWeavingSupport#makePerClauseAspect(ResolvedType, org.aspectj.weaver.patterns.PerClause.Kind)
 	 */
 	ConcreteTypeMunger makePerClauseAspect(ResolvedType aspect, PerClause.Kind kind);
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MemberImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MemberImpl.java
@@ -98,7 +98,7 @@ public class MemberImpl implements Member {
 	// ---- utility methods
 
 	/**
-	 * Build a signature based on the return type and parameter types. For example: "(Ljava/util/Set<Ljava/lang/String;>;)V" or
+	 * Build a signature based on the return type and parameter types. For example: "(Ljava/util/Set&lt;Ljava/lang/String;&gt;;)V" or
 	 * "(Ljava/util/Set;)V". The latter form shows what happens when the generics are erased
 	 */
 	public static String typesToSignature(UnresolvedType returnType, UnresolvedType[] paramTypes, boolean eraseGenerics) {
@@ -121,7 +121,7 @@ public class MemberImpl implements Member {
 	}
 
 	/**
-	 * Returns "(<signaturesOfParamTypes>,...)" - unlike the other typesToSignature that also includes the return type, this one
+	 * Returns "(&lt;signaturesOfParamTypes&gt;,...)" - unlike the other typesToSignature that also includes the return type, this one
 	 * just deals with the parameter types.
 	 */
 	public static String typesToSignature(UnresolvedType[] paramTypes) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NameMangler.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NameMangler.java
@@ -114,8 +114,8 @@ public class NameMangler {
 	}
 
 	/**
-	 * Create the old style (<1.6.9) format getter name which includes the aspect requesting access and the type containing the
-	 * field in the name of the type. At 1.6.9 and above the name is simply ajc$get$<fieldname>
+	 * Create the old style (&lt;1.6.9) format getter name which includes the aspect requesting access and the type containing the
+	 * field in the name of the type. At 1.6.9 and above the name is simply ajc$get$&lt;fieldname&gt;
 	 */
 	public static String privilegedAccessMethodForFieldGet(String name, UnresolvedType objectType, UnresolvedType aspectType) {
 		StringBuilder nameBuilder = new StringBuilder();
@@ -124,8 +124,8 @@ public class NameMangler {
 	}
 
 	/**
-	 * Create the old style (<1.6.9) format setter name which includes the aspect requesting access and the type containing the
-	 * field in the name of the type. At 1.6.9 and above the name is simply ajc$set$<fieldname>
+	 * Create the old style (&lt;1.6.9) format setter name which includes the aspect requesting access and the type containing the
+	 * field in the name of the type. At 1.6.9 and above the name is simply ajc$set$&lt;fieldname&gt;
 	 */
 	public static String privilegedAccessMethodForFieldSet(String name, UnresolvedType objectType, UnresolvedType aspectType) {
 		return makeName("privFieldSet", aspectType.getNameAsIdentifier(), objectType.getNameAsIdentifier(), name);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/PrivilegedAccessMunger.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/PrivilegedAccessMunger.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  * 
  * There are two syntax styles for field access, the older style was in use up to AspectJ 1.6.9 and involves long named getters and
  * setters which include the requesting aspect and the target type. The short style syntax is use from AspectJ 1.6.9 onwards is
- * simply 'ajc$get$<fieldname>' and 'ajc$set$<fieldname>' - as the requesting aspect isn't included in the name they can be shared
+ * simply 'ajc$get$&lt;fieldname&gt;' and 'ajc$set$&lt;fieldname&gt;' - as the requesting aspect isn't included in the name they can be shared
  * across aspects.
  */
 public class PrivilegedAccessMunger extends ResolvedTypeMunger {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedMemberImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedMemberImpl.java
@@ -462,8 +462,8 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 	}
 
 	/**
-	 * Return the member generic signature that would be suitable for inclusion in a class file Signature attribute. For: <T>
-	 * List<String> getThem(T t) {} we would create: <T:Ljava/lang/Object;>(TT;)Ljava/util/List<Ljava/lang/String;>;;
+	 * Return the member generic signature that would be suitable for inclusion in a class file Signature attribute. For: &lt;T&gt;
+	 * List&lt;String&gt; getThem(T t) {} we would create: &lt;T:Ljava/lang/Object;&gt;(TT;)Ljava/util/List&lt;Ljava/lang/String;&gt;;;
 	 * 
 	 * @return the generic signature for the member that could be inserted into a class file
 	 */
@@ -744,8 +744,8 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 
 	/**
 	 * Return a resolvedmember in which all the type variables in the signature have been replaced with the given bindings. The
-	 * 'isParameterized' flag tells us whether we are creating a raw type version or not. if (isParameterized) then List<T> will
-	 * turn into List<String> (for example) - if (!isParameterized) then List<T> will turn into List.
+	 * 'isParameterized' flag tells us whether we are creating a raw type version or not. if (isParameterized) then List&lt;T&gt; will
+	 * turn into List&lt;String&gt; (for example) - if (!isParameterized) then List&lt;T&gt; will turn into List.
 	 */
 	public ResolvedMemberImpl parameterizedWith(UnresolvedType[] typeParameters, ResolvedType newDeclaringType,
 			boolean isParameterized, List<String> aliases) {
@@ -805,7 +805,7 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 
 	/**
 	 * Replace occurrences of type variables in the signature with values contained in the map. The map is of the form
-	 * A=String,B=Integer and so a signature List<A> Foo.m(B i) {} would become List<String> Foo.m(Integer i) {}
+	 * A=String,B=Integer and so a signature List&lt;A&gt; Foo.m(B i) {} would become List&lt;String&gt; Foo.m(Integer i) {}
 	 */
 	public ResolvedMember parameterizedWith(Map<String, UnresolvedType> m, World w) {
 		// if (//isParameterized && <-- might need this bit...
@@ -926,8 +926,8 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 	}
 
 	/**
-	 * If this member is defined by a parameterized super-type, return the erasure of that member. For example: interface I<T> { T
-	 * foo(T aTea); } class C implements I<String> { String foo(String aString) { return "something"; } } The resolved member for
+	 * If this member is defined by a parameterized super-type, return the erasure of that member. For example: interface I&lt;T&gt; { T
+	 * foo(T aTea); } class C implements I&lt;String&gt; { String foo(String aString) { return "something"; } } The resolved member for
 	 * C.foo has signature String foo(String). The erasure of that member is Object foo(Object) -- use upper bound of type variable.
 	 * A type is a supertype of itself.
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
@@ -202,14 +202,14 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * returns an iterator through all of the fields of this type, in order for checking from JVM spec 2ed 5.4.3.2. This means that
 	 * the order is
-	 * <p/>
 	 * <ul>
 	 * <li>fields from current class</li>
 	 * <li>recur into direct superinterfaces</li>
 	 * <li>recur into superclass</li>
 	 * </ul>
-	 * <p/>
+	 * <p>
 	 * We keep a hashSet of interfaces that we've visited so we don't spiral out into 2^n land.
+	 * </p>
 	 */
 	public Iterator<ResolvedMember> getFields() {
 		final Iterators.Filter<ResolvedType> dupFilter = Iterators.dupFilter();
@@ -225,13 +225,11 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * returns an iterator through all of the methods of this type, in order for checking from JVM spec 2ed 5.4.3.3. This means that
 	 * the order is
-	 * <p/>
 	 * <ul>
 	 * <li>methods from current class</li>
 	 * <li>recur into superclass, all the way up, not touching interfaces</li>
 	 * <li>recur into all superinterfaces, in some unspecified order (but those 'closest' to this type are first)</li>
 	 * </ul>
-	 * <p/>
 	 * 
 	 * @param wantGenerics is true if the caller would like all generics information, otherwise those methods are collapsed to their
 	 *        erasure
@@ -739,14 +737,14 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * returns an iterator through all of the pointcuts of this type, in order for checking from JVM spec 2ed 5.4.3.2 (as for
 	 * fields). This means that the order is
-	 * <p/>
 	 * <ul>
 	 * <li>pointcuts from current class</li>
 	 * <li>recur into direct superinterfaces</li>
 	 * <li>recur into superclass</li>
 	 * </ul>
-	 * <p/>
+	 * <p>
 	 * We keep a hashSet of interfaces that we've visited so we don't spiral out into 2^n land.
+	 * </p>
 	 */
 	public Iterator<ResolvedMember> getPointcuts() {
 		final Iterators.Filter<ResolvedType> dupFilter = Iterators.dupFilter();
@@ -1557,10 +1555,11 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * Returns a ResolvedType object representing the declaring type of this type, or null if this type does not represent a
 	 * non-package-level-type.
-	 * <p/>
+	 * <p>
 	 * <strong>Warning</strong>: This is guaranteed to work for all member types. For anonymous/local types, the only guarantee is
 	 * given in JLS 13.1, where it guarantees that if you call getDeclaringType() repeatedly, you will eventually get the top-level
 	 * class, but it does not say anything about classes in between.
+	 * </p>
 	 * 
 	 * @return the declaring type, or null if it is not an nested type.
 	 */
@@ -2672,10 +2671,9 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * Determines if values of another type could possibly be cast to this type. The rules followed are from JLS 2ed 5.5,
 	 * "Casting Conversion".
-	 * <p/>
 	 * <p>
 	 * This method should be commutative, i.e., for all UnresolvedType a, b and all World w:
-	 * <p/>
+	 * </p>
 	 * <blockquote>
 	 * 
 	 * <pre>

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
@@ -313,15 +313,20 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * Return an iterator over the types in this types hierarchy - starting with this type first, then all superclasses up to Object
 	 * and then all interfaces (starting with those 'nearest' this type).
-	 * 
-	 * @param wantGenerics true if the caller wants full generic information
-	 * @param wantDeclaredParents true if the caller even wants those parents introduced via declare parents
 	 * @return an iterator over all types in the hierarchy of this type
 	 */
 	public Iterator<ResolvedType> getHierarchy() {
 		return getHierarchy(false, false);
 	}
 
+	/**
+	 * Return an iterator over the types in this types hierarchy - starting with this type first, then all superclasses up to Object
+	 * and then all interfaces (starting with those 'nearest' this type).
+	 *
+	 * @param wantGenerics true if the caller wants full generic information
+	 * @param wantDeclaredParents true if the caller even wants those parents introduced via declare parents
+	 * @return an iterator over all types in the hierarchy of this type
+	 */
 	public Iterator<ResolvedType> getHierarchy(final boolean wantGenerics, final boolean wantDeclaredParents) {
 
 		final Iterators.Getter<ResolvedType, ResolvedType> interfaceGetter = new Iterators.Getter<ResolvedType, ResolvedType>() {
@@ -2622,7 +2627,6 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	 * assignable to a variable of type X without loss of precision.
 	 * 
 	 * @param other the other type
-	 * @param world the {@link World} in which the possible assignment should be checked.
 	 * @return true iff variables of this type could be assigned values of other with possible conversion
 	 */
 	public final boolean isConvertableFrom(ResolvedType other) {
@@ -2660,7 +2664,6 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	 * assignment conversion as per JLS 2ed 5.2. For object types, this means supertypeOrEqual(THIS, OTHER).
 	 * 
 	 * @param other the other type
-	 * @param world the {@link World} in which the possible assignment should be checked.
 	 * @return true iff variables of this type could be assigned values of other without casting
 	 * @throws NullPointerException if other is null
 	 */
@@ -2683,7 +2686,6 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	 * </blockquote>
 	 * 
 	 * @param other the other type
-	 * @param world the {@link World} in which the possible coersion should be checked.
 	 * @return true iff values of other could possibly be cast to this type.
 	 * @throws NullPointerException if other is null.
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
@@ -690,7 +690,7 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * Do the two members conflict?  Due to the change in 1.7.1, field itds on interfaces now act like 'default' fields - so types implementing
 	 * those fields get the field if they don't have it already, otherwise they keep what they have.  The conflict detection below had to be
-	 * altered.  Previously (<1.7.1) it is not a conflict if the declaring types are different.  With v2itds it may still be a conflict if the
+	 * altered.  Previously (&lt;1.7.1) it is not a conflict if the declaring types are different.  With v2itds it may still be a conflict if the
 	 * declaring types are different.
 	 */
 	public static boolean conflictingSignature(Member m1, Member m2, boolean v2itds) {
@@ -1657,8 +1657,8 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 	/**
 	 * Called for all type mungers but only does something if they share type variables with a generic type which they target. When
 	 * this happens this routine will check for the target type in the target hierarchy and 'bind' any type parameters as
-	 * appropriate. For example, for the ITD "List<T> I<T>.x" against a type like this: "class A implements I<String>" this routine
-	 * will return a parameterized form of the ITD "List<String> I.x"
+	 * appropriate. For example, for the ITD "List&lt;T&gt; I&lt;T&gt;.x" against a type like this: "class A implements I&lt;String&gt;" this routine
+	 * will return a parameterized form of the ITD "List&lt;String&gt; I.x"
 	 */
 	public ConcreteTypeMunger fillInAnyTypeParameters(ConcreteTypeMunger munger) {
 		boolean debug = false;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedTypeMunger.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedTypeMunger.java
@@ -414,7 +414,7 @@ public abstract class ResolvedTypeMunger {
 
 	/**
 	 * return true if type variables are specified with the target type for this ITD. e.g. this would return true:
-	 * "int I<A,B>.m() { return 42; }"
+	 * "int I&lt;A,B&gt;.m() { return 42; }"
 	 */
 	public boolean sharesTypeVariablesWithGenericType() {
 		return (typeVariableAliases != null && typeVariableAliases.size() > 0);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
@@ -20,7 +20,7 @@ public class TypeFactory {
 	/**
 	 * Create a parameterized version of a generic type.
 	 * 
-	 * @param aGenericType
+	 * @param aBaseType
 	 * @param someTypeParameters note, in the case of an inner type of a parameterized type, this parameter may legitimately be null
 	 * @param inAWorld
 	 * @return

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
@@ -358,7 +358,7 @@ public class TypeFactory {
 
 	/**
 	 * Create a signature then delegate to the other factory method. Same input/output: baseTypeSignature="LSomeType;" arguments[0]=
-	 * something with sig "Pcom/Foo<Ljava/lang/String;>;" signature created = "PSomeType<Pcom/Foo<Ljava/lang/String;>;>;"
+	 * something with sig "Pcom/Foo&lt;Ljava/lang/String;&gt;;" signature created = "PSomeType&lt;Pcom/Foo&lt;Ljava/lang/String;&gt;;&gt;;"
 	 */
 	public static UnresolvedType createUnresolvedParameterizedType(String baseTypeSignature, UnresolvedType[] arguments) {
 		StringBuffer parameterizedSig = new StringBuffer();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/UnresolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/UnresolvedType.java
@@ -422,7 +422,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 	/**
 	 * Constructs a UnresolvedType for each JVM bytecode type signature in an incoming array.
 	 * 
-	 * @param names an array of JVM bytecode type signatures
+	 * @param sigs an array of JVM bytecode type signatures
 	 * @return an array of UnresolvedType objects.
 	 * @see #forSignature(String)
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/WeaverStateInfo.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/WeaverStateInfo.java
@@ -34,9 +34,9 @@ import org.aspectj.weaver.AjAttribute.WeaverVersionInfo;
  * whether reweaving is allowed. The format in the data stream is:
  * 
  * Byte: Kind. UNTOUCHED|WOVEN|EXTENDED - If extended it can have two extra bits set 'REWEAVABLE' and 'REWEAVABLE_COMPRESSION_BIT'
- * Short: typeMungerCount - how many type mungers have affected this type <UnresolvedType & ResolvedTypeMunger>: The type mungers
+ * Short: typeMungerCount - how many type mungers have affected this type &lt;UnresolvedType &amp; ResolvedTypeMunger&gt;: The type mungers
  * themselves If we are reweavable then we also have: Short: Number of aspects that touched this type in some way when it was
- * previously woven <String> The fully qualified name of each type Int: Length of class file data (i.e. the unwovenclassfile)
+ * previously woven &lt;String&gt; The fully qualified name of each type Int: Length of class file data (i.e. the unwovenclassfile)
  * Byte[]: The class file data, compressed if REWEAVABLE_COMPRESSION_BIT set.
  * 
  * @author Andy Clement

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AndTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AndTypePattern.java
@@ -24,7 +24,7 @@ import org.aspectj.weaver.VersionedDataInputStream;
 import org.aspectj.weaver.World;
 
 /**
- * left && right
+ * left &amp;&amp; right
  * 
  * <p>
  * any binding to formals is explicitly forbidden for any composite by the language

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationTypePattern.java
@@ -31,7 +31,7 @@ public abstract class AnnotationTypePattern extends PatternNode {
 	private boolean isForParameterAnnotationMatch;
 
 	/**
-	 * TODO: write, read, equals & hashCode both in annotation hierarchy and in altered TypePattern hierarchy
+	 * TODO: write, read, equals &amp; hashCode both in annotation hierarchy and in altered TypePattern hierarchy
 	 */
 	protected AnnotationTypePattern() {
 		super();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnyTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnyTypePattern.java
@@ -23,9 +23,7 @@ import org.aspectj.weaver.World;
 public class AnyTypePattern extends TypePattern {
 
 	/**
-	 * Constructor for EllipsisTypePattern.
-	 * 
-	 * @param includeSubtypes
+	 * Constructor for AnyTypePattern.
 	 */
 	public AnyTypePattern() {
 		super(false, false, new TypePatternList());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnyTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnyTypePattern.java
@@ -40,7 +40,7 @@ public class AnyTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesExactly(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesExactly(ResolvedType)
 	 */
 	@Override
 	protected boolean matchesExactly(ResolvedType type) {
@@ -53,7 +53,7 @@ public class AnyTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesInstanceof(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesInstanceof(ResolvedType)
 	 */
 	@Override
 	public FuzzyBoolean matchesInstanceof(ResolvedType type) {
@@ -72,7 +72,7 @@ public class AnyTypePattern extends TypePattern {
 	// return FuzzyBoolean.YES;
 	// }
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesSubtypes(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesSubtypes(ResolvedType)
 	 */
 	@Override
 	protected boolean matchesSubtypes(ResolvedType type) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/BindingAnnotationFieldTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/BindingAnnotationFieldTypePattern.java
@@ -31,11 +31,11 @@ import org.aspectj.weaver.WeaverMessages;
 import org.aspectj.weaver.World;
 
 /**
- * Represents an attempt to bind the field of an annotation within a pointcut. For example:<br>
- * <code><pre>
+ * Represents an attempt to bind the field of an annotation within a pointcut. For example:
+ * <pre><code>
  * before(Level lev): execution(* *(..)) &amp;&amp; @annotation(TraceAnnotation(lev))
- * </pre></code><br>
- * This binding annotation type pattern will be for 'lev'.
+ * </code></pre>
+ * <p>This binding annotation type pattern will be for 'lev'.</p>
  */
 public class BindingAnnotationFieldTypePattern extends ExactAnnotationTypePattern implements BindingPattern {
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareErrorOrWarning.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareErrorOrWarning.java
@@ -33,7 +33,7 @@ public class DeclareErrorOrWarning extends Declare {
 	}
 
 	/**
-	 * returns "declare warning: <message>" or "declare error: <message>"
+	 * returns "declare warning: &lt;message&gt;" or "declare error: &lt;message&gt;"
 	 */
 	public String toString() {
 		StringBuffer buf = new StringBuffer();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareTypeErrorOrWarning.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareTypeErrorOrWarning.java
@@ -38,7 +38,7 @@ public class DeclareTypeErrorOrWarning extends Declare {
 	}
 
 	/**
-	 * returns "declare warning: <typepattern>: <message>" or "declare error: <typepattern>: <message>"
+	 * returns "declare warning: &lt;typepattern&gt;: &lt;message&gt;" or "declare error: &lt;typepattern&gt;: &lt;message&gt;"
 	 */
 	public String toString() {
 		StringBuffer buf = new StringBuffer();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/EllipsisTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/EllipsisTypePattern.java
@@ -39,7 +39,7 @@ public class EllipsisTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesExactly(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesExactly(ResolvedType)
 	 */
 	@Override
 	protected boolean matchesExactly(ResolvedType type) {
@@ -52,7 +52,7 @@ public class EllipsisTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesInstanceof(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesInstanceof(ResolvedType)
 	 */
 	@Override
 	public FuzzyBoolean matchesInstanceof(ResolvedType type) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/EllipsisTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/EllipsisTypePattern.java
@@ -23,8 +23,6 @@ public class EllipsisTypePattern extends TypePattern {
 
 	/**
 	 * Constructor for EllipsisTypePattern.
-	 * 
-	 * @param includeSubtypes
 	 */
 	public EllipsisTypePattern() {
 		super(false, false, new TypePatternList());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactAnnotationFieldTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactAnnotationFieldTypePattern.java
@@ -28,11 +28,11 @@ import org.aspectj.weaver.VersionedDataInputStream;
 import org.aspectj.weaver.World;
 
 /**
- * Represents an attempt to bind the field of an annotation within a pointcut. For example:<br>
- * <code><pre>
+ * Represents an attempt to bind the field of an annotation within a pointcut. For example:
+ * <pre><code>
  * before(Level lev): execution(* *(..)) &amp;&amp; @annotation(TraceAnnotation(lev))
- * </pre></code><br>
- * This binding annotation type pattern will be for 'lev'.
+ * </code></pre>
+ * <p>This binding annotation type pattern will be for 'lev'.</p>
  */
 public class ExactAnnotationFieldTypePattern extends ExactAnnotationTypePattern {
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/FormalBinding.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/FormalBinding.java
@@ -71,7 +71,7 @@ public class FormalBinding implements IHasPosition {
 	 * A marker class for bindings for which we want to ignore unbound issue and consider them as implicit binding - f.e. to handle
 	 * JoinPoint in @AJ advices
 	 * 
-	 * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+	 * @author Alexandre Vasseur (alex AT gnilux DOT com)
 	 */
 	public static class ImplicitFormalBinding extends FormalBinding {
 		public ImplicitFormalBinding(UnresolvedType type, String name, int index) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePatternForPerThisMatching.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePatternForPerThisMatching.java
@@ -19,11 +19,11 @@ import org.aspectj.weaver.ConcreteTypeMunger;
 import org.aspectj.weaver.ResolvedType;
 
 /**
- * pr354470. This is a special subtype of HasMemberTypePattern. In order to optimize this situation: <br>
- * <code><pre>
+ * pr354470. This is a special subtype of HasMemberTypePattern. In order to optimize this situation:
+ * <pre><code>
  * aspect X perthis(transactional()) {<br>
  * pointcut transactional: execution(@Foo * *(..));<br>
- * </pre></code>
+ * </code></pre>
  * <p>
  * When this occurs we obviously only want an aspect instance when there is a method annotated with @Foo. For a regular execution
  * pointcut we couldn't really do this due to the multiple joinpoint signatures for each joinpoint (and so lots of types get the
@@ -36,6 +36,7 @@ import org.aspectj.weaver.ResolvedType;
  * subclass is created to say 'if the supertype thinks it is a match, great, but if it doesnt then if there are ITDs on the target,
  * they might match so just say 'true''. Note that returning true is just confirming whether the 'mightHaveAspect' interface (and
  * friends) are getting added.
+ * </p>
  * 
  * @author Andy Clement
  */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NoTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NoTypePattern.java
@@ -37,7 +37,7 @@ public class NoTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesExactly(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesExactly(ResolvedType)
 	 */
 	@Override
 	protected boolean matchesExactly(ResolvedType type) {
@@ -50,7 +50,7 @@ public class NoTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesInstanceof(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesInstanceof(ResolvedType)
 	 */
 	@Override
 	public FuzzyBoolean matchesInstanceof(ResolvedType type) {
@@ -69,7 +69,7 @@ public class NoTypePattern extends TypePattern {
 	// return FuzzyBoolean.YES;
 	// }
 	/**
-	 * @see org.aspectj.weaver.patterns.TypePattern#matchesSubtypes(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesSubtypes(ResolvedType)
 	 */
 	@Override
 	protected boolean matchesSubtypes(ResolvedType type) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternNodeVisitor.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternNodeVisitor.java
@@ -16,7 +16,7 @@ package org.aspectj.weaver.patterns;
 /**
  * A Pointcut or TypePattern visitor
  *
- * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+ * @author Alexandre Vasseur (alex AT gnilux DOT com)
  */
 public interface PatternNodeVisitor {
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternParser.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternParser.java
@@ -1049,7 +1049,7 @@ public class PatternParser {
 	}
 
 	/**
-	 * Attempt to parse a typeIs(<category>) construct. If it cannot be parsed we just return null and that should cause the caller
+	 * Attempt to parse a typeIs(&lt;category&gt;) construct. If it cannot be parsed we just return null and that should cause the caller
 	 * to reset their position and attempt to consume it in another way. This means we won't have problems here: execution(*
 	 * typeIs(..)) because someone has decided to call a method the same as our construct.
 	 * 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternParser.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternParser.java
@@ -1687,7 +1687,6 @@ public class PatternParser {
 	 * Parse type variable declarations for a generic method or at the start of a signature pointcut to identify type variable names
 	 * in a generic type.
 	 * 
-	 * @param includeParameterizedTypes
 	 * @return
 	 */
 	public TypeVariablePatternList maybeParseTypeVariableList() {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PerThisOrTargetPointcutVisitor.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PerThisOrTargetPointcutVisitor.java
@@ -21,7 +21,7 @@ import org.aspectj.weaver.Shadow;
  * Foo+ (this one is a special case..) - pertarget(execution(* Foo.do()) &rarr; Foo - perthis(call(* Foo.do()) &rarr; * - perthis(!call(*
  * Foo.do()) &rarr; * (see how the ! has been absorbed here..)
  * 
- * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+ * @author Alexandre Vasseur (alex AT gnilux DOT com)
  */
 public class PerThisOrTargetPointcutVisitor extends AbstractPatternNodeVisitor {
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PerThisOrTargetPointcutVisitor.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PerThisOrTargetPointcutVisitor.java
@@ -17,9 +17,9 @@ import org.aspectj.weaver.ResolvedType;
 import org.aspectj.weaver.Shadow;
 
 /**
- * A visitor that turns a pointcut into a type pattern equivalent for a perthis or pertarget matching: - pertarget(target(Foo)) =>
- * Foo+ (this one is a special case..) - pertarget(execution(* Foo.do()) => Foo - perthis(call(* Foo.do()) => * - perthis(!call(*
- * Foo.do()) => * (see how the ! has been absorbed here..)
+ * A visitor that turns a pointcut into a type pattern equivalent for a perthis or pertarget matching: - pertarget(target(Foo)) &rarr;
+ * Foo+ (this one is a special case..) - pertarget(execution(* Foo.do()) &rarr; Foo - perthis(call(* Foo.do()) &rarr; * - perthis(!call(*
+ * Foo.do()) &rarr; * (see how the ! has been absorbed here..)
  * 
  * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
  */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/Pointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/Pointcut.java
@@ -244,7 +244,7 @@ public abstract class Pointcut extends PatternNode {
 	 * Resolves and removes ReferencePointcuts, replacing with basic ones
 	 * 
 	 * @param inAspect the aspect to resolve relative to
-	 * @param bindings a Map from formal index in the current lexical context -> formal index in the concrete advice that will run
+	 * @param bindings a Map from formal index in the current lexical context &rarr; formal index in the concrete advice that will run
 	 * 
 	 *        This must always return a new Pointcut object (even if the concretized Pointcut is identical to the resolved one).
 	 *        That behavior is assumed in many places. XXX fix implementors to handle state

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PointcutEvaluationExpenseComparator.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PointcutEvaluationExpenseComparator.java
@@ -41,11 +41,11 @@ public class PointcutEvaluationExpenseComparator implements Comparator<Pointcut>
 	 * 
 	 * within
 	 * 
-	 * @within staticinitialization [make sure this has a fast match method] adviceexecution handler get, set withincode
-	 * @withincode execution, initialization, preinitialization call
-	 * @annotation this, target
-	 * @this, @target args
-	 * @args cflow, cflowbelow if
+	 * {@literal @}within staticinitialization [make sure this has a fast match method] adviceexecution handler get, set withincode
+	 * {@literal @}withincode execution, initialization, preinitialization call
+	 * {@literal @}annotation this, target
+	 * {@literal @}this, {@literal @}target args
+	 * {@literal @}args cflow, cflowbelow if
 	 */
 	public int compare(Pointcut p1, Pointcut p2) {
 		// important property for a well-defined comparator

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
@@ -51,25 +51,25 @@ import org.aspectj.weaver.World;
  * Foo where Foo exists and is generic Parser creates WildTypePattern namePatterns={Foo} resolveBindings resolves Foo to RT(Foo -
  * raw) return ExactTypePattern(LFoo;)
  * 
- * Foo<String> where Foo exists and String meets the bounds Parser creates WildTypePattern namePatterns = {Foo},
+ * Foo&lt;String&gt; where Foo exists and String meets the bounds Parser creates WildTypePattern namePatterns = {Foo},
  * typeParameters=WTP{String} resolveBindings resolves typeParameters to ExactTypePattern(String) resolves Foo to RT(Foo) returns
- * ExactTypePattern(PFoo<String>; - parameterized)
+ * ExactTypePattern(PFoo&lt;String&gt;; - parameterized)
  * 
- * Foo<Str*> where Foo exists and takes one bound Parser creates WildTypePattern namePatterns = {Foo}, typeParameters=WTP{Str*}
+ * Foo&lt;Str*&gt; where Foo exists and takes one bound Parser creates WildTypePattern namePatterns = {Foo}, typeParameters=WTP{Str*}
  * resolveBindings resolves typeParameters to WTP{Str*} resolves Foo to RT(Foo) returns WildTypePattern(name = Foo, typeParameters =
  * WTP{Str*} isGeneric=false)
  * 
- * Fo*<String> Parser creates WildTypePattern namePatterns = {Fo*}, typeParameters=WTP{String} resolveBindings resolves
+ * Fo*&lt;String&gt; Parser creates WildTypePattern namePatterns = {Fo*}, typeParameters=WTP{String} resolveBindings resolves
  * typeParameters to ETP{String} returns WildTypePattern(name = Fo*, typeParameters = ETP{String} isGeneric=false)
  * 
  * 
- * Foo<?>
+ * Foo&lt;?&gt;
  * 
- * Foo<? extends Number>
+ * Foo&lt;? extends Number&gt;
  * 
- * Foo<? extends Number+>
+ * Foo&lt;? extends Number+&gt;
  * 
- * Foo<? super Number>
+ * Foo&lt;? super Number&gt;
  * 
  */
 public class WildTypePattern extends TypePattern {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
@@ -218,7 +218,7 @@ public class WildTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.TypePattern#matchesExactly(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesExactly(ResolvedType)
 	 */
 	@Override
 	protected boolean matchesExactly(ResolvedType type) {
@@ -499,7 +499,7 @@ public class WildTypePattern extends TypePattern {
 	}
 
 	/**
-	 * @see org.aspectj.weaver.TypePattern#matchesInstanceof(IType)
+	 * @see org.aspectj.weaver.patterns.TypePattern#matchesInstanceof(ResolvedType)
 	 */
 	@Override
 	public FuzzyBoolean matchesInstanceof(ResolvedType type) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/AbstractTrace.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/AbstractTrace.java
@@ -189,7 +189,6 @@ public abstract class AbstractTrace implements Trace {
 	/**
 	 * Format arguments into a comma separated list
 	 *
-	 * @param names array of argument names
 	 * @param args array of arguments
 	 * @return the formated list
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/PointcutExpression.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/PointcutExpression.java
@@ -109,7 +109,6 @@ public interface PointcutExpression {
 	 * static initialization of the type).
 	 * @param aMethod the method being called
 	 * @param callerType the declared type of the caller
-	 * @param receiverType the declared type of the recipient of the call
 	 * @return a ShadowMatch indicating whether the pointcut always, sometimes, or never
 	 * matches join points representing a call to this method during the execution of the given member.
 	 */

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutExpression.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutExpression.java
@@ -60,7 +60,7 @@ public interface StandardPointcutExpression {
 	/**
 	 * Determine whether or not this pointcut matches the static initialization of the given class.
 	 * 
-	 * @param aClass the class being statically initialized
+	 * @param aType the class being statically initialized
 	 * @return a ShadowMatch indicating whether the pointcut always, sometimes, or never matchs join points representing the static
 	 *         initialization of the given type
 	 */

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc11CompilerAdapter.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc11CompilerAdapter.java
@@ -33,8 +33,9 @@ import java.io.File;
  * requires all the files every time.  To work around this,
  * set the global property CLEAN ("build.compiler.clean") to delete
  * all .class files in the destination directory before compiling.
+ * </p>
  * 
- * <p><u>Warnings</u>: 
+ * <p><u>Warnings</u>:</p>
  * <ol>
  * <li>cleaning will not work if no destination directory
  *     is specified in the javac task.
@@ -46,7 +47,7 @@ import java.io.File;
  * <li>If no files are out of date, then the adapter is <b>never</b> called
  *     and thus cannot gain control to clean out the destination dir.
  *     </li>
- * <p>
+ * </ol>
  * 
  * @author Wes Isberg
  * @since AspectJ 1.1, Ant 1.5.1

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
@@ -175,9 +175,9 @@ public class Ajc2 extends Javac {
     }
 
     /**
-     * Returns if the <code>-preprocess</code> flag is turned on.
+     * Set the <code>-preprocess</code> flag.
      *
-     * @return <code>true</code> if the <code>-preprocess</code> flag is on.
+     * @param preprocess <code>true</code> turns on the <code>-preprocess</code> flag.
      * @see    Ajc2#preprocess
      */
     public void setPreprocess(boolean preprocess) {

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
@@ -29,7 +29,7 @@ import java.util.StringTokenizer;
  * This task was developed by the <a href="http://aspectj.org">AspectJ Project</a>
  *
  * @author <a href="mailto:palm@parc.xerox.com">Jeffrey Palm</a>
- * @see    org.aspectj.tools.ant.taskdefs.compilers.AjcCompiler
+ * @see    org.aspectj.tools.ant.taskdefs.compilers.Ajc
  */
 public class Ajc2 extends Javac {
 
@@ -288,7 +288,7 @@ public class Ajc2 extends Javac {
      * to <code>true</code>.
      *
      * @return new PatternSet.NameEntry to be added to the include list.
-     * @see    org.apache.tools.taskdefs.Javac#createInclude()
+     * @see    org.apache.tools.ant.taskdefs.Javac#createInclude()
      */
     public PatternSet.NameEntry createInclude() {
         haveIncludes = true;
@@ -300,7 +300,7 @@ public class Ajc2 extends Javac {
      * to <code>true</code>.
      *
      * @return new PatternSet.NameEntry to be added to the exclude list.
-     * @see    org.apache.tools.taskdefs.Javac#createExclude()
+     * @see    org.apache.tools.ant.taskdefs.Javac#createExclude()
      */    
     public PatternSet.NameEntry createExclude() {
         haveExcludes = true;
@@ -312,7 +312,7 @@ public class Ajc2 extends Javac {
      * to <code>true</code>.
      *
      * @param includes Comma-separated list of includes.
-     * @see   org.apache.tools.taskdefs.Javac#setIncludes(java.lang.String)
+     * @see   org.apache.tools.ant.taskdefs.Javac#setIncludes(java.lang.String)
      */
     public void setIncludes(String includes) {
         haveIncludes = true;
@@ -324,7 +324,7 @@ public class Ajc2 extends Javac {
      * to <code>true</code>.
      *
      * @param excludes Comma-separated list of excludes.
-     * @see   org.apache.tools.taskdefs.Javac#setExcludes(java.lang.String)
+     * @see   org.apache.tools.ant.taskdefs.Javac#setExcludes(java.lang.String)
      */    
     public void setExcludes(String excludes) {
         haveExcludes = true;

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -114,8 +114,6 @@ public class AjcTask extends MatchingTask {
 	 * </pre>
 	 *
 	 * @param javac the Javac command to implement (not null)
-	 * @param ajc the AjcTask to adapt (not null)
-	 * @param destDir the File class destination directory (may be null)
 	 * @return null if no error, or String error otherwise
 	 */
 	public String setupAjc(Javac javac) {
@@ -1252,7 +1250,7 @@ public class AjcTask extends MatchingTask {
 	}
 
 	/**
-	 * @throw BuildException if options conflict
+	 * @throws BuildException if options conflict
 	 */
 	protected void verifyOptions() {
 		StringBuffer sb = new StringBuffer();
@@ -1509,7 +1507,6 @@ public class AjcTask extends MatchingTask {
 	}
 
 	// ------------------------------ setup and reporting
-	/** @return null if path null or empty, String rendition otherwise */
 	protected static void addFlaggedPath(String flag, Path path, List<String> list) {
 		if (!LangUtil.isEmpty(flag) && ((null != path) && (0 < path.size()))) {
 			list.add(flag);

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -1374,7 +1374,6 @@ public class AjcTask extends MatchingTask {
 	 *
 	 * @param args String[] of the complete compiler command to execute
 	 *
-	 * @see DefaultCompilerAdapter#executeExternalCompile(String[], int)
 	 * @throws BuildException if ajc aborts (negative value) or if failonerror and there were compile errors.
 	 */
 	protected void executeInOtherVM(String[] args) {

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -601,7 +601,7 @@ public class AjcTask extends MatchingTask {
 	}
 
 	/**
-	 * -Xlint - set default level of -Xlint messages to warning (same as </code>-Xlint:warning</code>)
+	 * -Xlint - set default level of -Xlint messages to warning (same as <code>-Xlint:warning</code>)
 	 */
 	public void setXlintwarnings(boolean xlintwarnings) {
 		cmd.addFlag("-Xlint", xlintwarnings);

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
@@ -59,7 +59,7 @@ public class Ajc extends DefaultCompilerAdapter {
 
     /**
      * Checks the command line for arguments allowed only in AJC and
-     * disallowed by AJC and then calls the <code>compile()<code> method.
+     * disallowed by AJC and then calls the <code>compile()</code> method.
      *
      * @return true if a good compile, false otherwise.
      * @throws org.apache.tools.ant.BuildException

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
@@ -32,7 +32,7 @@ import org.apache.tools.ant.types.Commandline;
  * This task was developed by the <a href="http://aspectj.org">AspectJ Project</a>
  *
  * @author <a href="mailto:palm@parc.xerox.com">Jeffrey Palm</a>
- * @see    org.aspectj.tools.ant.taskdefs.Ajc
+ * @see    org.aspectj.tools.ant.taskdefs.Ajc2
  */
 public class Ajc extends DefaultCompilerAdapter {
 

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
@@ -183,7 +183,7 @@ public class Ajc extends DefaultCompilerAdapter {
 
     /**
      * Logs the compilation parameters, adds the files to compile and logs the 
-     * &qout;niceSourceList&quot;
+     * &quot;niceSourceList&quot;
      */
     @Override
 	protected void logAndAddFilesToCompile(Commandline cmd) {

--- a/tests/ajde/examples/spacewar/spacewar/Game.java
+++ b/tests/ajde/examples/spacewar/spacewar/Game.java
@@ -44,7 +44,7 @@ public class Game extends Thread {
      * thread.  You can instantiate multiple games at once.  For the time being
      * the only way to end the game is to exit from the Java VM.
      *
-     * @param isDemo Controls whether the game runs in demo mode or not.  True
+     * @param mode Controls whether the game runs in demo mode or not.  True
      *   means it is a demo, false means it runs in normal 2 player mode.
      */
     public Game(String mode) {

--- a/tests/multiIncremental/SpaceWar/base/src/spacewar/Game.java
+++ b/tests/multiIncremental/SpaceWar/base/src/spacewar/Game.java
@@ -68,7 +68,7 @@ public class Game extends Thread {
      * thread.  You can instantiate multiple games at once.  For the time being
      * the only way to end the game is to exit from the Java VM.
      *
-     * @param isDemo Controls whether the game runs in demo mode or not.  True
+     * @param mode Controls whether the game runs in demo mode or not.  True
      *   means it is a demo, false means it runs in normal 2 player mode.
      */
     public Game(String mode) {

--- a/util/src/main/java/org/aspectj/util/FileUtil.java
+++ b/util/src/main/java/org/aspectj/util/FileUtil.java
@@ -324,7 +324,7 @@ public class FileUtil {
 	/**
 	 * Flatten File[] to String.
 	 *
-	 * @param files the File[] of paths to flatten - null ignored
+	 * @param paths the String[] of paths to flatten - null ignored
 	 * @param infix the String infix to use - null treated as File.pathSeparator
 	 */
 	public static String flatten(String[] paths, String infix) {
@@ -1288,9 +1288,9 @@ public class FileUtil {
 	 * result.
 	 *
 	 * @param sought the String text to seek in the file
-	 * @param sources the List of String paths to the source files
+	 * @param sourcePath the String of paths to the source files
 	 * @param listAll if false, only list first match in file
-	 * @param List sink the List for String entries of the form {sourcePath}:line:column
+	 * @param sink the List of String entries of the form {sourcePath}:line:column
 	 * @return String error if any, or add String entries to sink
 	 */
 	public static String lineSeek(String sought, String sourcePath, boolean listAll, List<String> sink) {

--- a/util/src/main/java/org/aspectj/util/LangUtil.java
+++ b/util/src/main/java/org/aspectj/util/LangUtil.java
@@ -865,7 +865,7 @@ public class LangUtil {
 	 * Renders exception <code>t</code> after unwrapping and eliding any test packages.
 	 *
 	 * @param t <code>Throwable</code> to print.
-	 * @see #maxStackTrace
+	 * @see StringChecker#TEST_PACKAGES
 	 */
 	public static String renderException(Throwable t) {
 		return renderException(t, true);

--- a/util/src/main/java/org/aspectj/util/PartialOrder.java
+++ b/util/src/main/java/org/aspectj/util/PartialOrder.java
@@ -31,14 +31,14 @@ public class PartialOrder {
 	 */
 	public interface PartialComparable {
 		/**
-		 * @returns <ul>
-		 *          <li>+1 if this is greater than other</li>
-		 *          <li>-1 if this is less than other</li>
-		 *          <li>0 if this is not comparable to other</li>
-		 *          </ul>
+		 * @return <ul>
+		 *         <li>+1 if this is greater than other</li>
+		 *         <li>-1 if this is less than other</li>
+		 *         <li>0 if this is not comparable to other</li>
+		 *         </ul>
 		 *
-		 *          <b> Note: returning 0 from this method doesn't mean the same thing as returning 0 from
-		 *          java.util.Comparable.compareTo()</b>
+		 *         <b> Note: returning 0 from this method doesn't mean the same thing as returning 0 from
+		 *         java.util.Comparable.compareTo()</b>
 		 */
 		int compareTo(Object other);
 
@@ -110,7 +110,7 @@ public class PartialOrder {
 	/**
 	 * @param objects must all implement PartialComparable
 	 *
-	 * @returns the same members as objects, but sorted according to their partial order. returns null if the objects are cyclical
+	 * @return the same members as objects, but sorted according to their partial order. returns null if the objects are cyclical
 	 *
 	 */
 	public static <T extends PartialComparable> List<T> sort(List<T> objects) {

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/AnnotationAccessVar.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/AnnotationAccessVar.java
@@ -262,7 +262,7 @@ public class AnnotationAccessVar extends BcelVar {
 	 * Return an object that can access a particular value of this annotation.
 	 * 
 	 * @param valueType The type from the annotation that is of interest
-	 * @param the formal name expressed in the pointcut, can be used to disambiguate
+	 * @param formalName the formal name expressed in the pointcut, can be used to disambiguate
 	 * @return a variable that represents access to that annotation value
 	 */
 	@Override

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
@@ -854,7 +854,7 @@ public class AtAjAttributes {
 	}
 
 	/**
-	 * Return a nicely formatted method string, for example: int X.foo(java.lang.String)
+	 * @return a nicely formatted method string, for example: int X.foo(java.lang.String)
 	 */
 	public static String getMethodForMessage(AjAttributeMethodStruct methodstructure) {
 		StringBuffer sb = new StringBuffer();

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
@@ -86,7 +86,7 @@ import org.aspectj.weaver.patterns.TypePattern;
 /**
  * Annotation defined aspect reader. Reads the Java 5 annotations and turns them into AjAttributes
  *
- * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+ * @author Alexandre Vasseur (alex AT gnilux DOT com)
  */
 public class AtAjAttributes {
 
@@ -1851,7 +1851,7 @@ public class AtAjAttributes {
 	 * LazyResolvedPointcutDefinition lazyly resolve the pointcut so that we have time to register all pointcut referenced before
 	 * pointcut resolution happens
 	 *
-	 * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+	 * @author Alexandre Vasseur (alex AT gnilux DOT com)
 	 */
 	public static class LazyResolvedPointcutDefinition extends ResolvedPointcutDefinition {
 		private final Pointcut m_pointcutUnresolved; // null for abstract

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelAccessForInlineMunger.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelAccessForInlineMunger.java
@@ -42,11 +42,13 @@ import org.aspectj.weaver.UnresolvedType;
 /**
  * Looks for all access to method or field that are not public within the body of the around advices and replace the invocations to
  * a wrapper call so that the around advice can further be inlined.
- * <p/>
+ * <p>
  * This munger is used for @AJ aspects for which inlining wrapper is not done at compile time.
- * <p/>
+ * </p>
+ * <p>
  * Specific state and logic is kept in the munger ala ITD so that call/get/set pointcuts can still be matched on the wrapped member
  * thanks to the EffectiveSignature attribute.
+ * </p>
  *
  * @author Alexandre Vasseur
  * @author Andy Clement

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
@@ -625,7 +625,7 @@ public class BcelShadow extends Shadow {
 
 	/**
 	 * Create an initialization join point associated with a constructor, but not with any body of code yet. If this is actually
-	 * matched, it's range will be set when we inline self constructors.
+	 * matched, its range will be set when we inline self constructors.
 	 *
 	 * @param constructor The constructor starting this initialization.
 	 */

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
@@ -2062,7 +2062,7 @@ public class BcelTypeMunger extends ConcreteTypeMunger {
 	}
 
 	/**
-	 * Returns a list of type variable aliases used in this munger. For example, if the ITD is 'int I<A,B>.m(List<A> las,List<B>
+	 * Returns a list of type variable aliases used in this munger. For example, if the ITD is 'int I&lt;A,B&gt;.m(List&lt;A&gt; las,List&lt;B&gt;
 	 * lbs) {}' then this returns a list containing the strings "A" and "B".
 	 */
 	public List<String> getTypeVariableAliases() {

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/Utility.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/Utility.java
@@ -480,7 +480,7 @@ public class Utility {
 	 * replace an instruction handle with another instruction, in this case, a branch instruction.
 	 * 
 	 * @param ih the instruction handle to replace.
-	 * @param branchInstruction the branch instruction to replace ih with
+	 * @param replacementInstructions the branch instruction to replace ih with
 	 * @param enclosingMethod where to find ih's instruction list.
 	 */
 	public static void replaceInstruction(InstructionHandle ih, InstructionList replacementInstructions,

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/IWeavingContext.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/IWeavingContext.java
@@ -39,7 +39,7 @@ public interface IWeavingContext {
 	Enumeration<URL> getResources(String name) throws IOException;
 
 	/**
-	 * In an OSGi environment, determin which bundle a URL originated from.
+	 * In an OSGi environment, determine which bundle a URL originated from.
 	 * In a non-OSGi environment, implementors should return <code>null</code>.
 	 * @param url
 	 * @return

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/IWeavingContext.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/IWeavingContext.java
@@ -40,7 +40,7 @@ public interface IWeavingContext {
 
 	/**
 	 * In an OSGi environment, determin which bundle a URL originated from.
-	 * In a non-OSGi environment, implementors should return <code>null<code>.
+	 * In a non-OSGi environment, implementors should return <code>null</code>.
 	 * @param url
 	 * @return
 	 * @deprecated use getFile() or getClassLoaderName()

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/Definition.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/Definition.java
@@ -19,7 +19,7 @@ import java.util.Map;
 /**
  * A POJO that contains raw strings from the XML (sort of XMLBean for our simple LTW DTD)
  * 
- * @author <a href="mailto:alex AT gnilux DOT com">Alexandre Vasseur</a>
+ * @author Alexandre Vasseur (alex AT gnilux DOT com)
  */
 public class Definition {
 

--- a/weaver/src/main/java/org/aspectj/weaver/ltw/LTWWorld.java
+++ b/weaver/src/main/java/org/aspectj/weaver/ltw/LTWWorld.java
@@ -97,7 +97,7 @@ public class LTWWorld extends BcelWorld implements IReflectionWorld {
 	// }
 
 	/**
-	 * @Override
+	 * Override
 	 */
 	@Override
 	protected ReferenceTypeDelegate resolveDelegate(ReferenceType ty) {

--- a/weaver/src/main/java/org/aspectj/weaver/model/AsmRelationshipUtils.java
+++ b/weaver/src/main/java/org/aspectj/weaver/model/AsmRelationshipUtils.java
@@ -48,7 +48,7 @@ public class AsmRelationshipUtils {
 	}
 
 	/**
-	 * Generates the pointcut details for the given pointcut, for example an anonymous pointcut will return '<anonymous pointcut>'
+	 * Generates the pointcut details for the given pointcut, for example an anonymous pointcut will return '&lt;anonymous pointcut&gt;'
 	 * and a named pointcut called p() will return 'p()..'
 	 */
 	public static String genPointcutDetails(Pointcut pcd) {

--- a/weaver/src/main/java/org/aspectj/weaver/tools/WeavingAdaptor.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/WeavingAdaptor.java
@@ -644,7 +644,6 @@ public class WeavingAdaptor implements IMessageContext {
 	 * @param name
 	 * @param b
 	 * @param before whether we are dumping before weaving
-	 * @throws Throwable
 	 */
 	protected void dump(String name, byte[] b, boolean before) {
 		String dirName = getDumpDir();

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/AbstractCacheBacking.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/AbstractCacheBacking.java
@@ -31,7 +31,7 @@ public abstract class AbstractCacheBacking implements CacheBacking {
      * Calculates CRC32 on the provided bytes
      * @param bytes The bytes array - ignored if <code>null</code>/empty
      * @return Calculated CRC
-     * @see {@link CRC32}
+     * @see CRC32
      */
     public static final long crc (byte[] bytes) {
         if ((bytes == null) || (bytes.length <= 0)) {

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/AsynchronousFileCacheBacking.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/AsynchronousFileCacheBacking.java
@@ -35,7 +35,7 @@ import org.aspectj.weaver.tools.TraceFactory;
  * to signal to a background thread various actions required to &quot;synchronize&quot;
  * the in-memory cache with the persisted copy. Whenever there is a cache miss
  * from the {@link #get(CachedClassReference)} call, the weaver issues a
- * {@link #put(CachedClassEntry)} call. This call has 2 side-effects:</BR>
+ * {@link #put(CachedClassEntry)} call. This call has 2 side-effects:
  * <UL>
  * 		<LI>
  * 		The in-memory cache is updated so that subsequent calls to {@link #get(CachedClassReference)}

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/AsynchronousFileCacheBacking.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/AsynchronousFileCacheBacking.java
@@ -34,11 +34,11 @@ import org.aspectj.weaver.tools.TraceFactory;
  * The class maintains an in-memory cache, and uses a queue of {@link AsyncCommand}s
  * to signal to a background thread various actions required to &quot;synchronize&quot;
  * the in-memory cache with the persisted copy. Whenever there is a cache miss
- * from the {@link #get(CachedClassReference)} call, the weaver issues a
- * {@link #put(CachedClassEntry)} call. This call has 2 side-effects:
+ * from the {@link #get(CachedClassReference, byte[])} call, the weaver issues a
+ * {@link #put(CachedClassEntry, byte[])} call. This call has 2 side-effects:
  * <UL>
  * 		<LI>
- * 		The in-memory cache is updated so that subsequent calls to {@link #get(CachedClassReference)}
+ * 		The in-memory cache is updated so that subsequent calls to {@link #get(CachedClassReference, byte[])}
  * 		will not return the mapped value.
  * 		</LI>
  *

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/AsynchronousFileCacheBacking.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/AsynchronousFileCacheBacking.java
@@ -43,7 +43,7 @@ import org.aspectj.weaver.tools.TraceFactory;
  * 		</LI>
  *
  *  	<LI>
- *  	An &quot;update index&quot {@link AsyncCommand} is posted to the background
+ *  	An &quot;update index&quot; {@link AsyncCommand} is posted to the background
  *  	thread so that the newly mapped value will be persisted (eventually)
  *  	</LI>
  * </UL>

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/CacheBacking.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/CacheBacking.java
@@ -15,10 +15,11 @@ package org.aspectj.weaver.tools.cache;
 /**
  * Interface for the backing to the cache; usually a file,
  * but could be an in-memory backing for testing.
- * <p/>
+ * <p>
  * aspectj and jvmti provide no suitable guarantees
  * on locking for class redefinitions, so every implementation
  * must have a some locking mechanism to prevent invalid reads.
+ * </p>
  */
 public interface CacheBacking {
 	/**

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/CacheKeyResolver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/CacheKeyResolver.java
@@ -20,10 +20,11 @@ import java.util.List;
  * a reasonable naive implementation, the management and invalidation
  * of the cache may be more usefully accomplished at the Application
  * or Container level.
- * <p/>
+ * <p>
  * The key is not a one-way hash; it must be convertible back to a
  * className and must match the regex for the type of key it is
  * (generated or weaved).
+ * </p>
  */
 public interface CacheKeyResolver {
 	/**

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/CachedClassReference.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/CachedClassReference.java
@@ -18,9 +18,10 @@ package org.aspectj.weaver.tools.cache;
  * cache entry is a simple string, but that string may contain
  * some specialized encoding. This class handles all of that
  * encoding.
- * <p/>
+ * <p>
  * External users of the cache should not be able to create these
  * objects manually.
+ * </p>
  */
 public class CachedClassReference {
 	enum EntryType {

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/DefaultCacheKeyResolver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/DefaultCacheKeyResolver.java
@@ -22,15 +22,18 @@ import java.util.zip.CRC32;
 /**
  * Naive default class and classloader hashing implementation useful
  * for some multi-classloader environments.
- * <p/>
- * This implementation creates classloader scopes of the form:<br/>
+ * <p>
+ * This implementation creates classloader scopes of the form:<br>
  * "ExampleClassLoaderName.[crc hash]"
- * <p/>
- * And weaved class keys of the form:<br/>
+ * </p>
+ * <p>
+ * And weaved class keys of the form:<br>
  * "com.foo.BarClassName.[bytes len][crc].weaved"
- * <p/>
- * And generated class keys of the form:<br/>
+ * </p>
+ * <p>
+ * And generated class keys of the form:<br>
  * "com.foo.BarClassName$AjClosure.generated
+ * </p>
  */
 public class DefaultCacheKeyResolver implements CacheKeyResolver {
 	public static final String GENERATED_SUFFIX = ".generated";

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/DefaultFileCacheBacking.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/DefaultFileCacheBacking.java
@@ -28,20 +28,23 @@ import org.aspectj.util.LangUtil;
 /**
  * Naive File-Backed Class Cache with no expiry or application
  * centric invalidation.
- * <p/>
+ * <p>
  * Enabled with the system property, "aj.weaving.cache.dir"
  * If this system property is not set, no caching will be
  * performed.
- * <p/>
+ * </p>
+ * <p>
  * A CRC checksum is stored alongside the class file to verify
  * the bytes on read. If for some reason there is an error
  * reading either the class or crc file, or if the crc does not
  * match the class data the cache entry is deleted.
- * <p/>
+ * </p>
+ * <p>
  * An alternate implementation of this could store the class file
  * as a jar/zip directly, which would have the required crc; as
  * a first pass however it is somewhat useful to view these files
  * in expanded form for debugging.
+ * </p>
  */
 public class DefaultFileCacheBacking extends AbstractIndexedFileCacheBacking {
 	private final Map<String, IndexEntry> index;

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/FlatFileCacheBacking.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/FlatFileCacheBacking.java
@@ -24,7 +24,7 @@ import org.aspectj.util.FileUtil;
 import org.aspectj.util.LangUtil;
 
 /**
- * Uses a &quot;flat&quot files model to store the cached instrumented classes
+ * Uses a &quot;flat&quot; files model to store the cached instrumented classes
  * and aspects - i.e., each class/aspect is stored as a <U>separate</U> (binary)
  * file. This is a good mechanism when the number of instrumented class is
  * relatively small (a few 10's). The reason for it is that scanning a folder

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/WeavedClassCache.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/WeavedClassCache.java
@@ -27,44 +27,49 @@ import org.aspectj.weaver.tools.GeneratedClassHandler;
  * except designed to operate across multiple restarts of the JVM and with one
  * cache per classloader; allowing URLClassLoaders with the same set of URI
  * paths to share the same cache (with the default configuration).
- * <p/>
+ * <p>
  * To enable the default configuration two system properties must be set:
+ * </p>
  * <pre>
  *    "-Daj.weaving.cache.enabled=true"
  *    "-Daj.weaving.cache.dir=/some/directory"
  * </pre>
- * <p/>
+ * <p>
  * The class cache is often something that application developers or
  * containers would like to manage, so there are a few interfaces for overriding the
  * default behavior and performing other management functions.
+ * </p>
  * <p/>
- * {@link CacheBacking} <br/>
+ * {@link CacheBacking} <br>
  * Provides an interface for implementing a custom backing store
  * for the cache; The default implementation in {@link DefaultFileCacheBacking}
  * provides a naive file-backed cache. An alternate implementation may ignore
  * caching until signaled explicitly by the application, or only cache files
  * for a specific duration. This class delegates the locking and synchronization
  * requirements to the CacheBacking implementation.
- * <p/>
- * {@link CacheKeyResolver} <br/>
+ * </p>
+ * <p>
+ * {@link CacheKeyResolver} <br>
  * Provides methods for creating keys from classes to be cached and for
  * creating the "scope" of the cache itself for a given classloader and aspect
  * list. The default implementation is provided by {@link DefaultCacheKeyResolver}
  * but an alternate implementation may want to associate a cache with a particular
  * application running underneath a container.
- * <p/>
+ * </p>
+ * <p>
  * This naive cache does not normally invalidate *any* classes; the interfaces above
  * must be used to implement more intelligent behavior. Cache invalidation
  * problems may occur in at least three scenarios:
- * <pre>
- *    1. New aspects are added dynamically somewhere in the classloader hierarchy; affecting
- *       other classes elsewhere.
- *    2. Use of declare parent in aspects to change the type hierarchy; if the cache
+ * </p>
+ * <ol>
+ *    <li>New aspects are added dynamically somewhere in the classloader hierarchy; affecting
+ *       other classes elsewhere.</li>
+ *    <li>Use of declare parent in aspects to change the type hierarchy; if the cache
  *       has not invalidated the right classes in the type hierarchy aspectj may not
- *       be reconstruct the class incorrectly.
- *    3. Similarly to (2), the addition of fields or methods on classes which have
- *       already been weaved and cached could have inter-type conflicts.
- * </pre>
+ *       be reconstruct the class incorrectly.</li>
+ *    <li>Similarly to (2), the addition of fields or methods on classes which have
+ *       already been weaved and cached could have inter-type conflicts.</li>
+ * </ol>
  */
 public class WeavedClassCache {
 	public static final String WEAVED_CLASS_CACHE_ENABLED = "aj.weaving.cache.enabled";


### PR DESCRIPTION
I attempted to build the javadoc documentation, but javadoc complained of many errors.  These commits fix the errors.  I divided them up by the type of error to make it easier for you to review (and easier to skip one if you object to something I've done).  The last commit fixes a handful of typos that I noticed while looking at the javadoc comments.

With these changes, I can now successfully generate javadocs for the following directories:

- ajbrowser
- ajde
- ajde.core
- ajdoc
- asm
- bridge
- loadtime
- org.aspectj.ajdt.core
- org.aspectj.matcher
- runtime
- taskdefs
- util
- weaver

There are still lots of warnings, but no errors.