### PR TITLE
Test for 1.9.6 concurrency bug in LocalVariableTable.unpack()

### DIFF
--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTable.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * This class represents collection of local variables in a method. This attribute is contained in the <em>Code</em> attribute.
- * 
+ *
  * @version $Id: LocalVariableTable.java,v 1.8 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Code
@@ -99,7 +99,7 @@ public class LocalVariableTable extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -117,7 +117,7 @@ public class LocalVariableTable extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -128,7 +128,7 @@ public class LocalVariableTable extends Attribute {
 
 	/**
 	 * Dump local variable table attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -189,6 +189,11 @@ public class LocalVariableTable extends Attribute {
 		return buf.toString();
 	}
 
+	@Override
+	public Object clone() throws CloneNotSupportedException {
+		return super.clone();
+	}
+
 	/**
 	 * @return deep copy of this attribute
 	 */
@@ -223,7 +228,7 @@ public class LocalVariableTable extends Attribute {
 			dis.close();
 			data = null; // throw it away now
 		} catch (IOException e) {
-			throw new RuntimeException("Unpacking of LocalVariableTable attribute failed");
+			throw new RuntimeException("Unpacking of LocalVariableTable attribute failed", e);
 		}
 		isInPackedState = false;
 	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTable.java
@@ -189,9 +189,16 @@ public class LocalVariableTable extends Attribute {
 		return buf.toString();
 	}
 
-	@Override
-	public Object clone() throws CloneNotSupportedException {
-		return super.clone();
+	/**
+	 * Returns copy of this attribute using same packed state. Used in unit tests.
+	 */
+	public synchronized LocalVariableTable copyFromPackedState() {
+		if (!isInPackedState) throw new IllegalStateException("No in packed state");
+		try {
+			return new LocalVariableTable(nameIndex, length, new DataInputStream(new ByteArrayInputStream(data)), getConstantPool());
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to unpack clone", e);
+		}
 	}
 
 	/**

--- a/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/LocalVariableTableConcurrencyTest.java
+++ b/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/LocalVariableTableConcurrencyTest.java
@@ -1,0 +1,94 @@
+/* *******************************************************************
+ * Copyright (c) 2004 IBM
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Andy Clement -     initial implementation
+ * ******************************************************************/
+
+package org.aspectj.apache.bcel.classfile.tests;
+
+import org.aspectj.apache.bcel.classfile.Code;
+import org.aspectj.apache.bcel.classfile.JavaClass;
+import org.aspectj.apache.bcel.classfile.LocalVariableTable;
+import org.aspectj.apache.bcel.classfile.Method;
+import org.aspectj.apache.bcel.classfile.tests.BcelTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+public class LocalVariableTableConcurrencyTest extends BcelTestCase {
+
+	private final int nThreads = Runtime.getRuntime().availableProcessors();
+
+	private final ExecutorService[] workers = new ExecutorService[nThreads];
+
+	private LocalVariableTable reference;
+
+	protected void setUp() throws Exception {
+		super.setUp();
+		for (int i = 0; i < nThreads; i++) workers[i] = Executors.newSingleThreadExecutor();
+
+		JavaClass clazz = getClassFromJar("SimpleGenericsProgram");
+
+		Method mainMethod = getMethod(clazz,"main");
+		Code codeAttr = (Code) findAttribute("Code",mainMethod.getAttributes());
+
+		reference =
+				(LocalVariableTable) findAttribute("LocalVariableTable",codeAttr.getAttributes());
+	}
+
+	private LocalVariableTable createReferenceCopy() {
+		try {
+			return (LocalVariableTable) reference.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException("Faileed to clone LocalVariableTable", e);
+		}
+	}
+
+	public void testLocalVariableTableAttributeConcurrency() throws RuntimeException, InterruptedException {
+		final AtomicReference<RuntimeException> error = new AtomicReference<>();
+		for (int i = 0; i < 100000; i++) {
+			LocalVariableTable sharedInstance = createReferenceCopy();
+			CountDownLatch preStart = new CountDownLatch(nThreads);
+			Semaphore start = new Semaphore(0);
+			CountDownLatch finish = new CountDownLatch(nThreads);
+
+			for (int j = 0; j < nThreads; j++) {
+				final boolean needsDelay = j > 0;
+				workers[j].execute(() -> {
+					preStart.countDown();
+					start.acquireUninterruptibly();
+					// trying to trigger concurrent unpacking - one tread should enter unpack() when other is about to leave it
+					if (needsDelay) createReferenceCopy().getTableLength();
+					try {
+						sharedInstance.getTableLength();
+					}
+					catch (RuntimeException ex) {
+						error.compareAndSet(null, ex);
+					}
+					finish.countDown();
+				});
+			}
+
+			preStart.await();
+			start.release(nThreads);
+			finish.await();
+
+			if (error.get() != null) throw error.get();
+		}
+	}
+
+	protected void tearDown() throws Exception {
+		for (int i = 0; i < nThreads; i++) if (workers[i] != null) workers[i].shutdownNow();
+		super.tearDown();
+	}
+}


### PR DESCRIPTION
Following suggestion from @kriegaex in https://github.com/eclipse/org.aspectj/pull/64#issuecomment-870160339, I am making formal PR for the test that reproduces concurrency bug in 1.9.6. version.

The test fails in 1.9.6 version and passes in 1.9.7. On 2018 MacBook Pro 2,6 GHz Intel Core i7 it takes 2 seconds to pass.

From javadoc for the test:
> Try to hit concurrency bug in `org.aspectj.apache.bcel.classfile.LocalVariableTable.unpack()`.
> We do so by running `unpack()` on same instance with multiple threads, and artificially
> delaying all threads but first so that they enter `unpack()` the moment first thread is about to leave it.
>
> Since this test relies on empirically obtained access pattern and number of iterations,
> it never has 100% probability of hitting the bug. If it fails - there is certainly a bug.
> If it passes, it could mean anything - fully correct code or slightly changed execution order preventing
> threads to collide at problematic location.
>
> As such, it is not really good for unit testing.

