### PR TITLE
Remove redundant File.exists() check before File.isDirectory()

### DIFF
--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassPath.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassPath.java
@@ -117,10 +117,10 @@ public class ClassPath implements Serializable {
 				File file = new File(path);
 
 				try {
-					if (file.exists()) {
-						if (file.isDirectory()) {
-							vec.add(new Dir(path));
-						} else if (file.getName().endsWith("jrt-fs.jar")) { // TODO a bit crude...
+					if (file.isDirectory()) {
+						vec.add(new Dir(path));
+					} else if (file.exists()) {
+						if (file.getName().endsWith("jrt-fs.jar")) { // TODO a bit crude...
 							vec.add(new JImage());
 						} else {
 							vec.add(new Zip(new ZipFile(file)));

--- a/build/src/test/java/org/aspectj/build/BuildModuleTests.java
+++ b/build/src/test/java/org/aspectj/build/BuildModuleTests.java
@@ -175,7 +175,7 @@ public class BuildModuleTests extends TestCase {
 
     void checkSourceDirectory(File srcDir, String module) {
         final String label = "source dir " + srcDir + " (module " + module + ")";
-        assertTrue(label,  (srcDir.exists() && srcDir.isDirectory()));
+        assertTrue(label, srcDir.isDirectory());
         String license = getLicense(module);
 //        if (replacing) {
 //            if (replacing && true) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
@@ -993,7 +993,7 @@ public class AjState implements CompilerConfigurationChangeFlags, TypeDelegateRe
 			if (f.exists() && !f.isDirectory() && (f.lastModified() >= lastSuccessfulBuildTime)) {
 				return true;
 			}
-			if (checkClassFiles && f.exists() && f.isDirectory()) {
+			if (checkClassFiles && f.isDirectory()) {
 
 				// We should use here a list/set of directories we know have or have not changed - some kind of
 				// List<File> buildConfig.getClasspathEntriesWithChangedContents()
@@ -1045,7 +1045,7 @@ public class AjState implements CompilerConfigurationChangeFlags, TypeDelegateRe
 			if (f.exists() && !f.isDirectory() && (f.lastModified() >= lastSuccessfulBuildTime)) {
 				return true;
 			}
-			if (checkClassFiles && f.exists() && f.isDirectory()) {
+			if (checkClassFiles && f.isDirectory()) {
 
 				// We should use here a list/set of directories we know have or have not changed - some kind of
 				// List<File> buildConfig.getClasspathEntriesWithChangedContents()

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
@@ -465,7 +465,7 @@ public class Ajc2 extends Javac {
         File parent = argfile.getParentFile();
 
         // Sanity check
-        if (parent == null || !parent.exists() || !parent.isDirectory()) {
+        if (parent == null || !parent.isDirectory()) {
             return;
         }
 

--- a/testing/src/test/java/org/aspectj/testing/util/FileUtil.java
+++ b/testing/src/test/java/org/aspectj/testing/util/FileUtil.java
@@ -267,7 +267,7 @@ public class FileUtil {
      *        return true;
      *     }}, true);</code></pre>
      * @param file root/starting point.  If a file, the only one visited.
-     * @param filter supplies boolean accept(File) method
+     * @param fileFilter supplies boolean accept(File) method
      * @param userRecursion - if true, do accept() on dirs; else, recurse
      * @return false if any fileFilter.accept(File) did.
      * @throws IllegalArgumentException if file or fileFilter is null
@@ -655,7 +655,6 @@ public class FileUtil {
      */
     protected static boolean deleteDirectory(File dir) {
         return ((null != dir)
-                && dir.exists()
                 && dir.isDirectory()
                 && FileUtil.descendFileTree(dir, DELETE_FILES, false)
                 && FileUtil.descendFileTree(dir, DELETE_DIRS, true)
@@ -675,7 +674,7 @@ public class FileUtil {
     protected static final FileFilter DELETE_DIRS = new FileFilter() {
             public boolean accept(File file) {
                 return ((null != file) && file.isDirectory()
-                        && file.exists() && file.delete());
+                        && file.delete());
             }
         };
     protected static final FileFilter DELETE_FILES = new FileFilter() {


### PR DESCRIPTION
According to javadoc File.isDirectory 'true' if and only if the file denoted by this abstract pathname exists and is a directory.
It means that separate File.exists() check before File.isDirectory() check is redundant.