### PR TITLE
Stabilise flaky test in Ajc1612Tests

### DIFF
--- a/testing/src/test/java/org/aspectj/testing/AjcTest.java
+++ b/testing/src/test/java/org/aspectj/testing/AjcTest.java
@@ -54,10 +54,9 @@ public class AjcTest {
 	public boolean runTest(AjcTestCase testCase) {
 		if (!canRunOnThisVM()) return false;
 		try {
-			System.out.print("TEST: " + getTitle() + "\t");
+			System.out.println("TEST: " + getTitle());
 			for (ITestStep step: testSteps) {
 				step.setBaseDir(getDir());
-				System.out.print(".");
 				step.execute(testCase);
 			}
 		} finally {

--- a/tests/bugs1612/pr356612/AnnoBinding.java
+++ b/tests/bugs1612/pr356612/AnnoBinding.java
@@ -10,19 +10,19 @@ import org.aspectj.lang.reflect.FieldSignature;
 
 public class AnnoBinding {
 	public static void main(String[] argv) {
-		long stime = System.currentTimeMillis();
-		// 10,000 or 100,000 rounds are too quick, making the test flaky
+		long stime = System.nanoTime();
+		// 10,000 or 100,000 rounds are too quick, making the test flaky on rare occasions
 		final int ROUNDS = 1000 * 1000;
 		for (int i = 0; i < ROUNDS; i++) {
 			runOne();
 		}
-		long etime = System.currentTimeMillis();
+		long etime = System.nanoTime();
 		long manual = (etime - stime);
-		stime = System.currentTimeMillis();
+		stime = System.nanoTime();
 		for (int i = 0; i < ROUNDS; i++) {
 			runTwo();
 		}
-		etime = System.currentTimeMillis();
+		etime = System.nanoTime();
 		long woven = (etime - stime);
 		System.out.println("woven=" + woven + " manual=" + manual);
 		if (woven > manual) {

--- a/tests/bugs1612/pr356612/AnnoBinding.java
+++ b/tests/bugs1612/pr356612/AnnoBinding.java
@@ -11,13 +11,15 @@ import org.aspectj.lang.reflect.FieldSignature;
 public class AnnoBinding {
 	public static void main(String[] argv) {
 		long stime = System.currentTimeMillis();
-		for (int i = 0; i < 10000; i++) {
+		// 10,000 or 100,000 rounds are too quick, making the test flaky
+		final int ROUNDS = 1000 * 1000;
+		for (int i = 0; i < ROUNDS; i++) {
 			runOne();
 		}
 		long etime = System.currentTimeMillis();
 		long manual = (etime - stime);
 		stime = System.currentTimeMillis();
-		for (int i = 0; i < 10000; i++) {
+		for (int i = 0; i < ROUNDS; i++) {
 			runTwo();
 		}
 		etime = System.currentTimeMillis();


### PR DESCRIPTION
By increasing from 10,000 to 1,000,000 rounds, the times compared for performance become considerably longer (but still in the tens or hundreds or milliseconds), decreasing the probability of the test failing due to CPU load or some other random effect.

Closes #83.

---

**Update:** Changing time measuring granularity by using `System.nanoTime()` instead of `currentTimeMillis()` also intrinsically reduces flakiness when comparing test runs with the same numbers of rounds. `nanoTime()` is better suited for measuring run times than `currentTimeMillis()` anyway, because the latter refers to wall clock time.