### PR TITLE
Fix missing dependencies in module 'run-all-junit-tests'

### DIFF
--- a/ajdoc/pom.xml
+++ b/ajdoc/pom.xml
@@ -18,7 +18,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
-            <!-- The tests need this during runtime, even though no direct usage is in our classes -->
+            <!-- The tests need these during runtime, even though no direct usage is in our classes -->
             <usedDependency>com.github.olivergondza:maven-jdk-tools-wrapper</usedDependency>
           </usedDependencies>
         </configuration>
@@ -27,6 +27,7 @@
   </build>
 
   <dependencies>
+
     <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>util</artifactId>
@@ -48,12 +49,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <!-- enables easy dependency on tools.jar -->
-      <groupId>com.github.olivergondza</groupId>
-      <artifactId>maven-jdk-tools-wrapper</artifactId>
-      <version>0.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>asm-renamed</artifactId>
     </dependency>
@@ -62,6 +57,17 @@
       <artifactId>testing-util</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+    </dependency>
+
+    <!--
+      The tests need these during runtime, even though no direct usage is in our classes.
+      See also 'usedDependencies' in maven-dependency-plugin configuration.
+    -->
+    <dependency>
+      <!-- enables easy dependency on tools.jar -->
+      <groupId>com.github.olivergondza</groupId>
+      <artifactId>maven-jdk-tools-wrapper</artifactId>
+      <version>0.1</version>
     </dependency>
 
   </dependencies>

--- a/run-all-junit-tests/pom.xml
+++ b/run-all-junit-tests/pom.xml
@@ -12,10 +12,7 @@
 	<artifactId>run-all-junit-tests</artifactId>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.aspectj</groupId>
-			<artifactId>asm-renamed</artifactId>
-		</dependency>
+
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>util</artifactId>
@@ -142,6 +139,41 @@
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+
+		<!--
+			The tests need these during runtime, even though no direct usage is in our classes.
+			See also 'usedDependencies' in maven-dependency-plugin configuration.
+		-->
+		<dependency>
+			<groupId>ant</groupId>
+			<artifactId>ant-launcher</artifactId>
+			<version>${lib.ant.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>asm-renamed</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>ajde</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>build</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>tests</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<profiles>
@@ -199,6 +231,20 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<configuration>
+					<usedDependencies>
+						<!-- The tests need these during runtime, even though no direct usage is in our classes -->
+						<usedDependency>ant:ant-launcher</usedDependency>
+						<usedDependency>org.aspectj:asm-renamed</usedDependency>
+						<usedDependency>org.aspectj:ajde</usedDependency>
+						<usedDependency>org.aspectj:build</usedDependency>
+						<usedDependency>org.aspectj:tests</usedDependency>
+					</usedDependencies>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -12,6 +12,7 @@
 	<artifactId>tests</artifactId>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>util</artifactId>
@@ -83,13 +84,18 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<!--
+			The tests need these during runtime, even though no direct usage is in our classes.
+			See also 'usedDependencies' in maven-dependency-plugin configuration.
+		-->
 		<dependency>
-			<!-- Identical to lib/ant/lib/ant-launcher.jar, a former system-scoped dependency -->
 			<groupId>ant</groupId>
 			<artifactId>ant-launcher</artifactId>
 			<version>${lib.ant.version}</version>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -110,7 +116,7 @@
 				<artifactId>maven-dependency-plugin</artifactId>
 				<configuration>
 					<usedDependencies>
-						<!-- The tests need this during runtime, even though no direct usage is in our classes -->
+						<!-- The tests need these during runtime, even though no direct usage is in our classes -->
 						<usedDependency>ant:ant-launcher</usedDependency>
 					</usedDependencies>
 				</configuration>


### PR DESCRIPTION
Some runtime dependencies are reported as unused in Maven Dependency Plugin goal `dependency:analyze`, but actually they are needed. I noticed by chance when running RunTheseBeforeYouCommitTests in IntelliJ IDEA for the first time after a while and dependency modules could not find classes.