### PR TITLE
Optimize class loading

### DIFF
--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
@@ -64,6 +64,7 @@ import java.net.URLClassLoader;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -73,11 +74,11 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
 
 /**
  * The repository maintains information about which classes have been loaded.
- * 
+ *
  * It loads its data from the ClassLoader implementation passed into its constructor.
- * 
+ *
  * @see org.aspectj.apache.bcel.Repository
- * 
+ *
  * @version $Id: ClassLoaderRepository.java,v 1.13 2009/09/09 19:56:20 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author David Dixon-Peugh
@@ -94,6 +95,16 @@ public class ClassLoaderRepository implements Repository {
 	private SoftHashMap /* <String,URL> */nameMap = new SoftHashMap(new HashMap(), false);
 
 	public static boolean useSharedCache = System.getProperty("org.aspectj.apache.bcel.useSharedCache", "true").equalsIgnoreCase("true");
+
+	//Cache not found classes as well to prevent unnecessary file I/O operations
+	public static final boolean useUnavailableClassesCache =
+		System.getProperty("org.aspectj.apache.bcel.useUnavailableClassesCache", "true").equalsIgnoreCase("true");
+	//Ignore cache clear requests to not build up the cache over and over again
+	public static final boolean ignoreCacheClearRequests =
+		System.getProperty("org.aspectj.apache.bcel.ignoreCacheClearRequests", "true").equalsIgnoreCase("true");
+
+	//Second cache for the unavailable classes
+	private static Set<String> unavailableClasses = new HashSet<String>();
 
 	private static int cacheHitsShared = 0;
 	private static int missSharedEvicted = 0; // Misses in shared cache access due to reference GC
@@ -183,8 +194,10 @@ public class ClassLoaderRepository implements Repository {
 
 		@Override
 		public void clear() {
-			processQueue();
-			map.clear();
+			if (!ignoreCacheClearRequests) {
+				processQueue();
+				map.clear();
+			}
 		}
 
 		@Override
@@ -281,12 +294,19 @@ public class ClassLoaderRepository implements Repository {
 	 */
 	public JavaClass loadClass(String className) throws ClassNotFoundException {
 
+		//Quick evaluation of unavailable classes to prevent unnecessary file I/O
+		if (useUnavailableClassesCache && unavailableClasses.contains(className))
+			throw new ClassNotFoundException(className + " not found.");
+
 		// translate to a URL
 		long time = System.currentTimeMillis();
 		java.net.URL url = toURL(className);
 		timeManipulatingURLs += (System.currentTimeMillis() - time);
-		if (url == null)
+		if (url == null) {
+			if (useUnavailableClassesCache)
+				unavailableClasses.add(className);
 			throw new ClassNotFoundException(className + " not found - unable to determine URL");
+		}
 
 		JavaClass clazz = null;
 
@@ -314,6 +334,9 @@ public class ClassLoaderRepository implements Repository {
 			InputStream is = (useSharedCache ? url.openStream() : loaderRef.getClassLoader().getResourceAsStream(
 					classFile + ".class"));
 			if (is == null) {
+				if (useUnavailableClassesCache) {
+					unavailableClasses.add(className);
+				}
 				throw new ClassNotFoundException(className + " not found using url " + url);
 			}
 			ClassParser parser = new ClassParser(is, className);
@@ -326,6 +349,7 @@ public class ClassLoaderRepository implements Repository {
 			classesLoadedCount++;
 			return clazz;
 		} catch (IOException e) {
+			unavailableClasses.add(className);
 			throw new ClassNotFoundException(e.toString());
 		}
 	}
@@ -384,10 +408,12 @@ public class ClassLoaderRepository implements Repository {
 
 	/** Clear all entries from the local cache */
 	public void clear() {
-		if (useSharedCache)
-			sharedCache.clear();
-		else
-			localCache.clear();
+		if (!ignoreCacheClearRequests) {
+			if (useSharedCache)
+				sharedCache.clear();
+			else
+				localCache.clear();
+		}
 	}
 
 }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
@@ -98,10 +98,10 @@ public class ClassLoaderRepository implements Repository {
 
 	//Cache not found classes as well to prevent unnecessary file I/O operations
 	public static final boolean useUnavailableClassesCache =
-		System.getProperty("org.aspectj.apache.bcel.useUnavailableClassesCache", "true").equalsIgnoreCase("true");
+		System.getProperty("org.aspectj.apache.bcel.useUnavailableClassesCache", "false").equalsIgnoreCase("true");
 	//Ignore cache clear requests to not build up the cache over and over again
 	public static final boolean ignoreCacheClearRequests =
-		System.getProperty("org.aspectj.apache.bcel.ignoreCacheClearRequests", "true").equalsIgnoreCase("true");
+		System.getProperty("org.aspectj.apache.bcel.ignoreCacheClearRequests", "false").equalsIgnoreCase("true");
 
 	//Second cache for the unavailable classes
 	private static Set<String> unavailableClasses = new HashSet<String>();
@@ -349,7 +349,9 @@ public class ClassLoaderRepository implements Repository {
 			classesLoadedCount++;
 			return clazz;
 		} catch (IOException e) {
-			unavailableClasses.add(className);
+			if (useUnavailableClassesCache) {
+				unavailableClasses.add(className);
+			}
 			throw new ClassNotFoundException(e.toString());
 		}
 	}

--- a/weaver/src/main/java/org/aspectj/weaver/reflect/Java15AnnotationFinder.java
+++ b/weaver/src/main/java/org/aspectj/weaver/reflect/Java15AnnotationFinder.java
@@ -50,7 +50,7 @@ public class Java15AnnotationFinder implements AnnotationFinder, ArgNameFinder {
 
 	//Use single instance of Repository and ClassLoader
 	public static final boolean useSingleInstances =
-		System.getProperty("org.aspectj.apache.bcel.useSingleRepositoryInstance", "true").equalsIgnoreCase("true");
+		System.getProperty("org.aspectj.apache.bcel.useSingleRepositoryInstance", "false").equalsIgnoreCase("true");
 
 	static {
 		try {
@@ -76,13 +76,13 @@ public class Java15AnnotationFinder implements AnnotationFinder, ArgNameFinder {
 			if (useSingleInstances && staticBcelRepository == null)
 				staticBcelRepository = new ClassLoaderRepository(getClassLoader());
 			else
-				this.bcelRepository = new ClassLoaderRepository(getClassLoader());
+				this.bcelRepository = new ClassLoaderRepository(classLoaderRef);
 		}
 		else {
 			if (useSingleInstances && staticBcelRepository == null)
 				staticBcelRepository = new NonCachingClassLoaderRepository(getClassLoader());
 			else
-				this.bcelRepository = new NonCachingClassLoaderRepository(getClassLoader());
+				this.bcelRepository = new NonCachingClassLoaderRepository(classLoaderRef);
 		}
 	}
 


### PR DESCRIPTION
Closes #9
Relates to https://bugs.eclipse.org/bugs/show_bug.cgi?id=565450

I rebased Steve's old commit/patch https://github.com/StrongSteve/org.aspectj/commit/07fcd35650e199c535f57640cd4e4fe16ad19154 on current master, removed his whitespace changes and commented-out parts of the code in order to minimise the patch and make it easier for @aclement to review and merge it.

Disclaimer: I have no idea what this patch does, but wanted to assist technically in order to get this into 1.9.7. Original commit comment below, slightly adjusted for better readability.

---

In our project we found out that during the build up of the Spring context the class loading takes a very long time. Root cause is the huge amount of file I/O during pointcut class loading. We are talking about ~250k file loads.

With these changes we managed to cut down the starting time by around 50%.

What we found out is that IMHO - the clear method of `ClassLoaderRepository` is called far too often -> in our settings this resulted in not a single cache hit as the cache got cleared permanently. Therefore, we deactived the cache clear calls inside `ClassLoaderRepository`.

Secondly, we changed `Java15AnnotationFinder` in a way to not always create new objects for the `ClassLoaderRepository` but re-use one static instance. Otherwise we experienced >100k objects being created.

Last but not least, we introduced a cache for unavailable classes so that they do not have to be looked up using file I/O over and over again.

The whole behavior is configurable via
+ `org.aspectj.apache.bcel.useSingleRepositoryInstance` (default: `true`)
+ `org.aspectj.apache.bcel.useUnavailableClassesCache` (default: `true`)
+ `org.aspectj.apache.bcel.ignoreCacheClearRequests` (default: `true`)