### PR TITLE
Only deploy main artifacts, default to no deployment for all others

### DIFF
--- a/asm-renamed/pom.xml
+++ b/asm-renamed/pom.xml
@@ -41,6 +41,11 @@
     the binaries. IDEA will just stop looking at the local Maven repository in this case.
   </description>
 
+  <properties>
+    <!-- By default, do not deploy artifacts - but deploy this one used by the main build -->
+    <maven.deploy.skip>false</maven.deploy.skip>
+  </properties>
+
   <distributionManagement>
     <repository>
       <id>github</id>

--- a/aspectjmatcher/pom.xml
+++ b/aspectjmatcher/pom.xml
@@ -13,6 +13,11 @@
 	<artifactId>aspectjmatcher</artifactId>
 	<name>AspectJ Matcher</name>
 
+	<properties>
+		<!-- By default, do not deploy artifacts - but deploy this public one -->
+		<maven.deploy.skip>false</maven.deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 

--- a/aspectjrt/pom.xml
+++ b/aspectjrt/pom.xml
@@ -13,6 +13,11 @@
 	<artifactId>aspectjrt</artifactId>
 	<name>AspectJ Runtime</name>
 
+	<properties>
+		<!-- By default, do not deploy artifacts - but deploy this public one -->
+		<maven.deploy.skip>false</maven.deploy.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.aspectj</groupId>

--- a/aspectjtools/pom.xml
+++ b/aspectjtools/pom.xml
@@ -13,6 +13,11 @@
 	<artifactId>aspectjtools</artifactId>
 	<name>AspectJ Compiler</name>
 
+	<properties>
+		<!-- By default, do not deploy artifacts - but deploy this public one -->
+		<maven.deploy.skip>false</maven.deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 

--- a/aspectjweaver/pom.xml
+++ b/aspectjweaver/pom.xml
@@ -13,6 +13,11 @@
 	<artifactId>aspectjweaver</artifactId>
 	<name>AspectJ Weaver</name>
 
+	<properties>
+		<!-- By default, do not deploy artifacts - but deploy this public one -->
+		<maven.deploy.skip>false</maven.deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -13,6 +13,11 @@
 	<artifactId>installer</artifactId>
 	<name>AspectJ Installer</name>
 
+	<properties>
+		<!-- By default, do not deploy artifacts - but deploy this public one -->
+		<maven.deploy.skip>false</maven.deploy.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.aspectj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
 		<revision>1.9.7.BUILD-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<!-- By default, do not deploy artifacts - override for the ones which actually should be deployed -->
+		<maven.deploy.skip>true</maven.deploy.skip>
 		<jdt.core.version>3.25.0-SNAPSHOT</jdt.core.version>
 		<lib.ant.version>1.6.3</lib.ant.version>
 		<lib.ant.xerces.version>2.6.2</lib.ant.xerces.version>


### PR DESCRIPTION
Prepare main artifacts to be deployed via Maven, step 2. This change affects the following modules:
  - aspectjmatcher
  - aspectjrt
  - aspectjtools
  - aspectjweaver
  - installer
  - asm-renamed

Set `maven.deploy.skip=false` in parent POM, i.e. Maven Deploy by default will **not** deploy anything. Only in the modules above, we change the value to `true` in order to deploy those artifacts.

This setting works for both snapshot repositories (GitHub Packages, soon to be migrated to aspectj.dev in a separate PR) and release repositories, i.e. in the future also for Maven Central.