### PR TITLE
Make AspectJ Ant task compatible with Java 16, 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,51 +68,23 @@
 			</releases>
 		</repository>
 		<repository>
-			<id>aspectj-dev</id>
-			<name>AspectJ artifacts on aspectj.dev</name>
-			<url>https://aspectj.dev/maven</url>
-			<layout>default</layout>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-			</releases>
-		</repository>
-		<repository>
-			<id>ossrh-snapshots-classic</id>
-			<name>Sonatype OSSRH snapshots classic</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			<layout>default</layout>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-			</releases>
-		</repository>
-		<repository>
-			<id>ossrh-snapshots-new</id>
-			<name>Sonatype OSSRH snapshots new</name>
-			<url> https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-			<layout>default</layout>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-			</releases>
-		</repository>
-		<repository>
 			<id>ossrh-snapshots</id>
 			<name>Sonatype OSSRH snapshots</name>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<layout>default</layout>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+		</repository>
+		<repository>
+			<id>aspectj-dev</id>
+			<name>AspectJ artifacts on aspectj.dev</name>
+			<url>https://aspectj.dev/maven</url>
 			<layout>default</layout>
 			<snapshots>
 				<enabled>true</enabled>

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -250,9 +250,9 @@ public class AjcTask extends MatchingTask {
 
 	public static final String COMMAND_EDITOR_NAME = AjcTask.class.getName() + ".COMMAND_EDITOR";
 
-	static final String[] TARGET_INPUTS = new String[] { "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "9", "10", "11", "12", "13", "14", "15" };
-	static final String[] SOURCE_INPUTS = new String[] { "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "9", "10", "11", "12", "13", "14", "15" };
-	static final String[] COMPLIANCE_INPUTS = new String[] { "-1.3", "-1.4", "-1.5", "-1.6", "-1.7", "-1.8", "-1.9", "-9", "-10", "-11", "-12", "-13", "-14", "15" };
+	static final String[] TARGET_INPUTS = new String[] { "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "9", "10", "11", "12", "13", "14", "15", "16", "17" };
+	static final String[] SOURCE_INPUTS = new String[] { "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "9", "10", "11", "12", "13", "14", "15", "16", "17" };
+	static final String[] COMPLIANCE_INPUTS = new String[] { "-1.3", "-1.4", "-1.5", "-1.6", "-1.7", "-1.8", "-1.9", "-9", "-10", "-11", "-12", "-13", "-14", "-15", "-16", "-17" };
 
 	private static final ICommandEditor COMMAND_EDITOR;
 


### PR DESCRIPTION
### Make AspectJ Ant task compatible with Java 16, 17
Closes #97.

### Remove redundant OSSRH snapshot repositories 

Background: When only consuming dependencies or plugins from OSSRH  snapshots, there is no need to differentiate between the classic and new URLs. This is only relevant when deploying snapshots, i.e. in the 'distributionManagement' POM section.