### PR TITLE
Detect previously failed downloads by verifying existing file checksums

### DIFF
--- a/docs/developer/RELEASE.md
+++ b/docs/developer/RELEASE.md
@@ -138,7 +138,7 @@ mvn nexus-staging:rc-list
 
 # Use the ID of the corresponding CLOSED staging repository for releasing to
 # Maven Central
- mvn nexus-staging:rc-release -DstagingRepositoryId=orgaspectj-1106
+mvn nexus-staging:rc-release -DstagingRepositoryId=orgaspectj-1106
 ```
 
 Tadaa! We have performed an AspectJ release. In a few minutes, the artifacts should appear on Maven Central somewhere

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -58,6 +58,10 @@
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
             <version>1.6.3</version>
+            <configuration>
+              <!-- Detect previously failed downloads by verifying checksums of existing files -> retry -->
+              <checkSignature>true</checkSignature>
+            </configuration>
             <executions>
               <execution>
                 <id>download-ant-binaries</id>


### PR DESCRIPTION
There was a helpful option hiding in Download Maven plugin, which we use to download artifacts unavailable on Maven Central, such as the Ant installer and several source packages: `checkSignature`. It has the effect of verifying checksums of existing, i.e. previously downloaded files too, not only newly downloaded ones. This helps detect interrupted downloads from previous runs or generally invalid files, whatever the reason. I was looking for this option before, but did not notice it because of the name. This is about verifying checksums, not checking signatures. Anyway, a maintainer just told me about it here:

maven-download-plugin/maven-download-plugin#186

I requested that the option be renamed and described better.