### PR TITLE
Bump download-maven-plugin to 1.6.7

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -57,10 +57,10 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.6.3</version>
+            <version>1.6.7</version>
             <configuration>
               <!-- Detect previously failed downloads by verifying checksums of existing files -> retry -->
-              <checkSignature>true</checkSignature>
+              <alwaysVerifyChecksum>true</alwaysVerifyChecksum>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
After my PR https://github.com/maven-download-plugin/maven-download-plugin/pull/191 was merged and https://github.com/maven-download-plugin/maven-download-plugin/issues/186 was closed, use a new release containing the option misnomer fix in order to make the POM more readable.