### PR TITLE
Use canonical snapshot version 1.9.7-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Once you have imported all the projects using `m2e`, close the `org.eclipse.jdt.
  
 ## Setting version for release:
 
-mvn versions:set -DgroupId=org.aspectj -DartifactId=* -DoldVersion=1.9.3.BUILD-SNAPSHOT -DnewVersion=1.9.3
+mvn versions:set -DgroupId=org.aspectj -DartifactId=* -DoldVersion=1.9.3-SNAPSHOT -DnewVersion=1.9.3

--- a/ajbrowser/pom.xml
+++ b/ajbrowser/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajbrowser</artifactId>

--- a/ajde.core/pom.xml
+++ b/ajde.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajde.core</artifactId>

--- a/ajde/pom.xml
+++ b/ajde/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajde</artifactId>

--- a/ajdoc/pom.xml
+++ b/ajdoc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajdoc</artifactId>

--- a/asm/pom.xml
+++ b/asm/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>asm</artifactId>

--- a/aspectjmatcher/pom.xml
+++ b/aspectjmatcher/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjmatcher</artifactId>

--- a/aspectjrt/pom.xml
+++ b/aspectjrt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjrt</artifactId>

--- a/aspectjtools/pom.xml
+++ b/aspectjtools/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjtools</artifactId>

--- a/aspectjweaver/pom.xml
+++ b/aspectjweaver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjweaver</artifactId>

--- a/bcel-builder/pom.xml
+++ b/bcel-builder/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bcel-builder</artifactId>

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bridge</artifactId>

--- a/build/build.xml
+++ b/build/build.xml
@@ -806,11 +806,11 @@ ant -propertyfile XXX publishtomaven
     <property name="maven.central.repository" value="https://repo.spring.io/libs-snapshot-local/org/aspectj/aspectjweaver"/>
 -->
 
-<!-- aspectjtools/target/aspectjtools-1.9.6.BUILD-SNAPSHOT.jar -->
+<!-- aspectjtools/target/aspectjtools-1.9.7-SNAPSHOT.jar -->
 
     <property name="bin.jars.folder" value="${build.root}/dist/tools/lib"/>
     <property name="src.jars.folder" value="${build.root}/src"/>
-    <property name="suffix" value="1.9.6.BUILD-SNAPSHOT"/>
+    <property name="suffix" value="1.9.7-SNAPSHOT"/>
 
     <!-- ASPECTJRT -->
     <maven:deploy file="${build.root}/aspectjrt/target/aspectjrt-${suffix}.jar">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>build</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>installer</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>lib</artifactId>

--- a/loadtime/pom.xml
+++ b/loadtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>loadtime</artifactId>

--- a/org.aspectj.ajdt.core/pom.xml
+++ b/org.aspectj.ajdt.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.aspectj.ajdt.core</artifactId>

--- a/org.aspectj.matcher/pom.xml
+++ b/org.aspectj.matcher/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.aspectj.matcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,12 @@
 
 	<groupId>org.aspectj</groupId>
 	<artifactId>aspectj-parent</artifactId>
-	<version>1.9.7.BUILD-SNAPSHOT</version>
+	<version>1.9.7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>AspectJ Parent Project</name>
 
 	<properties>
-		<!-- TODO: Do we still need this? -->
-		<revision>1.9.7.BUILD-SNAPSHOT</revision>
 		<!-- Basic build properties -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/run-all-junit-tests/pom.xml
+++ b/run-all-junit-tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>run-all-junit-tests</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>runtime</artifactId>

--- a/taskdefs/pom.xml
+++ b/taskdefs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>taskdefs</artifactId>

--- a/testing-client/pom.xml
+++ b/testing-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing-client</artifactId>

--- a/testing-drivers/pom.xml
+++ b/testing-drivers/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing-drivers</artifactId>

--- a/testing-util/pom.xml
+++ b/testing-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing-util</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.7.BUILD-SNAPSHOT</version>
+		<version>1.9.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tests</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>util</artifactId>

--- a/weaver/pom.xml
+++ b/weaver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.7.BUILD-SNAPSHOT</version>
+    <version>1.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>weaver</artifactId>


### PR DESCRIPTION
_FYI, this one is based on the fix in #55, so please merge that one first, because master has an invalid aspectjtools POM. Otherwise, this PR would not even build._

Before, we used 1.9.7.BUILD-SNAPSHOT, which according to Andy Clement was originally an intent across a group of Spring projects he was involved in, to ensure that SNAPSHOTS were sorted alphabetically ahead of MILESTONEs and ahead of RCs.