### PR TITLE
Fix apostrophe in the license

### DIFF
--- a/docs/dist/LICENSE-AspectJ.html
+++ b/docs/dist/LICENSE-AspectJ.html
@@ -32,7 +32,7 @@ is available from
 		<h3>Third Party Content</h3>
 		<p>The Content includes items that have been sourced from third parties as set out below. If you 
 		did not receive this Content directly from the Eclipse Foundation, the following is provided 
-		for informational purposes only, and you should look to the Redistributor’s license for 
+		for informational purposes only, and you should look to the Redistributor's license for 
 		terms and conditions of use.</p>
 		<em>
 


### PR DESCRIPTION
There is an 0xd5 character in the license text, where an apostrophe seems to be needed.  I cannot find a character encoding where 0xd5 is apostrophe, so I assume this is a mistake.  This commit replaces the 0xd5 with an ASCII apostrophe.  If you want a Unicode apostrophe instead, just let me know.