### PR TITLE
Allowed JAR saving if proceedOnError is specified

### DIFF
--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
@@ -436,7 +436,7 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
 			zos = null;
 
 			/* Ensure we don't write an incomplete JAR bug-71339 */
-			if (handler.hasErrors()) {
+			if (!proceedOnError() && handler.hasErrors()) {
 				outJar.delete();
 				if (buildConfig.getCompilationResultDestinationManager() != null) {
 					buildConfig.getCompilationResultDestinationManager().reportFileRemove(outJar.getPath(),


### PR DESCRIPTION
Added `proceedOnError()` check in order to allow JAR generation if -proceedOnError argument is passed.