### PR TITLE
Add JDK 16+ workaround for Nexus Staging Maven Plugin

### DIFF
--- a/docs/developer/RELEASE.md
+++ b/docs/developer/RELEASE.md
@@ -91,10 +91,6 @@ mvn versions:set -DnewVersion=1.9.7.M2
 # Verify if the POM changes are OK, then remove the POM backup files
 mvn versions:commit
 
-# Set some environment variables needed by Nexus Staging Maven plugin on JDK 16,
-# until https://issues.sonatype.org/browse/OSSRH-66257 is resolved
-export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-
 # Build and deploy the release to a Nexus staging repository.
 # The 'release' profile will activate:
 #   - Maven GPG plugin for signing artifacts (stand by to enter your passpharase).

--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,18 @@
 						<!-- Activate in order to directly release to Maven Central after successful staging -->
 						<autoReleaseAfterClose>false</autoReleaseAfterClose>
 					</configuration>
+					<dependencies>
+						<!--
+							Plugin version 1.6.8 does not work on JDK 16+ without special MAVEN_OPTS opening certain modules,
+							because the XStream version used needs it. One workaround is to use a more recent XStream version.
+							TODO: remove plugin dependency after OSSRH-66257, NEXUS-26993 are fixed.
+						-->
+						<dependency>
+							<groupId>com.thoughtworks.xstream</groupId>
+							<artifactId>xstream</artifactId>
+							<version>1.4.15</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Plugin version 1.6.8 does not work on JDK 16+ without special `MAVEN_OPTS` opening certain modules, because the XStream version used needs it. One workaround is to use a more recent XStream version.

Effect: one less step to follow in docs/developer/RELEASE.md when deploying to Maven Central.

**TODO:** remove plugin dependency after OSSRH-66257, NEXUS-26993 are fixed.