### PR TITLE
Added default values in parent pom for skip properties

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ AspectJ is a maven project, as such it should import cleanly into your IDE. The 
 Simply run the maven project importer and point it at the root of the cloned AspectJ repository. This will import all of the AspectJ
 modules.
 
-Each module comes with its own testsuites however there is a module called `run-all-junit-tests` - within there is a file `RunTheseBeforeYouCommitTests` which you can launch as a JUnit test (rightclick -> RunAs -> Junit Test).
+Each module comes with its own test suite, however there is a module called `run-all-junit-tests` - within there is a 
+file `RunTheseBeforeYouCommitTests` which you can launch as a JUnit test (rightclick -> RunAs -> Junit Test).
 This will run a few thousand tests to verify your IDE import.
 
 Some tests are conditional based on the JDK you are using in your IDE since they are exercising features only available in recent Java.
@@ -20,7 +21,12 @@ A JRE will likely not suffice because tools like javadoc will be invoked from th
 
 #### IntelliJ
 
-TODO
+Create a new project on the welcome screen with the `Get from VCS` button or within the IDE from `File | New | 
+Project from version control…` IntelliJ will recognize AspectJ as a multi-module maven project and import it as such.
+To build, create a run/debug configuration with the command line set to `clean install` and other settings as 
+appropriate. If you have multiple JDKs installed, on the `Runner` tab select the desired JDK for the build, set 
+`JAVA_HOME` to match, and uncheck `Skip Tests`. Before running the build, select the profile matching your JDK in 
+the maven pane (or put on the command line in your run/debug configuration with `-P`).
 
 
 ### Developing tests

--- a/aspectjmatcher/pom.xml
+++ b/aspectjmatcher/pom.xml
@@ -47,10 +47,9 @@
 	</scm>
 
 	<properties>
-		<!-- By default, do not deploy artifacts - but deploy this public one -->
+        <!-- Override defaults: always sign and deploy this required artifact -->
+        <maven.gpg.skip>false</maven.gpg.skip>
 		<maven.deploy.skip>false</maven.deploy.skip>
-		<!-- By default, do not sign artifacts - but sign this public one -->
-		<maven.gpg.skip>false</maven.gpg.skip>
 	</properties>
 
 	<build>
@@ -94,8 +93,6 @@
 									<Can-Redefine-Classes>true</Can-Redefine-Classes>
 									-->
 								</manifestEntries>
-
-
 								<manifestSections>
 									<manifestSection>
 										<name>org/aspectj/matcher/</name>
@@ -148,6 +145,7 @@
 						<configuration>
 							<!-- The assembly ID 'sources' becomes the artifact classifier, exactly what we want -->
 							<appendAssemblyId>true</appendAssemblyId>
+                            <!-- False for release profile (see parent POM) -->
 							<skipAssembly>${maven.source.skip}</skipAssembly>
 							<archive>
 							</archive>
@@ -171,11 +169,6 @@
 							<goal>copy</goal>
 						</goals>
 						<configuration>
-							<!--
-								Skip, if javadoc generation is also meant to be skipped, which is the default unless the 'release'
-								profile is active or the property is overridden manually to be false. See property definitions in parent
-								POM for default case and release profile.
-							-->
 							<skip>${maven.javadoc.skip}</skip>
 							<verbose>true</verbose>
 							<fileset>
@@ -270,7 +263,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore>true</ignore>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>

--- a/aspectjrt/pom.xml
+++ b/aspectjrt/pom.xml
@@ -46,10 +46,9 @@
 	</scm>
 
 	<properties>
-		<!-- By default, do not deploy artifacts - but deploy this public one -->
-		<maven.deploy.skip>false</maven.deploy.skip>
-		<!-- By default, do not sign artifacts - but sign this public one -->
-		<maven.gpg.skip>false</maven.gpg.skip>
+        <!-- Override defaults: always sign and deploy this required artifact -->
+        <maven.gpg.skip>false</maven.gpg.skip>
+        <maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
 
 	<build>
@@ -235,8 +234,8 @@
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
 			</plugin>
-
 		</plugins>
+
 		<pluginManagement>
 			<plugins>
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
@@ -263,7 +262,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore>true</ignore>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>

--- a/aspectjtools/pom.xml
+++ b/aspectjtools/pom.xml
@@ -48,10 +48,9 @@
 	</scm>
 
 	<properties>
-		<!-- By default, do not deploy artifacts - but deploy this public one -->
-		<maven.deploy.skip>false</maven.deploy.skip>
-		<!-- By default, do not sign artifacts - but sign this public one -->
-		<maven.gpg.skip>false</maven.gpg.skip>
+        <!-- Override defaults: always sign and deploy this required artifact -->
+        <maven.gpg.skip>false</maven.gpg.skip>
+        <maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
 
 	<build>
@@ -344,7 +343,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore>true</ignore>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>

--- a/aspectjweaver/pom.xml
+++ b/aspectjweaver/pom.xml
@@ -46,10 +46,9 @@
 	</scm>
 
 	<properties>
-		<!-- By default, do not deploy artifacts - but deploy this public one -->
+        <!-- Override defaults: always sign and deploy this required artifact -->
+        <maven.gpg.skip>false</maven.gpg.skip>
 		<maven.deploy.skip>false</maven.deploy.skip>
-		<!-- By default, do not sign artifacts - but sign this public one -->
-		<maven.gpg.skip>false</maven.gpg.skip>
 	</properties>
 
 	<build>
@@ -344,7 +343,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore>true</ignore>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -52,10 +52,9 @@
 			  ones from aspectjtools, because the installer contains runtime, weaver and tools and the latter one is a
 			  superset of the former two.
 		-->
-		<!-- By default, do not deploy artifacts - but deploy this public one -->
-		<!--<maven.deploy.skip>false</maven.deploy.skip>-->
-		<!-- By default, do not sign artifacts - but sign this public one -->
-		<!--<maven.gpg.skip>false</maven.gpg.skip>-->
+        <!-- Override defaults: always sign and deploy this public artifact -->
+        <!-- <maven.gpg.skip>false</maven.gpg.skip> -->
+        <!-- <maven.deploy.skip>false</maven.deploy.skip> -->
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,13 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<!-- By default, do not deploy artifacts - override for the ones which actually should be deployed -->
+		<!-- By default, do not sign or deploy artifacts. Overridden where needed. -->
+        <maven.gpg.skip>true</maven.gpg.skip>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<!-- By default, do not create javadoc - override in release profile or manually -->
+
+		<!-- By default, do not create javadoc or include source. Overridden in release profile. -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.source.skip>true</maven.source.skip>
 
 		<!-- Dependency versions -->
 		<jdt.core.version>1.9.7.M2</jdt.core.version>
@@ -144,22 +147,22 @@
 		<module>run-all-junit-tests</module>
 		<module>docs</module>
 
-		<!-- create the important artifacts we care about -->
+		<!-- These required artifacts are published in Maven Central upon release -->
 		<module>aspectjrt</module>
 		<module>aspectjweaver</module>
 		<module>aspectjtools</module>
 		<module>aspectjmatcher</module>
 
-		<!-- build the java -jar'able installer -->
+		<!-- Build the java -jar'able installer. Not currently published (see installer pom) -->
 		<module>installer</module>
 	</modules>
 
 	<!--
-    Caveat: Automatic, JDK-based profile activation can *not* be inherited by child POMs defining
-    the same profiles. Thus, we have to repeat activation conditions there.
+        Caveat: Automatic, JDK-based profile activation can *not* be inherited by child POMs defining
+        the same profiles. Thus, we have to repeat activation conditions there.
 
-    Note: We can check if automatic profile activation works via mvn help:active-profiles.
-  -->
+        Note: We can check if automatic profile activation works via mvn help:active-profiles.
+    -->
 	<profiles>
 		<profile>
 			<id>jdk-8-to-15</id>
@@ -189,6 +192,7 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
+                        <!-- FIXME Why getting 'plugin not found' error here? -->
 						<artifactId>maven-gpg-plugin</artifactId>
 					</plugin>
 				</plugins>
@@ -332,8 +336,8 @@
 								<goal>sign</goal>
 							</goals>
 							<configuration>
-								<!-- Only sign artifacts which are also meant to be deployed -->
-								<skip>${maven.gpg.skip}</skip>
+								<!-- Only sign certain artifacts, typically those also meant to be deployed -->
+                              <skip>${maven.gpg.skip}</skip>
 							</configuration>
 						</execution>
 					</executions>
@@ -492,8 +496,8 @@
 
 	<dependencies>
 		<!--
-			Actually, it would be cleaner to only define JUnit only it modules which actually use it. But since this comprises
-			the majority, we can afford to be a little bit unclean here with regard to dependency management.
+			It would be cleaner to only define JUnit in modules which actually use it. But since this comprises the
+			majority, we can afford to be a little bit unclean here with regard to dependency management.
 		-->
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.aspectj</groupId>
@@ -15,10 +16,13 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<!-- By default, do not deploy artifacts - override for the ones which actually should be deployed -->
+		<!-- By default, do not sign or deploy artifacts. Overridden where needed. -->
+		<maven.gpg.skip>true</maven.gpg.skip>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<!-- By default, do not create javadoc - override in release profile or manually -->
+
+		<!-- By default, do not create javadoc or include source. Overridden in release profile. -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
+		<maven.source.skip>true</maven.source.skip>
 
 		<!-- Dependency versions -->
 		<jdt.core.version>1.9.7.M2</jdt.core.version>
@@ -144,22 +148,22 @@
 		<module>run-all-junit-tests</module>
 		<module>docs</module>
 
-		<!-- create the important artifacts we care about -->
+		<!-- These required artifacts are published in Maven Central upon release -->
 		<module>aspectjrt</module>
 		<module>aspectjweaver</module>
 		<module>aspectjtools</module>
 		<module>aspectjmatcher</module>
 
-		<!-- build the java -jar'able installer -->
+		<!-- Build the java -jar'able installer. Not currently published (see installer pom) -->
 		<module>installer</module>
 	</modules>
 
 	<!--
-    Caveat: Automatic, JDK-based profile activation can *not* be inherited by child POMs defining
-    the same profiles. Thus, we have to repeat activation conditions there.
+        Caveat: Automatic, JDK-based profile activation can *not* be inherited by child POMs defining
+        the same profiles. Thus, we have to repeat activation conditions there.
 
-    Note: We can check if automatic profile activation works via mvn help:active-profiles.
-  -->
+        Note: We can check if automatic profile activation works via mvn help:active-profiles.
+    -->
 	<profiles>
 		<profile>
 			<id>jdk-8-to-15</id>
@@ -167,7 +171,7 @@
 				<jdk>[1.8,16)</jdk>
 			</activation>
 			<properties>
-				<jvm.arg.addOpens/>
+				<jvm.arg.addOpens />
 			</properties>
 		</profile>
 		<profile>
@@ -189,6 +193,7 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
+						<!-- FIXME Why getting 'plugin not found' error here? -->
 						<artifactId>maven-gpg-plugin</artifactId>
 					</plugin>
 				</plugins>
@@ -332,7 +337,7 @@
 								<goal>sign</goal>
 							</goals>
 							<configuration>
-								<!-- Only sign artifacts which are also meant to be deployed -->
+								<!-- Only sign certain artifacts, typically those also meant to be deployed -->
 								<skip>${maven.gpg.skip}</skip>
 							</configuration>
 						</execution>
@@ -492,8 +497,8 @@
 
 	<dependencies>
 		<!--
-			Actually, it would be cleaner to only define JUnit only it modules which actually use it. But since this comprises
-			the majority, we can afford to be a little bit unclean here with regard to dependency management.
+			It would be cleaner to only define JUnit in modules which actually use it. But since this comprises the
+			majority, we can afford to be a little bit unclean here with regard to dependency management.
 		-->
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Fixed 'cannot resolve symbol' for maven.gpg.skip and maven.source.skip. Added IntelliJ section in contributing.md. Fixed empty tag warnings in poms. Minor formatting for consistency. 

In Win10 and latest IntelliJ, found no solution for build error 'maven-gpg-plugin not found' in parent pom release profile.