### PR TITLE
Replace uses of StringBuffer with StringBuilder.

### DIFF
--- a/ajbrowser/src/main/java/org/aspectj/tools/ajbrowser/core/BrowserCompilerConfiguration.java
+++ b/ajbrowser/src/main/java/org/aspectj/tools/ajbrowser/core/BrowserCompilerConfiguration.java
@@ -36,7 +36,7 @@ public class BrowserCompilerConfiguration implements ICompilerConfiguration {
 	}
 
 	public String getClasspath() {
-		StringBuffer classpath = new StringBuffer();
+		StringBuilder classpath = new StringBuilder();
 		String userPath = preferencesAdapter.getProjectPreference(PreferenceStoreConstants.BUILD_CLASSPATH);
 		if (userPath != null && userPath.trim().length() != 0) {
 			classpath.append(userPath);

--- a/ajbrowser/src/main/java/org/aspectj/tools/ajbrowser/ui/BasicEditor.java
+++ b/ajbrowser/src/main/java/org/aspectj/tools/ajbrowser/ui/BasicEditor.java
@@ -156,7 +156,7 @@ public class BasicEditor implements EditorAdapter {
                 return "ERROR: file \"" + filePath + "\" does not exist.";
             }
             BufferedReader reader = new BufferedReader(new FileReader(file));
-            StringBuffer contents = new StringBuffer();
+            StringBuilder contents = new StringBuilder();
             String line = reader.readLine();
             int numLines = 0;
             while (line != null) {

--- a/ajde.core/src/main/java/org/aspectj/ajde/core/internal/AjdeCoreBuildManager.java
+++ b/ajde.core/src/main/java/org/aspectj/ajde/core/internal/AjdeCoreBuildManager.java
@@ -175,7 +175,7 @@ public class AjdeCoreBuildManager {
 			return "none";
 		}
 
-		StringBuffer formattedOptions = new StringBuffer();
+		StringBuilder formattedOptions = new StringBuilder();
 		for (Object option : options) {
 			String o = option.toString();
 			if (formattedOptions.length() > 0) {

--- a/ajde.core/src/test/java/org/aspectj/ajde/core/tests/AjConfigTest.java
+++ b/ajde.core/src/test/java/org/aspectj/ajde/core/tests/AjConfigTest.java
@@ -145,7 +145,7 @@ public class AjConfigTest extends AjdeCoreTestCase {
 	public void testClasspath() {
 		String classpath = compilerConfig.getClasspath();
 		List<String> found = genAjBuildConfig().getClasspath();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (Iterator<String> iterator = found.iterator(); iterator.hasNext();) {
 			String name = iterator.next();
 			sb.append(name);

--- a/ajde.core/src/test/java/org/aspectj/ajde/core/tests/ShowWeaveMessagesTest.java
+++ b/ajde.core/src/test/java/org/aspectj/ajde/core/tests/ShowWeaveMessagesTest.java
@@ -394,7 +394,7 @@ public class ShowWeaveMessagesTest extends AjdeCoreTestCase {
 	}
 
 	private String stringify(List<String> l) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		for (String str: l) {
 			result.append(str);
 			result.append("\n");

--- a/ajde/src/main/java/org/aspectj/ajde/Ajde.java
+++ b/ajde/src/main/java/org/aspectj/ajde/Ajde.java
@@ -258,7 +258,7 @@ public class Ajde {
 			if (LangUtil.isEmpty(mainClass)) {
 				showWarningMessage("No main class specified");
 			} else {
-				StringBuffer sb = new StringBuffer();
+				StringBuilder sb = new StringBuilder();
 				List outputDirs = compilerConfig.getOutputLocationManager().getAllOutputLocations();
 				for (Object outputDir : outputDirs) {
 					File dir = (File) outputDir;

--- a/ajde/src/main/java/org/aspectj/ajde/internal/LstBuildConfigFileUpdater.java
+++ b/ajde/src/main/java/org/aspectj/ajde/internal/LstBuildConfigFileUpdater.java
@@ -185,7 +185,7 @@ class LstBuildConfigFileUpdater {
 	 */
 	public void writeConfigFile(String filePath, List<String> fileContents) {
 		Set<String> contentsSet = new TreeSet<>(fileContents);
-		StringBuffer fileContentsSB = new StringBuffer();
+		StringBuilder fileContentsSB = new StringBuilder();
 		for (String s : contentsSet) {
 			fileContentsSB.append(s.toString());
 			fileContentsSB.append("\n");

--- a/ajdoc/src/main/java/org/aspectj/tools/ajdoc/HtmlDecorator.java
+++ b/ajdoc/src/main/java/org/aspectj/tools/ajdoc/HtmlDecorator.java
@@ -283,7 +283,7 @@ class HtmlDecorator {
 					String name = decl.toSignatureString();
 					int classEndIndex = contents.indexOf(name + "</B><DT>");
 					if (classEndIndex != -1) {
-						StringBuffer sb = new StringBuffer(contents.substring(secondClassStartIndex, classEndIndex));
+						StringBuilder sb = new StringBuilder(contents.substring(secondClassStartIndex, classEndIndex));
 						sb.replace(0, 5, "aspect");
 						fileContents.delete(secondClassStartIndex, classEndIndex);
 						fileContents.insert(secondClassStartIndex, sb.toString());
@@ -618,7 +618,7 @@ class HtmlDecorator {
 					parent = parent.getParent();
 					names.add(parent.toLinkLabelString());
 				}
-				StringBuffer sbuff = new StringBuffer();
+				StringBuilder sbuff = new StringBuilder();
 				for (int i = names.size() - 1; i >= 0; i--) {
 					String element = (String) names.get(i);
 					if (i == 0) {
@@ -634,7 +634,7 @@ class HtmlDecorator {
 
 				// need to replace " with quot; otherwise the links wont work
 				// for 'matches declare' relationship
-				StringBuffer sb = new StringBuffer(currDecl.toLabelString());
+				StringBuilder sb = new StringBuilder(currDecl.toLabelString());
 				int nextQuote = sb.toString().indexOf("\"");
 				while (nextQuote != -1) {
 					sb.deleteCharAt(nextQuote);
@@ -778,7 +778,7 @@ class HtmlDecorator {
 	 * @return String consisting of multiple "../" parts, one for each component part of the input <code>packagePath</code>.
 	 */
 	private static String getRelativePathFromHere(String packagePath) {
-		StringBuffer result = new StringBuffer("");
+		StringBuilder result = new StringBuilder("");
 		if (packagePath != null && (packagePath.contains("/"))) {
 			StringTokenizer sTok = new StringTokenizer(packagePath, "/", false);
 			while (sTok.hasMoreTokens()) {
@@ -839,7 +839,7 @@ class HtmlDecorator {
 	}
 
 	static String generateHREFName(IProgramElement decl) {
-		StringBuffer hrefLinkBuffer = new StringBuffer();
+		StringBuilder hrefLinkBuffer = new StringBuilder();
 		char[] declChars = decl.toLabelString().toCharArray();
 		for (char declChar : declChars) {
 			if (declChar == '"') {

--- a/ajdoc/src/main/java/org/aspectj/tools/ajdoc/Main.java
+++ b/ajdoc/src/main/java/org/aspectj/tools/ajdoc/Main.java
@@ -334,7 +334,7 @@ public class Main implements Config {
 			if (indexFile.exists()) {
 				BufferedReader indexFileReader = new BufferedReader(new FileReader(indexFile));
 				// StringBuffer greatly reduces the time it takes to remove generated tags
-				StringBuffer indexFileBuffer = new StringBuffer((int) indexFile.length());
+				StringBuilder indexFileBuffer = new StringBuilder((int) indexFile.length());
 				String line = indexFileReader.readLine();
 				while (line != null) {
 					int indexStart = line.indexOf(Config.DECL_ID_STRING);

--- a/ajdoc/src/main/java/org/aspectj/tools/ajdoc/StructureUtil.java
+++ b/ajdoc/src/main/java/org/aspectj/tools/ajdoc/StructureUtil.java
@@ -112,7 +112,7 @@ public class StructureUtil {
 	}
 
 	public static String genSignature(IProgramElement node) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 
 		String accessibility = node.getAccessibility().toString();
 		if (!accessibility.equals("package")) {

--- a/asm/src/main/java/org/aspectj/asm/AsmManager.java
+++ b/asm/src/main/java/org/aspectj/asm/AsmManager.java
@@ -511,7 +511,7 @@ public class AsmManager implements IStructureModel {
 			for (IRelationship ir : rels) {
 				List<String> targets = ir.getTargets();
 				for (String thid : targets) {
-					StringBuffer sb = new StringBuffer();
+					StringBuilder sb = new StringBuilder();
 					if (modelFilter == null || modelFilter.wantsHandleIds()) {
 						sb.append("Hid:" + (ctr++) + ":");
 					}
@@ -637,7 +637,7 @@ public class AsmManager implements IStructureModel {
 				// unexpected - time to give up
 				return "";
 			}
-			StringBuffer qualifiedTypeNameFromHandle = new StringBuffer();
+			StringBuilder qualifiedTypeNameFromHandle = new StringBuilder();
 			if (hasPackage != -1) {
 				int classfileLoc = handle.indexOf(HandleProviderDelimiter.CLASSFILE.getDelimiter(), hasPackage);
 				qualifiedTypeNameFromHandle.append(handle.substring(hasPackage + 1, classfileLoc));
@@ -1196,7 +1196,7 @@ public class AsmManager implements IStructureModel {
 		}
 
 		public String toString() {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append("Model node summary:\n");
 			Enumeration<String> nodeKeys = nodeTypeCount.keys();
 			while (nodeKeys.hasMoreElements()) {

--- a/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
@@ -60,12 +60,12 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 			if (end != -1) {
 				configFile = configFile.substring(start + 1, end);
 			} else {
-				configFile = new StringBuffer("=").append(configFile.substring(start + 1)).toString();
+				configFile = new StringBuilder("=").append(configFile.substring(start + 1)).toString();
 			}
 			ipe.setHandleIdentifier(configFile);
 			return configFile;
 		} else if (ipe.getKind() == IProgramElement.Kind.SOURCE_FOLDER) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(createHandleIdentifier(ipe.getParent())).append("/");
 			// pr249216 - escape any embedded slashes
 			String folder = ipe.getName();
@@ -86,7 +86,7 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 			parent = ipe.getParent().getParent();
 		}
 
-		StringBuffer handle = new StringBuffer();
+		StringBuilder handle = new StringBuilder();
 		// add the handle for the parent
 		handle.append(createHandleIdentifier(parent));
 		// add the correct delimiter for this ipe
@@ -133,7 +133,7 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 		}
 		List<String> sourceRefs = ipe.getParameterSignaturesSourceRefs();
 		List<char[]> parameterTypes = ipe.getParameterSignatures();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (sourceRefs != null) {
 			for (String sourceRef : sourceRefs) {
 				sb.append(HandleProviderDelimiter.getDelimiter(ipe));

--- a/asm/src/main/java/org/aspectj/asm/internal/ProgramElement.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/ProgramElement.java
@@ -436,7 +436,7 @@ public class ProgramElement implements IProgramElement {
 				// not parameterized
 				return new StringBuilder("L").append(name.replace('.', '/')).append(';').toString();
 			} else {
-				StringBuffer nameBuff = new StringBuffer();
+				StringBuilder nameBuff = new StringBuilder();
 				int nestLevel = 0;
 				nameBuff.append("L");
 				for (int i = 0; i < name.length(); i++) {
@@ -448,7 +448,7 @@ public class ProgramElement implements IProgramElement {
 					case '<':
 						nameBuff.append("<");
 						nestLevel++;
-						StringBuffer innerBuff = new StringBuffer();
+						StringBuilder innerBuff = new StringBuilder();
 						while (nestLevel > 0) {
 							c = name.charAt(++i);
 							if (c == '<') {
@@ -459,7 +459,7 @@ public class ProgramElement implements IProgramElement {
 							}
 							if (c == ',' && nestLevel == 1) {
 								nameBuff.append(nameToSignature(innerBuff.toString()));
-								innerBuff = new StringBuffer();
+								innerBuff = new StringBuilder();
 							} else {
 								if (nestLevel > 0) {
 									innerBuff.append(c);
@@ -623,7 +623,7 @@ public class ProgramElement implements IProgramElement {
 	}
 
 	public String toSignatureString(boolean getFullyQualifiedArgTypes) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(name);
 
 		List<char[]> ptypes = getParameterTypes();

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/BootstrapMethods.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/BootstrapMethods.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * Represents the BootstrapMethods attribute in Java 7 classes.
- * 
+ *
  * @author Andy Clement
  */
 public final class BootstrapMethods extends Attribute {
@@ -98,7 +98,7 @@ public final class BootstrapMethods extends Attribute {
 		file.readFully(data);
 		isInPackedState = true;
 	}
-	
+
 	public static class BootstrapMethod {
 		private int bootstrapMethodRef;
 		private int[] bootstrapArguments;
@@ -106,7 +106,7 @@ public final class BootstrapMethods extends Attribute {
 		BootstrapMethod(DataInputStream file) throws IOException {
 			this(file.readUnsignedShort(), readBootstrapArguments(file));
 		}
-		
+
 		private static int[] readBootstrapArguments(DataInputStream dis) throws IOException {
 			int numBootstrapMethods = dis.readUnsignedShort();
 			int[] bootstrapArguments = new int[numBootstrapMethods];
@@ -115,16 +115,16 @@ public final class BootstrapMethods extends Attribute {
 			}
 			return bootstrapArguments;
 		}
-		
+
 		public BootstrapMethod(int bootstrapMethodRef, int[] bootstrapArguments) {
 			this.bootstrapMethodRef = bootstrapMethodRef;
 			this.bootstrapArguments = bootstrapArguments;
 		}
-		
+
 		public int getBootstrapMethodRef() {
 			return bootstrapMethodRef;
 		}
-		
+
 		public int[] getBootstrapArguments() {
 			return bootstrapArguments;
 		}
@@ -137,15 +137,15 @@ public final class BootstrapMethods extends Attribute {
 				file.writeShort(bootstrapArgument);
 			}
 		}
-		
+
 		public final int getLength() {
 			return 2 /*bootstrapMethodRef*/+
 					2 /*number of arguments*/+
 					2 * bootstrapArguments.length;
 		}
-		
+
 	}
-	
+
 	// Unpacks the byte array into the table
 	private void unpack() {
 		if (isInPackedState) {
@@ -169,7 +169,7 @@ public final class BootstrapMethods extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -180,7 +180,7 @@ public final class BootstrapMethods extends Attribute {
 
 	/**
 	 * Dump line number table attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -210,8 +210,8 @@ public final class BootstrapMethods extends Attribute {
 	@Override
 	public final String toString() {
 		unpack();
-		StringBuffer buf = new StringBuffer();
-		StringBuffer line = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
+		StringBuilder line = new StringBuilder();
 
 		for (int i = 0; i < numBootstrapMethods; i++) {
 			BootstrapMethod bm = bootstrapMethods[i];
@@ -228,8 +228,8 @@ public final class BootstrapMethods extends Attribute {
 					line.append(arg).append("(").append(getConstantPool().getConstant(arg)).append(") ");
 				}
 			}
-			
-			
+
+
 			if (i < numBootstrapMethods - 1) {
 				line.append(", ");
 			}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Code.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Code.java
@@ -64,10 +64,10 @@ import org.aspectj.apache.bcel.Constants;
  * This class represents a chunk of Java byte code contained in a method. It is instantiated by the
  * <em>Attribute.readAttribute()</em> method. A <em>Code</em> attribute contains informations about operand stack, local variables,
  * byte code and the exceptions handled within this method.
- * 
+ *
  * This attribute has attributes itself, namely <em>LineNumberTable</em> which is used for debugging purposes and
  * <em>LocalVariableTable</em> which contains information about the local variables.
- * 
+ *
  * @version $Id: Code.java,v 1.9 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -149,7 +149,7 @@ public final class Code extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -159,7 +159,7 @@ public final class Code extends Attribute {
 
 	/**
 	 * Dump code attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -309,9 +309,9 @@ public final class Code extends Attribute {
 	 * @return String representation of code chunk.
 	 */
 	public final String toString(boolean verbose) {
-		StringBuffer buf;
+		StringBuilder buf;
 
-		buf = new StringBuffer("Code(max_stack = " + maxStack + ", max_locals = " + maxLocals + ", code_length = " + code.length
+		buf = new StringBuilder("Code(max_stack = " + maxStack + ", max_locals = " + maxLocals + ", code_length = " + code.length
 				+ ")\n" + Utility.codeToString(code, cpool, 0, -1, verbose));
 
 		if (exceptionTable.length > 0) {
@@ -348,7 +348,7 @@ public final class Code extends Attribute {
 	// Code c = (Code)clone();
 	// c.code = (byte[])code.clone();
 	// c.cpool = constant_pool;
-	//  
+	//
 	// c.exceptionTable = new CodeException[exceptionTable.length];
 	// for(int i=0; i < exceptionTable.length; i++)
 	// c.exceptionTable[i] = exceptionTable[i].copy();
@@ -365,7 +365,7 @@ public final class Code extends Attribute {
 	 * whether two pieces of code are equivalent.
 	 */
 	public String getCodeString() {
-		StringBuffer codeString = new StringBuffer();
+		StringBuilder codeString = new StringBuilder();
 		codeString.append("Code(max_stack = ").append(maxStack);
 		codeString.append(", max_locals = ").append(maxLocals);
 		codeString.append(", code_length = ").append(code.length).append(")\n");

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantPool.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantPool.java
@@ -136,7 +136,7 @@ public class ConstantPool implements Node {
 	/**
 	 * Get string from constant pool and bypass the indirection of `ConstantClass' and `ConstantString' objects. I.e. these classes
 	 * have an index field that points to another entry of the constant pool of type `ConstantUtf8' which contains the real data.
-	 * 
+	 *
 	 * @param index Index in constant pool
 	 * @param tag Tag of expected constant, either ConstantClass or ConstantString
 	 * @return Contents of string reference
@@ -207,7 +207,7 @@ public class ConstantPool implements Node {
 			str = (constantToString(((ConstantCP) c).getClassIndex(), Constants.CONSTANT_Class) + "." + constantToString(
 					((ConstantCP) c).getNameAndTypeIndex(), Constants.CONSTANT_NameAndType));
 			break;
-			
+
 		case Constants.CONSTANT_InvokeDynamic:
 			ConstantInvokeDynamic cID = ((ConstantInvokeDynamic)c);
 			return "#"+cID.getBootstrapMethodAttrIndex()+"."+constantToString(cID.getNameAndTypeIndex(), Constants.CONSTANT_NameAndType);
@@ -237,7 +237,7 @@ public class ConstantPool implements Node {
 
 	private static final String escape(String str) {
 		int len = str.length();
-		StringBuffer buf = new StringBuffer(len + 5);
+		StringBuilder buf = new StringBuilder(len + 5);
 		char[] ch = str.toCharArray();
 
 		for (int i = 0; i < len; i++) {
@@ -296,7 +296,7 @@ public class ConstantPool implements Node {
 		assert c.tag == Constants.CONSTANT_Utf8;
 		return (ConstantUtf8) c;
 	}
-	
+
 	public ConstantModule getConstantModule(int index) {
 		Constant c = getConstant(index);
 		assert c != null;
@@ -323,7 +323,7 @@ public class ConstantPool implements Node {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		for (int i = 1; i < poolSize; i++)
 			buf.append(i + ")" + pool[i] + "\n");
@@ -441,7 +441,7 @@ public class ConstantPool implements Node {
 
 	public int lookupFieldref(String searchClassname, String searchFieldname, String searchSignature) {
 		searchClassname = searchClassname.replace('.', '/');
-		String k = new StringBuffer().append(searchClassname).append(searchFieldname).append(searchSignature).toString();
+		String k = new StringBuilder().append(searchClassname).append(searchFieldname).append(searchSignature).toString();
 		Integer pos = fieldCache.get(k);
 		if (pos != null)
 			return pos;
@@ -621,7 +621,7 @@ public class ConstantPool implements Node {
 
 			return addNameAndType(u8.getValue(), u8_2.getValue());
 		}
-		
+
 		case Constants.CONSTANT_InvokeDynamic: {
 			ConstantInvokeDynamic cid = (ConstantInvokeDynamic)c;
 			int index1 = cid.getBootstrapMethodAttrIndex();
@@ -631,7 +631,7 @@ public class ConstantPool implements Node {
 			int index2 = addNameAndType(name.getValue(), signature.getValue());
 			return addInvokeDynamic(index1,index2);
 		}
-		
+
 		case Constants.CONSTANT_MethodHandle:
 			ConstantMethodHandle cmh = (ConstantMethodHandle)c;
 			return addMethodHandle(cmh.getReferenceKind(),addConstant(constants[cmh.getReferenceIndex()],cp));
@@ -650,7 +650,7 @@ public class ConstantPool implements Node {
 
 		case Constants.CONSTANT_Integer:
 			return addInteger(((ConstantInteger) c).getValue());
-			
+
 		case Constants.CONSTANT_MethodType:
 			ConstantMethodType cmt = (ConstantMethodType)c;
 			return addMethodType(addConstant(constants[cmt.getDescriptorIndex()],cp));
@@ -689,14 +689,14 @@ public class ConstantPool implements Node {
 			throw new RuntimeException("Unknown constant type " + c);
 		}
 	}
-	
+
 	public int addMethodHandle(byte referenceKind, int referenceIndex) {
 		adjustSize();
 		int ret = poolSize;
 		pool[poolSize++] = new ConstantMethodHandle(referenceKind, referenceIndex);
 		return ret;
 	}
-	
+
 	public int addMethodType(int descriptorIndex) {
 		adjustSize();
 		int ret = poolSize;
@@ -718,7 +718,7 @@ public class ConstantPool implements Node {
 		pool[poolSize++] = new ConstantMethodref(class_index, name_and_type_index);
 		return ret;
 	}
-	
+
 	public int addInvokeDynamic(int bootstrapMethodIndex, int constantNameAndTypeIndex) {
 		adjustSize();
 		int ret = poolSize;
@@ -768,7 +768,7 @@ public class ConstantPool implements Node {
 	}
 
 	public int lookupMethodref(String searchClassname, String searchMethodName, String searchSignature) {
-		String key = new StringBuffer().append(searchClassname).append(searchMethodName).append(searchSignature).toString();
+		String key = new StringBuilder().append(searchClassname).append(searchMethodName).append(searchSignature).toString();
 		Integer cached = methodCache.get(key);
 		if (cached != null)
 			return cached;

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ExceptionTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ExceptionTable.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.Constants;
  * This class represents the table of exceptions that are thrown by a method. This attribute may be used once per method. The name
  * of this class is <em>ExceptionTable</em> for historical reasons; The Java Virtual Machine Specification, Second Edition defines
  * this attribute using the name <em>Exceptions</em> (which is inconsistent with the other classes).
- * 
+ *
  * @version $Id: ExceptionTable.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Code
@@ -94,7 +94,7 @@ public final class ExceptionTable extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -114,7 +114,7 @@ public final class ExceptionTable extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -124,7 +124,7 @@ public final class ExceptionTable extends Attribute {
 
 	/**
 	 * Dump exceptions attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -173,7 +173,7 @@ public final class ExceptionTable extends Attribute {
 	 */
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer("");
+		StringBuilder buf = new StringBuilder("");
 		String str;
 
 		for (int i = 0; i < number_of_exceptions; i++) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Field.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Field.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.generic.Type;
 /**
  * This class represents the field info structure, i.e., the representation for a variable in the class. See JVM specification for
  * details.
- * 
+ *
  * @version $Id: Field.java,v 1.6 2009/09/15 03:33:52 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -103,7 +103,7 @@ public final class Field extends FieldOrMethod {
 	@Override
 	public final String toString() {
 		// Get names from constant pool
-		StringBuffer buf = new StringBuffer(Utility.accessToString(modifiers));
+		StringBuilder buf = new StringBuilder(Utility.accessToString(modifiers));
 		if (buf.length() > 0) {
 			buf.append(" ");
 		}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/InnerClasses.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/InnerClasses.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from <em>Attribute</em> and denotes that this class is an Inner class of another. to the source file of
  * this class. It is instantiated from the <em>Attribute.readAttribute()</em> method.
- * 
+ *
  * @version $Id: InnerClasses.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -94,7 +94,7 @@ public final class InnerClasses extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -114,7 +114,7 @@ public final class InnerClasses extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -124,7 +124,7 @@ public final class InnerClasses extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -157,7 +157,7 @@ public final class InnerClasses extends Attribute {
 	 */
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		for (int i = 0; i < number_of_classes; i++)
 			buf.append(inner_classes[i].toString(cpool) + "\n");

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
@@ -77,10 +77,10 @@ import org.aspectj.apache.bcel.util.SyntheticRepository;
 /**
  * Represents a Java class, i.e., the data structures, constant pool, fields, methods and commands contained in a Java .class file.
  * See <a href="ftp://java.sun.com/docs/specs/">JVM specification</a> for details.
- * 
+ *
  * The intent of this class is to represent a parsed or otherwise existing class file. Those interested in programatically
  * generating classes should see the <a href="../generic/ClassGen.html">ClassGen</a> class.
- * 
+ *
  * @version $Id: JavaClass.java,v 1.22 2009/09/15 19:40:14 aclement Exp $
  * @see org.aspectj.apache.bcel.generic.ClassGen
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
@@ -185,7 +185,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	public void accept(ClassVisitor v) {
@@ -194,7 +194,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	/**
 	 * Dump class to a file.
-	 * 
+	 *
 	 * @param file Output file
 	 * @throws IOException
 	 */
@@ -209,7 +209,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	/**
 	 * Dump class to a file named file_name.
-	 * 
+	 *
 	 * @param file_name Output file name
 	 * @exception IOException
 	 */
@@ -523,7 +523,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 		String access = Utility.accessToString(modifiers, true);
 		access = access.equals("") ? "" : access + " ";
 
-		StringBuffer buf = new StringBuffer(access + Utility.classOrInterface(modifiers) + " " + classname + " extends "
+		StringBuilder buf = new StringBuilder(access + Utility.classOrInterface(modifiers) + " " + classname + " extends "
 				+ Utility.compactClassName(superclassname, false) + '\n');
 		int size = interfaces.length;
 
@@ -580,7 +580,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	private static final String indent(Object obj) {
 		StringTokenizer tok = new StringTokenizer(obj.toString(), "\n");
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		while (tok.hasMoreTokens()) {
 			buf.append("\t" + tok.nextToken() + "\n");
@@ -671,7 +671,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	/**
 	 * Equivalent to runtime "instanceof" operator.
-	 * 
+	 *
 	 * @return true if this JavaClass is derived from teh super class
 	 */
 	public final boolean instanceOf(JavaClass super_class) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LineNumberTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LineNumberTable.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class represents a table of line numbers for debugging purposes. This attribute is used by the <em>Code</em> attribute. It
  * contains pairs of PCs and line numbers.
- * 
+ *
  * @version $Id: LineNumberTable.java,v 1.8 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Code changes: asc Feb06 Made unpacking lazy
@@ -94,7 +94,7 @@ public final class LineNumberTable extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index of name
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -132,7 +132,7 @@ public final class LineNumberTable extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -143,7 +143,7 @@ public final class LineNumberTable extends Attribute {
 
 	/**
 	 * Dump line number table attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -184,8 +184,8 @@ public final class LineNumberTable extends Attribute {
 	@Override
 	public final String toString() {
 		unpack();
-		StringBuffer buf = new StringBuffer();
-		StringBuffer line = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
+		StringBuilder line = new StringBuilder();
 
 		for (int i = 0; i < tableLength; i++) {
 			line.append(table[i].toString());
@@ -208,7 +208,7 @@ public final class LineNumberTable extends Attribute {
 
 	/**
 	 * Map byte code positions to source code lines.
-	 * 
+	 *
 	 * @param pos byte code offset
 	 * @return corresponding line in source code
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTable.java
@@ -177,7 +177,7 @@ public class LocalVariableTable extends Attribute {
 	 */
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer("");
+		StringBuilder buf = new StringBuilder("");
 		unpack();
 		for (int i = 0; i < localVariableTableLength; i++) {
 			buf.append(localVariableTable[i].toString());

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTypeTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariableTypeTable.java
@@ -104,7 +104,7 @@ public class LocalVariableTypeTable extends Attribute {
 	 */
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer("");
+		StringBuilder buf = new StringBuilder("");
 
 		for (int i = 0; i < local_variable_type_table_length; i++) {
 			buf.append(local_variable_type_table[i].toString());

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Method.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Method.java
@@ -67,7 +67,7 @@ import org.aspectj.apache.bcel.generic.Type;
 /**
  * This class represents the method info structure, i.e., the representation for a method in the class. See JVM specification for
  * details. A method has access flags, a name, a signature and a number of attributes.
- * 
+ *
  * @version $Id: Method.java,v 1.11 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -151,7 +151,7 @@ public final class Method extends FieldOrMethod {
 	public final String toString() {
 		ConstantUtf8 c;
 		String name, signature, access; // Short cuts to constant pool
-		StringBuffer buf;
+		StringBuilder buf;
 
 		access = Utility.accessToString(modifiers);
 
@@ -163,7 +163,7 @@ public final class Method extends FieldOrMethod {
 		name = c.getValue();
 
 		signature = Utility.methodSignatureToString(signature, name, access, true, getLocalVariableTable());
-		buf = new StringBuffer(signature);
+		buf = new StringBuilder(signature);
 
         for (Attribute a : attributes) {
             if (!((a instanceof Code) || (a instanceof ExceptionTable)))

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ModulePackages.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ModulePackages.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * Indicates all the packages of a module that are exported or opened by the module attribute.
  * http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jvms-diffs.pdf 4.7.26
- * 
+ *
  * @author Andy Clement
  */
 public final class ModulePackages extends Attribute {
@@ -116,7 +116,7 @@ public final class ModulePackages extends Attribute {
 
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		for (int packageIndex : packageIndices) {
 			buf.append(cpool.getPackageName(packageIndex) + "\n");
 		}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestHost.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestHost.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.28
- * 
+ *
  * @see Attribute
  */
 public final class NestHost extends Attribute {
@@ -100,7 +100,7 @@ public final class NestHost extends Attribute {
 	public final void setHostClassIndex(int hostClassIndex) {
 		this.hostClassIndex = hostClassIndex;
 	}
-	
+
 	public final String getHostClassName() {
 		ConstantClass constantClass = (ConstantClass)cpool.getConstant(hostClassIndex,Constants.CONSTANT_Class);
 		return constantClass.getClassname(cpool);
@@ -108,7 +108,7 @@ public final class NestHost extends Attribute {
 
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("NestHost(");
 		ConstantClass constantClass = (ConstantClass)cpool.getConstant(hostClassIndex,Constants.CONSTANT_Class);
 		buf.append(constantClass.getClassname(cpool));

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestMembers.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestMembers.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.29
- * 
+ *
  * @see Attribute
  */
 public final class NestMembers extends Attribute {
@@ -109,7 +109,7 @@ public final class NestMembers extends Attribute {
 		this.classes = inner_classes;
 		numberOfClasses = (inner_classes == null) ? 0 : inner_classes.length;
 	}
-	
+
 	public final String[] getClassesNames() {
 		String[] result = new String[numberOfClasses];
 		for (int i = 0; i < numberOfClasses; i++) {
@@ -121,7 +121,7 @@ public final class NestMembers extends Attribute {
 
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		for (int i = 0; i < numberOfClasses; i++) {
 			ConstantClass constantClass = (ConstantClass)cpool.getConstant(classes[i],Constants.CONSTANT_Class);
 			buf.append(constantClass.getClassname(cpool)).append(" ");

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Signature.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Signature.java
@@ -52,7 +52,7 @@ package org.aspectj.apache.bcel.classfile;
  * individuals on behalf of the Apache Software Foundation.  For more
  * information on the Apache Software Foundation, please see
  * <http://www.apache.org/>.
- * 
+ *
  * Extended by Adrian Colyer, June 2005 to support unpacking of Signature
  * attribute
  */
@@ -67,7 +67,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from <em>Attribute</em> and represents a reference to a <href="http://wwwipd.ira.uka.de/~pizza/gj/">GJ</a>
  * attribute.
- * 
+ *
  * @version $Id: Signature.java,v 1.11 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -85,7 +85,7 @@ public final class Signature extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -110,7 +110,7 @@ public final class Signature extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -121,7 +121,7 @@ public final class Signature extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -192,7 +192,7 @@ public final class Signature extends Attribute {
 		// System.out.println("return from ident:" + (char)ch);
 
 		if (!identStart(ch)) {
-			StringBuffer buf2 = new StringBuffer();
+			StringBuilder buf2 = new StringBuilder();
 
 			int count = 1;
 			while (Character.isJavaIdentifierPart((char) ch)) {
@@ -216,7 +216,7 @@ public final class Signature extends Attribute {
 			return;
 		}
 
-		StringBuffer buf2 = new StringBuffer();
+		StringBuilder buf2 = new StringBuilder();
 		ch = in.read();
 
 		do {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMap.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMap.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.Constants;
  * This class represents a stack map attribute used for preverification of Java classes for the <a href="http://java.sun.com/j2me/">
  * Java 2 Micro Edition</a> (J2ME). This attribute is used by the <a href="http://java.sun.com/products/cldc/">KVM</a> and contained
  * within the Code attribute of a method. See CLDC specification 5.3.1.2
- * 
+ *
  * @version $Id: StackMap.java,v 1.6 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Code
@@ -77,11 +77,11 @@ public final class StackMap extends Attribute {
 
 	/*
 	 * @param name_index Index of name
-	 * 
+	 *
 	 * @param length Content length in bytes
-	 * 
+	 *
 	 * @param map Table of stack map entries
-	 * 
+	 *
 	 * @param constant_pool Array of constants
 	 */
 	public StackMap(int name_index, int length, StackMapEntry[] map, ConstantPool constant_pool) {
@@ -92,7 +92,7 @@ public final class StackMap extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index of name
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -111,7 +111,7 @@ public final class StackMap extends Attribute {
 
 	/**
 	 * Dump line number table attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -144,7 +144,7 @@ public final class StackMap extends Attribute {
 	 */
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer("StackMap(");
+		StringBuilder buf = new StringBuilder("StackMap(");
 
 		for (int i = 0; i < map_length; i++) {
 			buf.append(map[i].toString());
@@ -176,7 +176,7 @@ public final class StackMap extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMapEntry.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMapEntry.java
@@ -113,7 +113,7 @@ public final class StackMapEntry implements Cloneable {
    *
    * @param file Output file stream
    * @throws IOException
-   */ 
+   */
   public final void dump(DataOutputStream file) throws IOException
   {
     file.writeShort(byte_code_offset);
@@ -129,9 +129,9 @@ public final class StackMapEntry implements Cloneable {
 
   /**
    * @return String representation.
-   */ 
+   */
   public final String toString() {
-    StringBuffer buf = new StringBuffer("(offset=" + byte_code_offset);
+    StringBuilder buf = new StringBuilder("(offset=" + byte_code_offset);
 
     if(number_of_locals > 0) {
       buf.append(", locals={");
@@ -159,7 +159,7 @@ public final class StackMapEntry implements Cloneable {
 
     buf.append(")");
 
-    return buf.toString();    
+    return buf.toString();
   }
 
 
@@ -198,12 +198,12 @@ public final class StackMapEntry implements Cloneable {
 
   /**
    * @return Constant pool used by this object.
-   */   
+   */
   public final ConstantPool getConstantPool() { return constant_pool; }
 
   /**
    * @param constant_pool Constant pool to be used for this object.
-   */   
+   */
   public final void setConstantPool(ConstantPool constant_pool) {
     this.constant_pool = constant_pool;
   }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Synthetic.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Synthetic.java
@@ -65,7 +65,7 @@ import org.aspectj.apache.bcel.Constants;
  * specification states "A class member that does not appear in the source code must be marked using a Synthetic attribute." It may
  * appear in the ClassFile attribute table, a field_info table or a method_info table. This class is intended to be instantiated
  * from the <em>Attribute.readAttribute()</em> method.
- * 
+ *
  * @version $Id: Synthetic.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -81,7 +81,7 @@ public final class Synthetic extends Attribute {
 		this(c.getNameIndex(), c.getLength(), c.getBytes(), c.getConstantPool());
 	}
 
-	//  
+	//
 	// public Synthetic(ConstantPoolGen cpool) {
 	// super(Constants.ATTR_SYNTHETIC, cpool.addUtf8("Synthetic"), 0, cpool);
 	// ConstantPoolGen cpg = myGen.getConstantPool();
@@ -102,7 +102,7 @@ public final class Synthetic extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -122,7 +122,7 @@ public final class Synthetic extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -132,7 +132,7 @@ public final class Synthetic extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -162,7 +162,7 @@ public final class Synthetic extends Attribute {
 	 */
 	@Override
 	public final String toString() {
-		StringBuffer buf = new StringBuffer("Synthetic");
+		StringBuilder buf = new StringBuilder("Synthetic");
 
 		if (length > 0)
 			buf.append(" " + Utility.toHexString(bytes));

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Utility.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Utility.java
@@ -74,10 +74,10 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * Utility functions that do not really belong to any class in particular.
- * 
+ *
  * @version $Id: Utility.java,v 1.14 2009/09/28 16:39:46 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
- * 
+ *
  *         modified: Andy Clement 2-mar-05 Removed unnecessary static and optimized
  */
 public abstract class Utility {
@@ -91,7 +91,7 @@ public abstract class Utility {
 
 	/**
 	 * Convert bit field of flags into string such as 'static final'.
-	 * 
+	 *
 	 * @param access_flags Access flags
 	 * @return String representation of flags
 	 */
@@ -101,16 +101,16 @@ public abstract class Utility {
 
 	/**
 	 * Convert bit field of flags into string such as 'static final'.
-	 * 
+	 *
 	 * Special case: Classes compiled with new compilers and with the 'ACC_SUPER' flag would be said to be "synchronized". This is
 	 * because SUN used the same value for the flags 'ACC_SUPER' and 'ACC_SYNCHRONIZED'.
-	 * 
+	 *
 	 * @param access_flags Access flags
 	 * @param for_class access flags are for class qualifiers ?
 	 * @return String representation of flags
 	 */
 	public static final String accessToString(int access_flags, boolean for_class) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		int p = 0;
 		for (int i = 0; p < Constants.MAX_ACC_FLAG; i++) { // Loop through known flags
@@ -136,7 +136,7 @@ public abstract class Utility {
 	/**
 	 * Disassemble a byte array of JVM byte codes starting from code line 'index' and return the disassembled string representation.
 	 * Decode only 'num' opcodes (including their operands), use -1 if you want to decompile everything.
-	 * 
+	 *
 	 * @param code byte code array
 	 * @param constant_pool Array of constants
 	 * @param index offset in `code' array <EM>(number of opcodes, not bytes!)</EM>
@@ -145,7 +145,7 @@ public abstract class Utility {
 	 * @return String representation of byte codes
 	 */
 	public static final String codeToString(byte[] code, ConstantPool constant_pool, int index, int length, boolean verbose) {
-		StringBuffer buf = new StringBuffer(code.length * 20); // Should be sufficient
+		StringBuilder buf = new StringBuilder(code.length * 20); // Should be sufficient
 		ByteSequence stream = new ByteSequence(code);
 
 		try {
@@ -182,7 +182,7 @@ public abstract class Utility {
 
 	/**
 	 * Shorten long class names, <em>java/lang/String</em> becomes <em>String</em>.
-	 * 
+	 *
 	 * @param str The long class name
 	 * @return Compacted class name
 	 */
@@ -193,7 +193,7 @@ public abstract class Utility {
 	/**
 	 * Shorten long class name <em>str</em>, i.e., chop off the <em>prefix</em>, if the class name starts with this string and the
 	 * flag <em>chopit</em> is true. Slashes <em>/</em> are converted to dots <em>.</em>.
-	 * 
+	 *
 	 * @param str The long class name
 	 * @param prefix The prefix the get rid off
 	 * @param chopit Flag that determines whether chopping is executed or not
@@ -217,7 +217,7 @@ public abstract class Utility {
 	/**
 	 * Shorten long class names, <em>java/lang/String</em> becomes <em>java.lang.String</em>, e.g.. If <em>chopit</em> is
 	 * <em>true</em> the prefix <em>java.lang</em> is also removed.
-	 * 
+	 *
 	 * @param str The long class name
 	 * @param chopit Flag that determines whether chopping is executed or not
 	 * @return Compacted class name
@@ -240,7 +240,7 @@ public abstract class Utility {
 	 */
 	public static final String methodSignatureToString(String signature, String name, String access, boolean chopit,
 			LocalVariableTable vars) throws ClassFormatException {
-		StringBuffer buf = new StringBuffer("(");
+		StringBuilder buf = new StringBuilder("(");
 		String type;
 		int index;
 		int var_index = (access.contains("static")) ? 0 : 1;
@@ -298,7 +298,7 @@ public abstract class Utility {
 
 	/**
 	 * Replace all occurences of <em>old</em> in <em>str</em> with <em>new</em>.
-	 * 
+	 *
 	 * @param str String to permute
 	 * @param old String to be replaced
 	 * @param new Replacement string
@@ -306,7 +306,7 @@ public abstract class Utility {
 	 */
 	public static final String replace(String str, String old, String new_) {
 		int index, old_index;
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		try {
 			index = str.indexOf(old);
@@ -332,7 +332,7 @@ public abstract class Utility {
 
 	/**
 	 * Converts signature to string with all class names compacted.
-	 * 
+	 *
 	 * @param signature to convert
 	 * @return Human readable signature
 	 */
@@ -381,7 +381,7 @@ public abstract class Utility {
 					int genericEnd = signature.indexOf('>');
 					// FIXME asc going to need a lot more work in here for generics
 					ResultHolder rh = signatureToStringInternal(signature.substring(genericStart + 1, genericEnd), chopit);
-					StringBuffer sb = new StringBuffer();
+					StringBuilder sb = new StringBuilder();
 					sb.append(signature.substring(1, genericStart));
 					sb.append("<").append(rh.getResult()).append(">");
 					ResultHolder retval = new ResultHolder(compactClassName(sb.toString(), chopit), genericEnd + 1);
@@ -399,10 +399,10 @@ public abstract class Utility {
 				return ResultHolder.BOOLEAN;
 
 			case '[': { // Array declaration
-				StringBuffer brackets;
+				StringBuilder brackets;
 				int consumedChars, n;
 
-				brackets = new StringBuffer(); // Accumulate []'s
+				brackets = new StringBuilder(); // Accumulate []'s
 				// Count opening brackets and look for optional size argument
 				for (n = 0; signature.charAt(n) == '['; n++) {
 					brackets.append("[]");
@@ -426,7 +426,7 @@ public abstract class Utility {
 
 	/**
 	 * Return type of method signature as a byte value as defined in <em>Constants</em>
-	 * 
+	 *
 	 * @param signature in format described above
 	 * @return type of method signature
 	 * @see Constants
@@ -453,11 +453,11 @@ public abstract class Utility {
 
 	/**
 	 * Convert bytes into hexidecimal string
-	 * 
+	 *
 	 * @return bytes as hexidecimal string, e.g. 00 FA 12 ...
 	 */
 	public static final String toHexString(byte[] bytes) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		for (int i = 0; i < bytes.length; i++) {
 			short b = byteToShort(bytes[i]);
@@ -480,7 +480,7 @@ public abstract class Utility {
 
 	/**
 	 * Return a string for an integer justified left or right and filled up with 'fill' characters if necessary.
-	 * 
+	 *
 	 * @param i integer to format
 	 * @param length length of desired string
 	 * @param left_justify format left or right
@@ -493,7 +493,7 @@ public abstract class Utility {
 
 	/**
 	 * Fillup char with up to length characters with char `fill' and justify it left or right.
-	 * 
+	 *
 	 * @param str string to format
 	 * @param length length of desired string
 	 * @param left_justify format left or right
@@ -520,7 +520,7 @@ public abstract class Utility {
 	 */
 	public static final String convertString(String label) {
 		char[] ch = label.toCharArray();
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		for (char c : ch) {
 			switch (c) {
@@ -550,7 +550,7 @@ public abstract class Utility {
 
 	/**
 	 * Converts a list of AnnotationGen objects into a set of attributes that can be attached to the class file.
-	 * 
+	 *
 	 * @param cp The constant pool gen where we can create the necessary name refs
 	 * @param annotations A list of AnnotationGen objects
 	 */
@@ -747,7 +747,7 @@ public abstract class Utility {
 
 	/**
 	 * Return type of signature as a byte value as defined in <em>Constants</em>
-	 * 
+	 *
 	 * @param signature in format described above
 	 * @return type of signature
 	 * @see Constants
@@ -816,7 +816,7 @@ public abstract class Utility {
 
 	/**
 	 * Disassemble a stream of byte codes and return the string representation.
-	 * 
+	 *
 	 * @param bytes stream of bytes
 	 * @param constant_pool Array of constants
 	 * @param verbose be verbose, e.g. print constant pool index
@@ -828,7 +828,7 @@ public abstract class Utility {
 		int index, vindex, constant;
 		int[] match, jump_table;
 		int no_pad_bytes = 0, offset;
-		StringBuffer buf = new StringBuffer(Constants.OPCODE_NAMES[opcode]);
+		StringBuilder buf = new StringBuilder(Constants.OPCODE_NAMES[opcode]);
 
 		/*
 		 * Special case: Skip (0-3) padding bytes, i.e., the following bytes are 4-byte-aligned
@@ -995,13 +995,13 @@ public abstract class Utility {
 					+ bytes.readUnsignedByte()); // Last byte is a reserved
 			// space
 			break;
-			
+
 		case Constants.INVOKEDYNAMIC://http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-6.html#jvms-6.5.invokedynamic
 			index = bytes.readUnsignedShort();
 			bytes.readUnsignedShort(); // zeroes
 			buf.append("\t" + constant_pool.constantToString(index) + (verbose ? " (" + index + ")" : ""));
 			break;
-			
+
 		// Operands are references to items in constant pool
 		case Constants.LDC_W:
 		case Constants.LDC2_W:
@@ -1076,13 +1076,13 @@ public abstract class Utility {
 
 	/**
 	 * Convert type to Java method signature, e.g. int[] f(java.lang.String x) becomes (Ljava/lang/String;)[I
-	 * 
+	 *
 	 * @param returnType what the method returns
 	 * @param argTypes what are the argument types
 	 * @return method signature for given type(s).
 	 */
 	public static String toMethodSignature(Type returnType, Type[] argTypes) {
-		StringBuffer buf = new StringBuffer("(");
+		StringBuilder buf = new StringBuilder("(");
 		int length = (argTypes == null) ? 0 : argTypes.length;
 		for (int i = 0; i < length; i++) {
 			buf.append(argTypes[i].getSignature());

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/AnnotationElementValue.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/AnnotationElementValue.java
@@ -48,7 +48,7 @@ public class AnnotationElementValue extends ElementValue {
 
 	@Override
 	public String stringifyValue() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		ConstantUtf8 cu8 = (ConstantUtf8) cpool.getConstant(a.getTypeIndex(), Constants.CONSTANT_Utf8);
 		sb.append(cu8.getValue());
 		// haven't really tested this values section:

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/AnnotationGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/AnnotationGen.java
@@ -113,7 +113,7 @@ public class AnnotationGen {
 
 	@Override
 	public String toString() {
-		StringBuffer s = new StringBuffer();
+		StringBuilder s = new StringBuilder();
 		s.append("AnnotationGen:[" + getTypeName() + " #" + pairs.size() + " {");
 		for (int i = 0; i < pairs.size(); i++) {
 			s.append(pairs.get(i));
@@ -125,7 +125,7 @@ public class AnnotationGen {
 	}
 
 	public String toShortString() {
-		StringBuffer s = new StringBuffer();
+		StringBuilder s = new StringBuilder();
 		s.append("@").append(getTypeName());
 		if (pairs.size()!=0) {
 			s.append("(");

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/ArrayElementValue.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/ArrayElementValue.java
@@ -62,7 +62,7 @@ public class ArrayElementValue extends ElementValue {
 
 	@Override
 	public String stringifyValue() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("[");
 		for (int i = 0; i < evalues.length; i++) {
 			ElementValue element = evalues[i];

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/EnumElementValue.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/EnumElementValue.java
@@ -76,7 +76,7 @@ public class EnumElementValue extends ElementValue {
 	 */
 	@Override
 	public String stringifyValue() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		ConstantUtf8 cu8 = (ConstantUtf8) cpool.getConstant(typeIdx, Constants.CONSTANT_Utf8);
 		sb.append(cu8.getValue());
 		cu8 = (ConstantUtf8) cpool.getConstant(valueIdx, Constants.CONSTANT_Utf8);

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/NameValuePair.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/annotation/NameValuePair.java
@@ -68,7 +68,7 @@ public class NameValuePair {
 
 	@Override
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(getNameString()).append("=").append(value.stringifyValue());
 		return sb.toString();
 	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ArrayType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ArrayType.java
@@ -55,7 +55,7 @@ package org.aspectj.apache.bcel.generic;
  */
 import org.aspectj.apache.bcel.Constants;
 
-/** 
+/**
  * Denotes array type, such as int[][]
  *
  * @version $Id: ArrayType.java,v 1.4 2008/08/26 15:02:04 aclement Exp $
@@ -69,7 +69,7 @@ public final class ArrayType extends ReferenceType {
    * Convenience constructor for array type, e.g. int[]
    *
    * @param type array type, e.g. T_INT
-   */ 
+   */
   public ArrayType(byte type, int dimensions) {
     this(BasicType.getType(type), dimensions);
   }
@@ -78,7 +78,7 @@ public final class ArrayType extends ReferenceType {
    * Convenience constructor for reference array type, e.g. Object[]
    *
    * @param class_name complete name of class (java.lang.String, e.g.)
-   */ 
+   */
   public ArrayType(String class_name, int dimensions) {
     this(new ObjectType(class_name), dimensions);
   }
@@ -87,7 +87,7 @@ public final class ArrayType extends ReferenceType {
    * Constructor for array of given type
    *
    * @param type type of array (may be an array itself)
-   */ 
+   */
   public ArrayType(Type type, int dimensions) {
     super(Constants.T_ARRAY, "<dummy>");
 
@@ -100,7 +100,7 @@ public final class ArrayType extends ReferenceType {
       this.dimensions = dimensions + array.dimensions;
       basic_type      = array.basic_type;
       break;
-      
+
     case Constants.T_VOID:
       throw new ClassGenException("Invalid type: void[]");
 
@@ -110,7 +110,7 @@ public final class ArrayType extends ReferenceType {
       break;
     }
 
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     for(int i=0; i < this.dimensions; i++)
       buf.append('[');
 

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldGen.java
@@ -75,7 +75,7 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeAnnos;
 /**
  * Template class for building up a field. The only extraordinary thing one can do is to add a constant value attribute to a field
  * (which must of course be compatible with the declared type).
- * 
+ *
  * @version $Id: FieldGen.java,v 1.11 2011/10/03 22:41:24 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Field
@@ -86,7 +86,7 @@ public class FieldGen extends FieldGenOrMethodGen {
 	/**
 	 * Declare a field. If it is static (isStatic() == true) and has a basic type like int or String it may have an initial value
 	 * associated with it as defined by setInitValue().
-	 * 
+	 *
 	 * @param modifiers access qualifiers
 	 * @param type field type
 	 * @param name field name
@@ -101,7 +101,7 @@ public class FieldGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Instantiate from existing field.
-	 * 
+	 *
 	 * @param field Field object
 	 * @param cp constant pool (must contain the same entries as the field's constant pool)
 	 */
@@ -230,7 +230,7 @@ public class FieldGen extends FieldGenOrMethodGen {
 		String signature = type.toString();
 		String name = getName();
 
-		StringBuffer buf = new StringBuffer(access).append(signature).append(" ").append(name);
+		StringBuilder buf = new StringBuilder(access).append(signature).append(" ").append(name);
 		String value = getInitialValue();
 
 		if (value != null) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Instruction.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Instruction.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * Abstract super class for all Java byte codes.
- * 
+ *
  * @version $Id: Instruction.java,v 1.10 2011/04/05 15:15:33 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -86,7 +86,7 @@ public class Instruction implements Cloneable, Serializable, Constants {
 	/**
 	 * Use with caution, since 'BranchInstruction's have a 'target' reference which is not copied correctly (only basic types are).
 	 * This also applies for 'Select' instructions with their multiple branch targets.
-	 * 
+	 *
 	 * @return (shallow) copy of an instruction
 	 */
 	// GET RID OF THIS - make it throw an exception and track the callers
@@ -107,7 +107,7 @@ public class Instruction implements Cloneable, Serializable, Constants {
 
 	/**
 	 * Read an instruction bytecode from an input stream and return the appropriate object.
-	 * 
+	 *
 	 * @param file file to read from
 	 * @return instruction object being read
 	 */
@@ -439,7 +439,7 @@ public class Instruction implements Cloneable, Serializable, Constants {
 	 */
 	public String toString(boolean verbose) {
 		if (verbose) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(getName()).append("[").append(opcode).append("](size").append(Constants.iLen[opcode]).append(")");
 			return sb.toString();
 		} else {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionCP.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionCP.java
@@ -70,7 +70,7 @@ import org.aspectj.apache.bcel.classfile.ConstantUtf8;
 
 /**
  * Class for instructions that use an index into the constant pool such as LDC, INVOKEVIRTUAL, etc.
- * 
+ *
  * @version $Id: InstructionCP.java,v 1.6 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -111,10 +111,10 @@ public class InstructionCP extends Instruction {
 
 	/**
 	 * Long output format:
-	 * 
+	 *
 	 * &lt;name of opcode&gt; "["&lt;opcode number&gt;"]" "("&lt;length of instruction&gt;")" "&lt;"&lt; constant pool
 	 * index&gt;"&gt;"
-	 * 
+	 *
 	 * @param verbose long/short format switch
 	 * @return mnemonic for instruction
 	 */
@@ -172,7 +172,7 @@ public class InstructionCP extends Instruction {
 			// ConstantPool cp = cpg.getConstantPool();
 			// String name = cp.getConstantString(index, CONSTANT_Class);
 			if (!name.startsWith("[")) {
-				StringBuffer sb = new StringBuffer();
+				StringBuilder sb = new StringBuilder();
 				sb.append("L").append(name).append(";");
 				return Type.getType(sb.toString());
 			} else {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionList.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionList.java
@@ -74,9 +74,9 @@ import org.aspectj.apache.bcel.util.ByteSequence;
  * inserted, moved, deleted, etc.. Instructions are being wrapped into <a href="InstructionHandle.html">InstructionHandles</a>
  * objects that are returned upon append/insert operations. They give the user (read only) access to the list structure, such that
  * it can be traversed and manipulated in a controlled way.
- * 
+ *
  * A list is finally dumped to a byte code array with <a href="#getByteCode()">getByteCode</a>.
- * 
+ *
  * @version $Id: InstructionList.java,v 1.12 2011/09/02 22:33:04 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author Abraham Nevado
@@ -106,7 +106,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Find the target instruction (handle) that corresponds to the given target position (byte code offset).
-	 * 
+	 *
 	 * @param ihs array of instruction handles, i.e. il.getInstructionHandles()
 	 * @param pos array of positions corresponding to ihs, i.e. il.getInstructionPositions()
 	 * @param count length of arrays
@@ -143,7 +143,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Get instruction handle for instruction at byte code position pos. This only works properly, if the list is freshly
 	 * initialized from a byte array or setPositions() has been called before this method.
-	 * 
+	 *
 	 * @param pos byte code position to search for
 	 * @return target position's instruction handle if available
 	 */
@@ -166,7 +166,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Initialize instruction list from byte array.
-	 * 
+	 *
 	 * @param code byte array containing the instructions
 	 */
 	public InstructionList(byte[] code) {
@@ -248,7 +248,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append another list after instruction (handle) ih contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param appendTo where to append the instruction list
 	 * @param appendee Instruction list to append to this one
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -283,7 +283,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append another list after instruction i contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param i where to append the instruction list
 	 * @param il Instruction list to append to this one
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -300,7 +300,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append another list to this one. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param il list to append to end of this list
 	 * @return instruction handle of the <B>first</B> appended instruction
 	 */
@@ -326,7 +326,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction to the end of this list.
-	 * 
+	 *
 	 * @param ih instruction to append
 	 */
 	private void append(InstructionHandle ih) {
@@ -345,7 +345,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction to the end of this list.
-	 * 
+	 *
 	 * @param i instruction to append
 	 * @return instruction handle of the appended instruction
 	 */
@@ -376,7 +376,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append a branch instruction to the end of this list.
-	 * 
+	 *
 	 * @param i branch instruction to append
 	 * @return branch instruction handle of the appended instruction
 	 */
@@ -389,7 +389,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append a single instruction j after another instruction i, which must be in this list of course!
-	 * 
+	 *
 	 * @param i Instruction in list
 	 * @param j Instruction to append after i in list
 	 * @return instruction handle of the first appended instruction
@@ -400,7 +400,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction after instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to append the instruction list
 	 * @param i Instruction to append
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -411,7 +411,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction after instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to append the instruction list
 	 * @param i Instruction to append
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -428,7 +428,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert another list before Instruction handle ih contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param i where to append the instruction list
 	 * @param il Instruction list to insert
 	 * @return instruction handle of the first inserted instruction
@@ -464,7 +464,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert another list.
-	 * 
+	 *
 	 * @param il list to insert before start of this list
 	 * @return instruction handle of the first inserted instruction
 	 */
@@ -479,7 +479,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction at start of this list.
-	 * 
+	 *
 	 * @param ih instruction to insert
 	 */
 	private void insert(InstructionHandle ih) {
@@ -498,7 +498,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert another list before Instruction i contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param i where to append the instruction list
 	 * @param il Instruction list to insert
 	 * @return instruction handle pointing to the first inserted instruction, i.e., il.getStart()
@@ -515,7 +515,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction at start of this list.
-	 * 
+	 *
 	 * @param i instruction to insert
 	 * @return instruction handle of the inserted instruction
 	 */
@@ -528,7 +528,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert a branch instruction at start of this list.
-	 * 
+	 *
 	 * @param i branch instruction to insert
 	 * @return branch instruction handle of the appended instruction
 	 */
@@ -540,7 +540,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert a single instruction j before another instruction i, which must be in this list of course!
-	 * 
+	 *
 	 * @param i Instruction in list
 	 * @param j Instruction to insert before i in list
 	 * @return instruction handle of the first inserted instruction
@@ -551,7 +551,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction before instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to insert to the instruction list
 	 * @param i Instruction to insert
 	 * @return instruction handle of the first inserted instruction
@@ -562,7 +562,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction before instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to insert to the instruction list
 	 * @param i Instruction to insert
 	 * @return instruction handle of the first inserted instruction
@@ -582,7 +582,7 @@ public class InstructionList implements Serializable {
 	 * be after "start" and target must not be located withing this range. If you want to move something to the start of the list
 	 * use null as value for target.<br>
 	 * Any instruction targeters pointing to handles within the block, keep their targets.
-	 * 
+	 *
 	 * @param start of moved block
 	 * @param end of moved block
 	 * @param target of moved block
@@ -644,7 +644,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Move a single instruction (handle) to a new location.
-	 * 
+	 *
 	 * @param ih moved instruction
 	 * @param target new location of moved instruction
 	 */
@@ -654,10 +654,10 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Remove from instruction 'prev' to instruction 'next' both contained in this list.
-	 * 
+	 *
 	 * If careAboutLostTargeters is true then this method will throw a TargetLostException when one of the removed instruction
 	 * handles is still being targeted.
-	 * 
+	 *
 	 * @param prev where to start deleting (predecessor, exclusive)
 	 * @param next where to end deleting (successor, exclusive)
 	 */
@@ -697,7 +697,7 @@ public class InstructionList implements Serializable {
 			ih.getInstruction().dispose(); // e.g. BranchInstructions release their targets
 		}
 
-		StringBuffer buf = new StringBuffer("{ ");
+		StringBuilder buf = new StringBuilder("{ ");
 		for (InstructionHandle ih = first; ih != null; ih = next) {
 			next = ih.next;
 			length--;
@@ -757,7 +757,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Remove instruction from this list. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param ih instruction (handle) to remove
 	 */
 	public void delete(InstructionHandle ih) throws TargetLostException {
@@ -766,7 +766,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Remove instruction from this list. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param i instruction to remove
 	 */
 	// public void delete(Instruction i) throws TargetLostException {
@@ -780,7 +780,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Remove instructions from instruction `from' to instruction `to' contained in this list. The user must ensure that `from' is
 	 * an instruction before `to', or risk havoc. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param from where to start deleting (inclusive)
 	 * @param to where to end deleting (inclusive)
 	 */
@@ -791,7 +791,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Remove instructions from instruction `from' to instruction `to' contained in this list. The user must ensure that `from' is
 	 * an instruction before `to', or risk havoc. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param from where to start deleting (inclusive)
 	 * @param to where to end deleting (inclusive)
 	 */
@@ -810,7 +810,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Search for given Instruction reference, start at beginning of list.
-	 * 
+	 *
 	 * @param i instruction to search for
 	 * @return instruction found on success, null otherwise
 	 */
@@ -826,7 +826,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Search for given Instruction reference, start at end of list
-	 * 
+	 *
 	 * @param i instruction to search for
 	 * @return instruction found on success, null otherwise
 	 */
@@ -864,7 +864,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Give all instructions their position number (offset in byte stream), i.e., make the list ready to be dumped.
-	 * 
+	 *
 	 * @param check Perform sanity checks, e.g. if all targeted instructions really belong to this list
 	 */
 	public void setPositions(boolean check) {
@@ -972,7 +972,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * When everything is finished, use this method to convert the instruction list into an array of bytes.
-	 * 
+	 *
 	 * @return the byte code ready to be dumped
 	 */
 	public byte[] getByteCode() {
@@ -1029,7 +1029,7 @@ public class InstructionList implements Serializable {
 	 * @return String containing all instructions in this list.
 	 */
 	public String toString(boolean verbose) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		for (InstructionHandle ih = start; ih != null; ih = ih.next) {
 			buf.append(ih.toString(verbose) + "\n");
@@ -1079,7 +1079,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Get positions (offsets) of all instructions in the list. This relies on that the list has been freshly created from an byte
 	 * code array, or that setPositions() has been called. Otherwise this may be inaccurate.
-	 * 
+	 *
 	 * @return array containing all instruction's offset in byte code
 	 */
 	public int[] getInstructionPositions() {
@@ -1208,7 +1208,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Redirect all references from old_target to new_target, i.e., update targets of branch instructions.
-	 * 
+	 *
 	 * @param old_target the old target instruction handle
 	 * @param new_target the new target instruction handle
 	 */
@@ -1239,7 +1239,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Redirect all references of local variables from old_target to new_target.
-	 * 
+	 *
 	 * @param lg array of local variables
 	 * @param old_target the old target instruction handle
 	 * @param new_target the new target instruction handle
@@ -1261,7 +1261,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Redirect all references of exception handlers from old_target to new_target.
-	 * 
+	 *
 	 * @param exceptions array of exception handlers
 	 * @param old_target the old target instruction handle
 	 * @param new_target the new target instruction handle

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionSelect.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionSelect.java
@@ -60,7 +60,7 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * Select - Abstract super class for LOOKUPSWITCH and TABLESWITCH instructions.
- * 
+ *
  * @version $Id: InstructionSelect.java,v 1.4 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see LOOKUPSWITCH
@@ -79,7 +79,7 @@ public abstract class InstructionSelect extends InstructionBranch {
 
 	/**
 	 * (Match, target) pairs for switch. `Match' and `targets' must have the same length of course.
-	 * 
+	 *
 	 * @param match array of matching values
 	 * @param targets instruction targets
 	 * @param target default instruction target
@@ -119,11 +119,11 @@ public abstract class InstructionSelect extends InstructionBranch {
 	/**
 	 * Since this is a variable length instruction, it may shift the following instructions which then need to update their
 	 * position.
-	 * 
+	 *
 	 * Called by InstructionList.setPositions when setting the position for every instruction. In the presence of variable length
 	 * instructions `setPositions' performs multiple passes over the instruction list to calculate the correct (byte) positions and
 	 * offsets by calling this function.
-	 * 
+	 *
 	 * @param offset additional offset caused by preceding (variable length) instructions
 	 * @param max_offset the maximum offset that may be caused by these instructions
 	 * @return additional offset caused by possible change of this instruction's length
@@ -146,7 +146,7 @@ public abstract class InstructionSelect extends InstructionBranch {
 
 	/**
 	 * Dump instruction as byte code to stream out.
-	 * 
+	 *
 	 * @param out Output stream
 	 */
 	public void dump(DataOutputStream out) throws IOException {
@@ -177,7 +177,7 @@ public abstract class InstructionSelect extends InstructionBranch {
 	 * @return mnemonic for instruction
 	 */
 	public String toString(boolean verbose) {
-		StringBuffer buf = new StringBuffer(super.toString(verbose));
+		StringBuilder buf = new StringBuilder(super.toString(verbose));
 
 		if (verbose) {
 			for (int i = 0; i < matchLength; i++) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/MethodGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/MethodGen.java
@@ -79,10 +79,10 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeParamAnnos;
  * Template class for building up a method. This is done by defining exception handlers, adding thrown exceptions, local variables
  * and attributes, whereas the 'LocalVariableTable' and 'LineNumberTable' attributes will be set automatically for the code. Use
  * stripAttributes() if you don't like this.
- * 
+ *
  * While generating code it may be necessary to insert NOP operations. You can use the `removeNOPs' method to get rid off them. The
  * resulting method object can be obtained via the `getMethod()' method.
- * 
+ *
  * @version $Id: MethodGen.java,v 1.17 2011/05/19 23:23:46 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author <A HREF="http://www.vmeng.com/beard">Patrick C. Beard</A> [setMaxStack()]
@@ -115,10 +115,10 @@ public class MethodGen extends FieldGenOrMethodGen {
 	 * Declare method. If the method is non-static the constructor automatically declares a local variable `$this' in slot 0. The
 	 * actual code is contained in the `il' parameter, which may further manipulated by the user. But he must take care not to
 	 * remove any instruction (handles) that are still referenced from this object.
-	 * 
+	 *
 	 * For example one may not add a local variable and later remove the instructions it refers to without causing havoc. It is safe
 	 * however if you remove that local variable, too.
-	 * 
+	 *
 	 * @param access_flags access qualifiers
 	 * @param return_type method type
 	 * @param arg_types argument types
@@ -164,7 +164,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 		// throw new ClassGenException("'void' is an illegal argument type for a method");
 		// }
 		// }
-		//	
+		//
 		// if(arg_names != null) { // Names for variables provided?
 		// if(size != arg_names.length)
 		// throw new ClassGenException("Mismatch in argument array lengths: " +
@@ -192,7 +192,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Instantiate from existing method.
-	 * 
+	 *
 	 * @param m method
 	 * @param class_name class name containing this method
 	 * @param cp constant pool
@@ -362,7 +362,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Adds a local variable to this method and assigns an index automatically.
-	 * 
+	 *
 	 * @param name variable name
 	 * @param type variable type
 	 * @param start from where the variable is valid, if this is null, it is valid from the start
@@ -424,7 +424,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	/*
 	 * If the range of the variable has not been set yet, it will be set to be valid from the start to the end of the instruction
 	 * list.
-	 * 
+	 *
 	 * @return array of declared local variables sorted by index
 	 */
 	public LocalVariableGen[] getLocalVariables() {
@@ -466,7 +466,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Give an instruction a line number corresponding to the source code line.
-	 * 
+	 *
 	 * @param ih instruction to tag
 	 * @return new line number object
 	 * @see LineNumber
@@ -517,7 +517,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	/**
 	 * Add an exception handler, i.e., specify region where a handler is active and an instruction where the actual handling is
 	 * done.
-	 * 
+	 *
 	 * @param start_pc Start of region (inclusive)
 	 * @param end_pc End of region (inclusive)
 	 * @param handler_pc Where handling is done
@@ -578,7 +578,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Add an exception possibly thrown by this method.
-	 * 
+	 *
 	 * @param class_name (fully qualified) name of exception
 	 */
 	public void addException(String class_name) {
@@ -629,7 +629,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	 * Add an attribute to the code. Currently, the JVM knows about the LineNumberTable, LocalVariableTable and StackMap attributes,
 	 * where the former two will be generated automatically and the latter is used for the MIDP only. Other attributes will be
 	 * ignored by the JVM but do no harm.
-	 * 
+	 *
 	 * @param a attribute to be added
 	 */
 	public void addCodeAttribute(Attribute a) {
@@ -674,7 +674,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	/**
 	 * Get method object. Never forget to call setMaxStack() or setMaxStack(max), respectively, before calling this method (the same
 	 * applies for max locals).
-	 * 
+	 *
 	 * @return method object
 	 */
 	public Method getMethod() {
@@ -879,10 +879,10 @@ public class MethodGen extends FieldGenOrMethodGen {
 	public void setMaxLocals() {
 		setMaxLocals(false);
 	}
-	
+
 	/**
 	 * Compute maximum number of local variables.
-	 * 
+	 *
 	 * @param respectLocalVariableTable if true and the local variable table indicates more are in use
 	 * than the code suggests, respect the higher value from the local variable table data.
 	 */
@@ -966,7 +966,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Computes stack usage of an instruction list by performing control flow analysis.
-	 * 
+	 *
 	 * @return maximum stack depth used by method
 	 */
 	public static int getMaxStack(ConstantPool cp, InstructionList il, CodeExceptionGen[] et) {
@@ -1050,7 +1050,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Return string representation close to declaration format, `public static void main(String[]) throws IOException', e.g.
-	 * 
+	 *
 	 * @return String representation of the method.
 	 */
 	@Override
@@ -1060,7 +1060,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 		signature = Utility.methodSignatureToString(signature, name, access, true, getLocalVariableTable(cp));
 
-		StringBuffer buf = new StringBuffer(signature);
+		StringBuilder buf = new StringBuilder(signature);
 
 		if (exceptionsThrown.size() > 0) {
 			for (String s : exceptionsThrown) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ObjectType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ObjectType.java
@@ -59,7 +59,7 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
 
 /**
  * Denotes reference such as java.lang.String.
- * 
+ *
  * @version $Id: ObjectType.java,v 1.7 2009/09/28 16:39:46 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -84,7 +84,7 @@ public class ObjectType extends ReferenceType {
 	}
 
 	private static String toSignature(String classname) {
-		StringBuffer sig = new StringBuffer();
+		StringBuilder sig = new StringBuilder();
 		sig.append("L").append(classname.replace('.', '/'));
 		sig.append(";");
 		return sig.toString();

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Type.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Type.java
@@ -67,10 +67,10 @@ import org.aspectj.apache.bcel.classfile.Utility;
 /**
  * Abstract super class for all possible java types, namely basic types such as int, object types like String and array types, e.g.
  * int[]
- * 
+ *
  * @version $Id: Type.java,v 1.14 2011/09/28 01:14:54 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
- * 
+ *
  *         modified: AndyClement 2-mar-05: Removed unnecessary static and optimized
  */
 public abstract class Type {
@@ -233,7 +233,7 @@ public abstract class Type {
 
 	/**
 	 * Convert signature to a Type object.
-	 * 
+	 *
 	 * @param signature signature string such as Ljava/lang/String;
 	 * @return type object
 	 */
@@ -292,7 +292,7 @@ public abstract class Type {
 
 	/**
 	 * Convert return value of a method (signature) to a Type object.
-	 * 
+	 *
 	 * @param signature signature string such as (Ljava/lang/String;)V
 	 * @return return type
 	 */
@@ -308,7 +308,7 @@ public abstract class Type {
 
 	/**
 	 * Convert arguments of a method (signature) to an array of Type objects.
-	 * 
+	 *
 	 * @param signature signature string such as (Ljava/lang/String;)V
 	 * @return array of argument types
 	 */
@@ -419,7 +419,7 @@ public abstract class Type {
 
 	/**
 	 * Convert runtime java.lang.Class to BCEL Type object.
-	 * 
+	 *
 	 * @param cl Java class
 	 * @return corresponding Type object
 	 */
@@ -463,7 +463,7 @@ public abstract class Type {
 	}
 
 	public static String getSignature(java.lang.reflect.Method meth) {
-		StringBuffer sb = new StringBuffer("(");
+		StringBuilder sb = new StringBuilder("(");
 		Class[] params = meth.getParameterTypes(); // avoid clone
 
 		for (Class param : params) {
@@ -476,7 +476,7 @@ public abstract class Type {
 	}
 
 	public static String getSignature(java.lang.reflect.Constructor<?> cons) {
-		StringBuffer sb = new StringBuffer("(");
+		StringBuilder sb = new StringBuilder("(");
 		Class<?>[] params = cons.getParameterTypes(); // avoid clone
 
 		for (Class<?> param : params) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
@@ -73,11 +73,11 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
 
 /**
  * The repository maintains information about which classes have been loaded.
- * 
+ *
  * It loads its data from the ClassLoader implementation passed into its constructor.
- * 
+ *
  * @see org.aspectj.apache.bcel.Repository
- * 
+ *
  * @version $Id: ClassLoaderRepository.java,v 1.13 2009/09/09 19:56:20 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author David Dixon-Peugh
@@ -334,7 +334,7 @@ public class ClassLoaderRepository implements Repository {
 	 * Produce a report on cache usage.
 	 */
 	public String report() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("BCEL repository report.");
 		if (useSharedCache)
 			sb.append(" (shared cache)");

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassPath.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassPath.java
@@ -217,7 +217,7 @@ public class ClassPath implements Serializable {
 					list.add(ext_dir.toString() + File.separatorChar + extension);
 		}
 
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		for (Iterator<String> e = list.iterator(); e.hasNext();) {
 			buf.append(e.next());

--- a/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/BcelTestCase.java
+++ b/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/BcelTestCase.java
@@ -116,7 +116,7 @@ public abstract class BcelTestCase extends TestCase {
 	}
 
 	protected String dumpAnnotations(AnnotationGen[] as) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		result.append("[");
 		for (int i = 0; i < as.length; i++) {
 			AnnotationGen annotation = as[i];
@@ -129,7 +129,7 @@ public abstract class BcelTestCase extends TestCase {
 	}
 
 	protected String dumpAnnotations(List<AnnotationGen> as) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		result.append("[");
 		for (int i = 0; i < as.size(); i++) {
 			AnnotationGen annotation = as.get(i);
@@ -142,7 +142,7 @@ public abstract class BcelTestCase extends TestCase {
 	}
 
 	protected String dumpAttributes(Attribute[] as) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		result.append("AttributeArray:[");
 		for (int i = 0; i < as.length; i++) {
 			Attribute attr = as[i];

--- a/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/GenericSignatureParsingTest.java
+++ b/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/GenericSignatureParsingTest.java
@@ -324,7 +324,7 @@ public class GenericSignatureParsingTest extends BcelTestCase {
 	   * @return byte code signature
 	   */
 	  public static String getSignature(String type) {
-	    StringBuffer buf        = new StringBuffer();
+	    StringBuilder buf       = new StringBuilder();
 	    char[]       chars      = type.toCharArray();
 	    boolean      char_found = false, delim = false;
 	    int          index      = -1;
@@ -451,7 +451,7 @@ public class GenericSignatureParsingTest extends BcelTestCase {
 	   */
 	  public final static String methodTypeToSignature(String returnType, String[] methodArgs) throws ClassFormatException {
 
-	    StringBuffer buf = new StringBuffer("(");
+	    StringBuilder buf = new StringBuilder("(");
 
 	    if (methodArgs != null) {
 			for (String methodArg : methodArgs) {

--- a/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
+++ b/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
@@ -851,7 +851,7 @@ public class MessageUtil {
 		if (null == loc) {
 			return "((ISourceLocation) null)";
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 
 		File sourceFile = loc.getSourceFile();
 		if (sourceFile != ISourceLocation.NO_FILE) {
@@ -901,7 +901,7 @@ public class MessageUtil {
 		Throwable thrown = message.getThrown();
 		ISourceLocation sl = message.getSourceLocation();
 		IMessage.Kind kind = message.getKind();
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		result.append(kind.toString());
 		result.append(": ");
 		if (null != thrown) {
@@ -988,7 +988,7 @@ public class MessageUtil {
 		if (0 == holder.numMessages(null, false)) {
 			return "(0 messages)";
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (IMessage.Kind kind : IMessage.KINDS) {
 			int num = holder.numMessages(kind, false);
 			if (0 < num) {

--- a/bridge/src/main/java/org/aspectj/bridge/SourceLocation.java
+++ b/bridge/src/main/java/org/aspectj/bridge/SourceLocation.java
@@ -131,7 +131,7 @@ public class SourceLocation implements ISourceLocation {
 
 	/** @return String {context\n}{file:}line{:column} */
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (null != context) {
 			sb.append(context);
 			sb.append(LangUtil.EOL);

--- a/bridge/src/main/java/org/aspectj/bridge/WeaveMessage.java
+++ b/bridge/src/main/java/org/aspectj/bridge/WeaveMessage.java
@@ -57,7 +57,7 @@ public class WeaveMessage extends Message {
 	 * @return new weaving message
 	 */
 	public static WeaveMessage constructWeavingMessage(WeaveMessageKind kind, String[] inserts) {
-		StringBuffer str = new StringBuffer(kind.getMessage());
+		StringBuilder str = new StringBuilder(kind.getMessage());
 		int pos = -1;
 		while ((pos = new String(str).indexOf("%")) != -1) {
 			int n = Character.getNumericValue(str.charAt(pos + 1));
@@ -77,7 +77,7 @@ public class WeaveMessage extends Message {
 	 */
 	public static WeaveMessage constructWeavingMessage(WeaveMessageKind kind, String[] inserts, String affectedtypename,
 			String aspectname) {
-		StringBuffer str = new StringBuffer(kind.getMessage());
+		StringBuilder str = new StringBuilder(kind.getMessage());
 		int pos = -1;
 		while ((pos = new String(str).indexOf("%")) != -1) {
 			int n = Character.getNumericValue(str.charAt(pos + 1));

--- a/bridge/src/main/java/org/aspectj/bridge/context/CompilationAndWeavingContext.java
+++ b/bridge/src/main/java/org/aspectj/bridge/context/CompilationAndWeavingContext.java
@@ -138,7 +138,7 @@ public class CompilationAndWeavingContext {
 				explanationStack.push(getFormatter(entry).formatEntry(entry.phaseId, data));
 			}
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		while (!explanationStack.isEmpty()) {
 			sb.append("when ");
 			sb.append(explanationStack.pop().toString());
@@ -240,7 +240,7 @@ public class CompilationAndWeavingContext {
 	private static class DefaultFormatter implements ContextFormatter {
 
 		public String formatEntry(int phaseId, Object data) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(PHASE_NAMES[phaseId]);
 			sb.append(" ");
 			if (data instanceof char[]) {

--- a/bridge/src/main/java/org/aspectj/bridge/context/PinpointingMessageHandler.java
+++ b/bridge/src/main/java/org/aspectj/bridge/context/PinpointingMessageHandler.java
@@ -44,7 +44,7 @@ public class PinpointingMessageHandler implements IMessageHandler {
 			ex.fillInStackTrace();
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(CompilationAndWeavingContext.getCurrentContext());
 			sb.append(sw.toString());
 			IMessage pinpointedMessage = new PinpointedMessage(message,sb.toString());

--- a/bridge/src/test/java/org/aspectj/bridge/MessageTest.java
+++ b/bridge/src/test/java/org/aspectj/bridge/MessageTest.java
@@ -286,7 +286,7 @@ class KindTest {
 
     /** @return error if failed */
     String checkExpectedKind(IMessage m) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         for (int i = 0; i < KINDS.length; i++) {
             if (expected.get(i) != checkKindMethods(m, i)) {
                 String s = "expected " + expected.get(i)

--- a/build/src/main/java/$installer$/org/aspectj/Main.java
+++ b/build/src/main/java/$installer$/org/aspectj/Main.java
@@ -799,7 +799,7 @@ abstract class WizardPane {
 	public static String stringFromStream(InputStream stream) throws IOException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "US-ASCII"));
 
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		int data;
 		while ((data = reader.read()) != -1) {
 			ret.append((char) data);
@@ -827,7 +827,7 @@ abstract class WizardPane {
 	public static String applyProperties(String text, Map<String,String> map) {
 		// ${name} -> map.get(name).toString()
 		int lastIndex = 0;
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		int startIndex;
 		while ((startIndex = text.indexOf("${", lastIndex)) != -1) {

--- a/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/AJInstaller.java
+++ b/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/AJInstaller.java
@@ -148,7 +148,7 @@ public class AJInstaller extends MatchingTask {
 
     protected void writeContents(ZipOutputStream zOut) throws IOException {
         // write to a StringBuffer
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append(contentsBytes);
         buf.append(NEWLINE);
 		for (String name : contentsNames) {
@@ -160,7 +160,7 @@ public class AJInstaller extends MatchingTask {
 
     protected void writeManifest(ZipOutputStream zOut) throws IOException {
         // write to a StringBuffer
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("Manifest-Version: 1.0");
         buf.append(NEWLINE);
         buf.append("Main-Class: " + MAIN_CLASS);

--- a/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/AntBuilder.java
+++ b/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/AntBuilder.java
@@ -92,7 +92,7 @@ public class AntBuilder extends Builder {
 			target.setName(resultTargetName);
 
 			Result[] reqs = result.getRequired();
-			StringBuffer depends = new StringBuffer();
+			StringBuilder depends = new StringBuilder();
 			boolean first = true;
 			for (Result reqResult : reqs) {
 				if (!first) {
@@ -616,7 +616,7 @@ public class AntBuilder extends Builder {
 			} catch (BuildException e) {
 				throw e;
 			} catch (Throwable t) {
-				StringBuffer sb = new StringBuffer();
+				StringBuilder sb = new StringBuilder();
 				sb.append("classpath=");
 				sb.append(url);
 				throw new BuildException(sb.toString(), t);

--- a/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/Checklics.java
+++ b/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/Checklics.java
@@ -314,7 +314,7 @@ public class Checklics extends MatchingTask {
 
 	private void list() {
 		Iterator enu = LICENSES.keySet().iterator();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("known license keys:");
 		boolean first = true;
 		while (enu.hasNext()) {

--- a/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/StripNonBodyHtml.java
+++ b/build/src/main/java/org/aspectj/internal/tools/ant/taskdefs/StripNonBodyHtml.java
@@ -176,7 +176,7 @@ public class StripNonBodyHtml extends MatchingTask {
     String stripTags(String input, final String SOURCE,
                      final String START, final String END) {
         if (null == input) return  input;
-        StringBuffer buffer = new StringBuffer(input.length());
+        StringBuilder buffer = new StringBuilder(input.length());
         String result = input;
         int curLoc = 0;
         while (true) {

--- a/build/src/main/java/org/aspectj/internal/tools/build/Builder.java
+++ b/build/src/main/java/org/aspectj/internal/tools/build/Builder.java
@@ -473,7 +473,7 @@ public abstract class Builder {
         // copy binaries (but not module flag files)
         String excludes = null;
         {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
 			for (ProductModule productModule : productModules) {
 				if (0 < buf.length()) {
 					buf.append(",");

--- a/build/src/main/java/org/aspectj/internal/tools/build/Module.java
+++ b/build/src/main/java/org/aspectj/internal/tools/build/Module.java
@@ -610,7 +610,7 @@ public class Module {
             final String DELIM = " \n\t\\<>\"=";
             StringTokenizer st = new StringTokenizer(line, DELIM, true);
             ArrayList<String> result = new ArrayList<>();
-            StringBuffer quote = new StringBuffer();
+            StringBuilder quote = new StringBuilder();
             boolean inQuote = false;
             while (st.hasMoreTokens()) {
                 String s = st.nextToken();

--- a/build/src/main/java/org/aspectj/internal/tools/build/SampleGatherer.java
+++ b/build/src/main/java/org/aspectj/internal/tools/build/SampleGatherer.java
@@ -167,7 +167,7 @@ public class SampleGatherer {
         Reader reader = null;
         try {
             String author = null;
-            StringBuffer sampleCode = new StringBuffer();
+            StringBuilder sampleCode = new StringBuilder();
             String anchorName = null;
             String anchorTitle = null;
             ArrayList<String> flags = new ArrayList<>();
@@ -747,7 +747,7 @@ class HTMLSamplesRenderer extends SamplesRenderer {
             }
         }
         // build up prefix
-        StringBuffer branchAnchor = new StringBuffer();
+        StringBuilder branchAnchor = new StringBuilder();
         for (int i = 0; i < firstDiff;) {
             branchAnchor.append(parts[i]);
             i++;
@@ -991,7 +991,7 @@ class SampleUtil {
         if (from.length != to.length) {
             throw new IllegalArgumentException("unmatched from/to");
         }
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         int LEN = source.length();
         int start = 0;
         for (int i = 0; i < LEN; i++) {

--- a/build/src/main/java/org/aspectj/internal/tools/build/Util.java
+++ b/build/src/main/java/org/aspectj/internal/tools/build/Util.java
@@ -151,7 +151,7 @@ public class Util {
     }
 
     public static String path(String[] segments) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if ((null != segments)) {
             for (int i = 0; i < segments.length; i++) {
                 if (0 < i) {

--- a/build/src/test/java/org/aspectj/internal/build/BuildModuleTest.java
+++ b/build/src/test/java/org/aspectj/internal/build/BuildModuleTest.java
@@ -107,7 +107,7 @@ public class BuildModuleTest extends TestCase {
 			if (!Util.delete(file)) {
 				File[] list = file.listFiles();
 				if (!Util.isEmpty(list)) {
-					StringBuffer sb = new StringBuffer();
+					StringBuilder sb = new StringBuilder();
 					sb.append("warning: BuildModuleTest unable to delete ");
 					sb.append(file.toString());
 					sb.append("\n"); // XXX platform

--- a/build/src/test/java/org/aspectj/internal/build/ModulesTest.java
+++ b/build/src/test/java/org/aspectj/internal/build/ModulesTest.java
@@ -115,7 +115,7 @@ public class ModulesTest extends TestCase {
             }
         }
         if (!badModules.isEmpty()) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for (Module module: badModules) {
                 System.err.println(module.toLongString());
                 sb.append("\n");

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
@@ -345,7 +345,7 @@ public class ClassLoaderWeavingAdaptor extends WeavingAdaptor {
 	 * @param definitions
 	 */
 	private void registerOptions(final BcelWeaver weaver, final ClassLoader loader, final List<Definition> definitions) {
-		StringBuffer allOptions = new StringBuffer();
+		StringBuilder allOptions = new StringBuilder();
 		for (Definition definition : definitions) {
 			allOptions.append(definition.getWeaverOptions()).append(' ');
 		}
@@ -956,7 +956,7 @@ public class ClassLoaderWeavingAdaptor extends WeavingAdaptor {
 	@Override
 	protected String getDumpDir() {
 		if (dumpDirPerClassloader) {
-			StringBuffer dir = new StringBuffer();
+			StringBuilder dir = new StringBuilder();
 			dir.append("_ajdump").append(File.separator).append(weavingContext.getId());
 			return dir.toString();
 		} else {

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ConcreteAspectCodeGen.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ConcreteAspectCodeGen.java
@@ -321,7 +321,7 @@ public class ConcreteAspectCodeGen {
 	 * @return string repr.
 	 */
 	private String stringify() {
-		StringBuffer sb = new StringBuffer("<concrete-aspect name='");
+		StringBuilder sb = new StringBuilder("<concrete-aspect name='");
 		sb.append(concreteAspect.name);
 		sb.append("' extends='");
 		sb.append(concreteAspect.extend);

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/ajc/BuildArgParser.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/ajc/BuildArgParser.java
@@ -708,7 +708,7 @@ public class BuildArgParser extends Main {
 			} else if (arg.equals("-bootclasspath")) {
 				if (args.size() > nextArgIndex) {
 					String bcpArg = args.get(nextArgIndex).getValue();
-					StringBuffer bcp = new StringBuffer();
+					StringBuilder bcp = new StringBuilder();
 					StringTokenizer strTok = new StringTokenizer(bcpArg, File.pathSeparator);
 					while (strTok.hasMoreTokens()) {
 						bcp.append(makeFile(strTok.nextToken()));
@@ -724,7 +724,7 @@ public class BuildArgParser extends Main {
 			} else if (arg.equals("-classpath") || arg.equals("-cp")) {
 				if (args.size() > nextArgIndex) {
 					String cpArg = args.get(nextArgIndex).getValue();
-					StringBuffer cp = new StringBuffer();
+					StringBuilder cp = new StringBuilder();
 					StringTokenizer strTok = new StringTokenizer(cpArg, File.pathSeparator);
 					while (strTok.hasMoreTokens()) {
 						cp.append(makeFile(strTok.nextToken()));
@@ -756,7 +756,7 @@ public class BuildArgParser extends Main {
 			} else if (arg.equals("-extdirs")) {
 				if (args.size() > nextArgIndex) {
 					String extdirsArg = args.get(nextArgIndex).getValue();
-					StringBuffer ed = new StringBuffer();
+					StringBuilder ed = new StringBuilder();
 					StringTokenizer strTok = new StringTokenizer(extdirsArg, File.pathSeparator);
 					while (strTok.hasMoreTokens()) {
 						ed.append(makeFile(strTok.nextToken()));

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjPipeliningCompilerAdapter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjPipeliningCompilerAdapter.java
@@ -230,7 +230,7 @@ public class AjPipeliningCompilerAdapter extends AbstractCompilerAdapter {
 				pipelineOutput = new Hashtable();
 			}
 			pipelineOutput.put("filesContainingAspects", Integer.toString(toWaitFor));
-			StringBuffer order = new StringBuffer();
+			StringBuilder order = new StringBuilder();
 			order.append("[");
 			for (int i = 0; i < units.length; i++) {
 				if (i != 0) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverAdapter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverAdapter.java
@@ -199,7 +199,7 @@ public class WeaverAdapter implements IClassFileProvider, IWeaveRequestor, Itera
 		AjClassFile ajcf = new AjClassFile(key, result.getBytes());
 		lastReturnedResult.result().record(ajcf.fileName(), ajcf);
 		if (!weaverMessageHandler.isIgnoring(IMessage.INFO) || progressListener != null) {
-			StringBuffer msg = new StringBuffer();
+			StringBuilder msg = new StringBuilder();
 			msg.append(progressPhasePrefix).append(result.getClassName()).append(" (from ").append(nowProcessing.fileName())
 					.append(")");
 			weaverMessageHandler.handleMessage(MessageUtil.info(msg.toString()));

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverMessageHandler.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverMessageHandler.java
@@ -113,7 +113,7 @@ public class WeaverMessageHandler implements IMessageHandler {
 				usedBinarySourceFileName);
 		problem.setSeeAlsoProblems(seeAlso);
 
-		StringBuffer details = new StringBuffer();
+		StringBuilder details = new StringBuilder();
 		// Stick more info in supplementary message info
 		if (message.getDetails() != null) {
 			details.append(message.getDetails());

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AdviceDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AdviceDeclaration.java
@@ -308,7 +308,7 @@ public class AdviceDeclaration extends AjMethodDeclaration {
 	}
 
 	private String buildArgNameRepresentation() {
-		StringBuffer args = new StringBuffer();
+		StringBuilder args = new StringBuilder();
 		int numArgsWeCareAbout = getDeclaredParameterCount();
 		if (this.arguments != null) {
 			for (int i = 0; i < numArgsWeCareAbout; i++) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/DeclareDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/DeclareDeclaration.java
@@ -75,7 +75,7 @@ public class DeclareDeclaration extends AjMethodDeclaration {
 			DeclareParents dp = (DeclareParents) declareDecl;
 			String childPattern = dp.getChild().toString();
 			Collection parentPatterns = dp.getParents().getExactTypes();
-			StringBuffer parents = new StringBuffer();
+			StringBuilder parents = new StringBuilder();
 			for (Iterator iter = parentPatterns.iterator(); iter.hasNext();) {
 				UnresolvedType urt = ((UnresolvedType) iter.next());
 				parents.append(urt.getName());
@@ -174,7 +174,7 @@ public class DeclareDeclaration extends AjMethodDeclaration {
 		super.postParse(typeDec);
 		int declareSequenceNumberInType = ((AspectDeclaration) typeDec).declareCounter++;
 		// FIXME asc the name should perhaps include the hashcode of the pattern (type/sig) for binary compatibility reasons!
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("ajc$declare");
 		// Declares can choose to provide a piece of the name - to enable
 		// them to be easily distinguised at weave time (e.g. see declare annotation)

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/IfPseudoToken.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/IfPseudoToken.java
@@ -139,7 +139,7 @@ public class IfPseudoToken extends PseudoToken {
 
 
 		// create a more stable name 277508
-		StringBuffer ifSelector = new StringBuffer();
+		StringBuilder ifSelector = new StringBuilder();
 		ifSelector.append("ajc$if$");
 		if (nameSuffix == null || nameSuffix.length()==0) {
 			boolean computedName = false;

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/PointcutDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/PointcutDeclaration.java
@@ -146,7 +146,7 @@ public class PointcutDeclaration extends AjMethodDeclaration {
 	}
 
 	private String buildArgNameRepresentation() {
-		StringBuffer args = new StringBuffer();
+		StringBuilder args = new StringBuilder();
 		if (this.arguments != null) {
 			for (int i = 0; i < this.arguments.length; i++) {
 				if (i != 0)

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/PointcutDesignator.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/PointcutDesignator.java
@@ -97,7 +97,7 @@ public class PointcutDesignator extends ASTNode {
 	}
 
 	public String getPointcutDeclarationText() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		PseudoToken[] toks = tokens.tokens;
 		for (int i = 0; i < (toks.length - 1); i++) {
 			sb.append(toks[i].getString());

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
@@ -942,7 +942,7 @@ public class AjLookupEnvironment extends LookupEnvironment implements AnonymousC
 		if ((bits & TagBits.AnnotationForType) != 0) {
 			s.add("TYPE");
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("{");
 		for (Iterator<String> iter = s.iterator(); iter.hasNext();) {
 			String element = iter.next();

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseResolvedMember.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseResolvedMember.java
@@ -171,7 +171,7 @@ public class EclipseResolvedMember extends ResolvedMemberImpl {
 					QualifiedNameReference qnr = (QualifiedNameReference) e;
 					if (qnr.binding instanceof FieldBinding) {
 						FieldBinding fb = (FieldBinding) qnr.binding;
-						StringBuffer sb = new StringBuffer();
+						StringBuilder sb = new StringBuilder();
 						sb.append(fb.declaringClass.signature());
 						sb.append(fb.name);
 						return sb.toString();

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseSourceLocation.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseSourceLocation.java
@@ -123,7 +123,7 @@ public class EclipseSourceLocation implements ISourceLocation {
 
     /** @return String {file:}line{:column} */
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         if (getSourceFile() != ISourceLocation.NO_FILE) {
             sb.append(getSourceFile().getPath());

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PushinCollector.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PushinCollector.java
@@ -133,7 +133,7 @@ public class PushinCollector {
 		}
 
 		// Process all types working from end to start as whatever we do (insert-wise) will affect locations later in the file
-		StringBuffer sourceContents = new StringBuffer();
+		StringBuilder sourceContents = new StringBuilder();
 		// put the whole original file in the buffer
 		boolean changed = false;
 		sourceContents.append(compilationUnitDeclaration.compilationResult.compilationUnit.getContents());
@@ -165,8 +165,8 @@ public class PushinCollector {
 			TypeReference sr = sourceTypeBinding.scope.referenceContext.superclass;
 			TypeReference[] trs = sourceTypeBinding.scope.referenceContext.superInterfaces;
 			List<ExactTypePattern> newParents = additionalParents.get(sourceTypeBinding);
-			StringBuffer extendsString = new StringBuffer();
-			StringBuffer implementsString = new StringBuffer();
+			StringBuilder extendsString = new StringBuilder();
+			StringBuilder implementsString = new StringBuilder();
 			if (newParents != null && newParents.size() > 0) {
 				for (ExactTypePattern newParent : newParents) {
 					ResolvedType newParentType = newParent.getExactType().resolve(world);
@@ -272,7 +272,7 @@ public class PushinCollector {
 	}
 
 	private String getOutputFileFor(CompilationUnitDeclaration unit) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 
 		// Create the directory portion of the output location
 		if (specifiedOutputDirectory != null) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
@@ -456,7 +456,7 @@ public class AjProblemReporter extends ProblemReporter {
 	}
 
 	private String typesAsString(boolean isVarargs, TypeBinding[] types, boolean makeShort) {
-		StringBuffer buffer = new StringBuffer(10);
+		StringBuilder buffer = new StringBuilder(10);
 		for (int i = 0, length = types.length; i < length; i++) {
 			if (i != 0)
 				buffer.append(", "); //$NON-NLS-1$
@@ -661,7 +661,7 @@ public class AjProblemReporter extends ProblemReporter {
 			ex.fillInStackTrace();
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(CompilationAndWeavingContext.getCurrentContext());
 			sb.append(sw.toString());
 			problem = new PinpointedProblem(problem, sb.toString());

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
@@ -98,7 +98,7 @@ public class AjBuildConfig implements CompilerConfigurationChangeFlags {
 
 	@Override
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("BuildConfig[" + (configFile == null ? "null" : configFile.getAbsoluteFile().toString()) + "] #Files="
 				+ files.size() + " AopXmls=#" + xmlfiles.size());
 		return sb.toString();

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
@@ -1301,7 +1301,7 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
 		if (buildConfig == null || buildConfig.getFullClasspath() == null) {
 			return "";
 		}
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		boolean first = true;
         for (String s : buildConfig.getFullClasspath()) {
             if (first) {
@@ -1393,7 +1393,7 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("AjBuildManager(");
 		buf.append(")");
 		return buf.toString();
@@ -1531,7 +1531,7 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
 
 		@Override
 		public String formatEntry(int phaseId, Object data) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			if (phaseId == CompilationAndWeavingContext.BATCH_BUILD) {
 				sb.append("batch building ");
 			} else {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjCompilerOptions.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjCompilerOptions.java
@@ -286,7 +286,7 @@ public class AjCompilerOptions extends CompilerOptions {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer(super.toString());
+		StringBuilder buf = new StringBuilder(super.toString());
 		// now add AspectJ additional options
 		buf.append("\n\tAspectJ Specific Options:");
 		buf.append("\n\t- terminate after compilation: ").append(this.terminateAfterCompilation ? ENABLED : DISABLED); //$NON-NLS-1$

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
@@ -802,7 +802,7 @@ public class AjState implements CompilerConfigurationChangeFlags, TypeDelegateRe
 
 	@Override
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		// null config means failed build i think as it is only set on successful full build?
 		sb.append("AjState(").append((buildConfig == null ? "NULLCONFIG" : buildConfig.getConfigFile().toString())).append(")");
 		return sb.toString();
@@ -2189,7 +2189,7 @@ public class AjState implements CompilerConfigurationChangeFlags, TypeDelegateRe
 	// }
 
 	private String stringifySet(Set<?> l) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("{");
 		for (Iterator<?> iter = l.iterator(); iter.hasNext();) {
 			Object el = iter.next();

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmElementFormatter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmElementFormatter.java
@@ -70,7 +70,7 @@ public class AsmElementFormatter {
 				node.setCorrespondingType(ad.returnType.toString()); // returnTypeToString(0));
 			}
 
-			StringBuffer details = new StringBuffer();
+			StringBuilder details = new StringBuilder();
 			if (ad.pointcutDesignator != null) {
 				details.append(AsmRelationshipUtils.genPointcutDetails(ad.pointcutDesignator.getPointcut()));
 			} else {
@@ -110,7 +110,7 @@ public class AsmElementFormatter {
 				node.setName(name + AsmRelationshipUtils.DECLARE_PARENTS);
 
 				String kindOfDP = null;
-				StringBuffer details = new StringBuffer("");
+				StringBuilder details = new StringBuilder("");
 				TypePattern[] newParents = dp.getParents().getTypePatterns();
 				for (int i = 0; i < newParents.length; i++) {
 					TypePattern tp = newParents[i];
@@ -248,7 +248,7 @@ public class AsmElementFormatter {
 	}
 
 	private String genDecaLabel(DeclareAnnotation deca) {
-		StringBuffer sb = new StringBuffer("");
+		StringBuilder sb = new StringBuilder("");
 		sb.append(deca.getPatternAsString());
 		sb.append(" : ");
 		sb.append(deca.getAnnotationString());

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmHierarchyBuilder.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmHierarchyBuilder.java
@@ -249,7 +249,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 			if (unitPackage == null) {
 				pkgName = "";
 			} else {
-				StringBuffer nameBuffer = new StringBuffer();
+				StringBuilder nameBuffer = new StringBuilder();
 				final char[][] importName = unitPackage.getImportName();
 				final int last = importName.length - 1;
 				for (int i = 0; i < importName.length; i++) {
@@ -357,7 +357,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 			String packageString = packageDecl.toString();
 			ProgramElement packageDeclaration = new ProgramElement(activeStructureModel, packageString,
 					IProgramElement.Kind.PACKAGE_DECLARATION, makeLocation(packageDecl), 0, null, null);
-			StringBuffer packageSourceDeclaration = new StringBuffer();
+			StringBuilder packageSourceDeclaration = new StringBuilder();
 			packageSourceDeclaration.append("package ");
 			packageSourceDeclaration.append(packageString);
 			packageSourceDeclaration.append(";");
@@ -914,7 +914,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 				if (star != 0 && (comment[star - 1] == '/') && (comment[star + 1] == '*')
 						&& (star - 2 < 0 || comment[star - 2] != '/')) {
 					boolean completed = false;
-					StringBuffer sb = new StringBuffer();
+					StringBuilder sb = new StringBuilder();
 					for (int i = 0; i < comment.length && !completed; i++) {
 						char curr = comment[i];
 						if (curr == '/' && sb.length() > 2 && sb.charAt(sb.length() - 1) == '*') {
@@ -985,7 +985,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 			stack.push(null); // a little weird but does the job
 			return true;
 		}
-		StringBuffer argumentsSignature = new StringBuffer();
+		StringBuilder argumentsSignature = new StringBuilder();
 		argumentsSignature.append("(");
 		if (constructorDeclaration.arguments != null) {
 			for (int i = 0; i < constructorDeclaration.arguments.length; i++) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/EclipseClassPathManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/EclipseClassPathManager.java
@@ -90,7 +90,7 @@ public class EclipseClassPathManager extends ClassPathManager {
 	 * @see java.lang.Object#toString()
 	 */
 	public String toString() {
-		StringBuffer buf = new StringBuffer("EclipseClassPathManager: ");
+		StringBuilder buf = new StringBuilder("EclipseClassPathManager: ");
 		buf.append(nameEnv.toString());
 		return buf.toString();
 	}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTConverter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTConverter.java
@@ -695,7 +695,7 @@ public class AjASTConverter extends ASTConverter {
 	}
 
 	private String updateString(String message) {
-		StringBuffer sb = new StringBuffer(message);
+		StringBuilder sb = new StringBuilder(message);
 		int nextQuote = sb.toString().indexOf("\"");
 		while (nextQuote != -1) {
 			sb.insert(nextQuote, "\\");

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
@@ -554,7 +554,7 @@ public class Main {
 		public static String render(IMessage message) {
 			// IMessage.Kind kind = message.getKind();
 
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			String text = message.getMessage();
 			if (text.equals(AbortException.NO_MESSAGE_TEXT)) {
 				text = null;

--- a/org.aspectj.ajdt.core/src/test/java/WeaveTest.java
+++ b/org.aspectj.ajdt.core/src/test/java/WeaveTest.java
@@ -237,7 +237,7 @@ public class WeaveTest {
 
 		for(int classcounter = 0; classcounter < NUMCLASSES; classcounter++) {
 
-			StringBuffer classfile = new StringBuffer(1000);
+			StringBuilder classfile = new StringBuilder(1000);
 
 			classfile.append("// Auto-generated" + NL);
 			classfile.append("package " + OUTPUT_PACKAGE + ";" + NL + NL);
@@ -281,7 +281,7 @@ public class WeaveTest {
 		}
 
 		if (INCLUDE_TEST_CLASSES) {
-			StringBuffer testFiles = new StringBuffer(1000);
+			StringBuilder testFiles = new StringBuilder(1000);
 
 			try {
 				testFiles.append("// Auto generated" + NL);
@@ -307,7 +307,7 @@ public class WeaveTest {
 				System.exit(-1);
 			}
 
-			testFiles = new StringBuffer(1000);
+			testFiles = new StringBuilder(1000);
 
 			try {
 				testFiles.append("// Auto generated" + NL);
@@ -334,7 +334,7 @@ public class WeaveTest {
 			}
 		}
 
-		StringBuffer buildList = new StringBuffer(100);
+		StringBuilder buildList = new StringBuilder(100);
 
 		for(int i = 0; i < NUMCLASSES; i++)
 			buildList.append("C" + i + ".java" + NL);
@@ -392,7 +392,7 @@ public class WeaveTest {
 
 	private static void createAllAspects(String adviceType, int pointcut) {
 
-		StringBuffer aspectFile = new StringBuffer(1000);
+		StringBuilder aspectFile = new StringBuilder(1000);
 
 		// Capitalises the first char in the adviceType String, and then adds "Advice" to it.
 		String adviceName = (char)(adviceType.charAt(0) - 32) + adviceType.substring(1) + "Advice";

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/ajdt/internal/compiler/batch/IncrementalCase.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/ajdt/internal/compiler/batch/IncrementalCase.java
@@ -48,7 +48,7 @@ public class IncrementalCase { // XXX NOT bound to junit - bridge tests?
     	IncrementalCase me = new IncrementalCase();
 		MessageHandler h = new MessageHandler();
 //		boolean result;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (String arg : args) {
 			sb.append("\n###### results for " + arg);
 			sb.append("\n" + me.run(new File(arg), h) + ": " + h);
@@ -177,7 +177,7 @@ public class IncrementalCase { // XXX NOT bound to junit - bridge tests?
 		log("verifyCompile -        def ", def, handler);
         log("verifyCompile -    command ", commandLine.toString(), handler);
 		log("verifyCompile -   messages ", compilerMessages, handler);
-        StringBuffer failures = new StringBuffer();
+        StringBuilder failures = new StringBuilder();
         if (def.expectFail == result) {
              failures.append("iteration " + iteration +
                 " expected to " + (def.expectFail ? "fail\n" : "pass"));
@@ -303,7 +303,7 @@ public class IncrementalCase { // XXX NOT bound to junit - bridge tests?
 		}
 		boolean result = true;
 		final int[] exp = new int[expected.length];
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("[");
 		for (int i = 0; i < exp.length; i++) {
 			String s = expected[i];

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
@@ -144,7 +144,7 @@ public abstract class AjcTestCase extends TestCase {
 		 */
 		public Message(int line, String srcFile, String text, ISourceLocation[] seeAlso) {
 			this.line = line;
-			StringBuffer srcFileName = new StringBuffer();
+			StringBuilder srcFileName = new StringBuilder();
 			if (srcFile != null) {
 				char[] chars = srcFile.toCharArray();
 				for (char c : chars) {
@@ -230,7 +230,7 @@ public abstract class AjcTestCase extends TestCase {
 		 */
 		@Override
 		public String toString() {
-			StringBuffer buff = new StringBuffer();
+			StringBuilder buff = new StringBuilder();
 			buff.append("message ");
 			if (sourceFileName != null) {
 				buff.append("in file ");
@@ -704,7 +704,7 @@ public abstract class AjcTestCase extends TestCase {
 		ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
 
 
-		StringBuffer command = new StringBuffer();
+		StringBuilder command = new StringBuilder();
 		command.append("java -classpath ");
 		command.append(cp.toString());
 		command.append(" ");

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/CompilationResult.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/CompilationResult.java
@@ -153,7 +153,7 @@ public class CompilationResult {
 	 */
 	@Override
 	public String toString() {
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		buff.append("AspectJ Compilation Result:\n");
 		int totalMessages = infoMessages.size() + warningMessages.size() + errorMessages.size() + failMessages.size() + weaveMessages.size();
 		buff.append(totalMessages);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AbstractAnnotationAJ.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AbstractAnnotationAJ.java
@@ -95,7 +95,7 @@ public abstract class AbstractAnnotationAJ implements AnnotationAJ {
 	 * {@inheritDoc}
 	 */
 	public final String getValidTargets() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("{");
 		for (Iterator<String> iter = supportedTargets.iterator(); iter.hasNext();) {
 			String evalue = iter.next();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Advice.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Advice.java
@@ -429,7 +429,7 @@ public abstract class Advice extends ShadowMunger {
 
 	@Override
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("(").append(getKind()).append(extraParametersToString());
 		sb.append(": ").append(pointcut).append("->").append(signature).append(")");
 		return sb.toString();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjcMemberMaker.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjcMemberMaker.java
@@ -255,7 +255,7 @@ public class AjcMemberMaker {
 			} else {
 				args = new UnresolvedType[] { fieldDeclaringType };
 			}
-			StringBuffer name = new StringBuffer("ajc$get$");
+			StringBuilder name = new StringBuilder("ajc$get$");
 			name.append(field.getName());
 			return new ResolvedMemberImpl(Member.METHOD, fieldDeclaringType, PUBLIC_STATIC, field.getReturnType(), name.toString(),
 					args);
@@ -289,7 +289,7 @@ public class AjcMemberMaker {
 			} else {
 				args = new UnresolvedType[] { fieldDeclaringType, field.getType() };
 			}
-			StringBuffer name = new StringBuffer("ajc$set$");
+			StringBuilder name = new StringBuilder("ajc$set$");
 			name.append(field.getName());
 			return new ResolvedMemberImpl(Member.METHOD, fieldDeclaringType, PUBLIC_STATIC, UnresolvedType.VOID, name.toString(),
 					args);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AnnotationNameValuePair.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AnnotationNameValuePair.java
@@ -31,13 +31,13 @@ public class AnnotationNameValuePair {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(name + "=" + val.toString());
 		return sb.toString();
 	}
 
 	public String stringify() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (!name.equals("value")) {
 			sb.append(name + "=");
 		}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ArrayAnnotationValue.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ArrayAnnotationValue.java
@@ -33,7 +33,7 @@ public class ArrayAnnotationValue extends AnnotationValue {
 	}
 
 	public String stringify() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("[");
 		for (int i = 0; i < values.length; i++) {
 			sb.append(values[i].stringify());
@@ -45,7 +45,7 @@ public class ArrayAnnotationValue extends AnnotationValue {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("{");
 		for (int i = 0; i < values.length; i++) {
 			sb.append(values[i].toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Checker.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Checker.java
@@ -192,7 +192,7 @@ public class Checker extends ShadowMunger {
 				return msg;
 			}
 		}
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		while (curlyIndex >= 0) {
 			if (curlyIndex > 0) {
 				ret.append(msg.substring(pos, curlyIndex).replace("\\{", "{"));

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/IntMap.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/IntMap.java
@@ -130,7 +130,7 @@ public class IntMap {
 	// ---- from object
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer("[");
+		StringBuilder buf = new StringBuilder("[");
 		boolean seenFirst = false;
 		for (int i = 0, len = map.length; i < len; i++) {
 			if (map[i] != MISSING) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/JoinPointSignature.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/JoinPointSignature.java
@@ -291,7 +291,7 @@ public class JoinPointSignature implements ResolvedMember {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(getReturnType().getName());
 		buf.append(' ');
 		buf.append(getDeclaringType().getName());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MemberImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MemberImpl.java
@@ -125,7 +125,7 @@ public class MemberImpl implements Member {
 	 * just deals with the parameter types.
 	 */
 	public static String typesToSignature(UnresolvedType[] paramTypes) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("(");
 		for (UnresolvedType paramType : paramTypes) {
 			buf.append(paramType.getSignature());
@@ -316,7 +316,7 @@ public class MemberImpl implements Member {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(returnType.getName());
 		buf.append(' ');
 		if (declaringType == null) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NameMangler.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NameMangler.java
@@ -327,13 +327,13 @@ public class NameMangler {
 	}
 
 	public static String aroundShadowMethodName(Member shadowSig, String suffixTag) {
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		ret.append(getExtractableName(shadowSig)).append("_aroundBody").append(suffixTag);
 		return ret.toString();
 	}
 
 	public static String aroundAdviceMethodName(Member shadowSig, String suffixTag) {
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		ret.append(getExtractableName(shadowSig)).append("_aroundBody").append(suffixTag).append("$advice");
 		return ret.toString();
 	}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ReferenceType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ReferenceType.java
@@ -1127,7 +1127,7 @@ public class ReferenceType extends ResolvedType {
 	private static String makeParameterizedSignature(ResolvedType aGenericType,
 			ResolvedType[] someParameters) {
 		String rawSignature = aGenericType.getErasureSignature();
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		ret.append(PARAMETERIZED_TYPE_IDENTIFIER);
 		ret.append(rawSignature.substring(1, rawSignature.length() - 1));
 		ret.append("<");
@@ -1140,7 +1140,7 @@ public class ReferenceType extends ResolvedType {
 
 	private static String makeDeclaredSignature(ResolvedType aGenericType,
 			UnresolvedType[] someParameters) {
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		String rawSig = aGenericType.getErasureSignature();
 		ret.append(rawSig.substring(0, rawSig.length() - 1));
 		ret.append("<");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedMemberImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedMemberImpl.java
@@ -468,7 +468,7 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 	 * @return the generic signature for the member that could be inserted into a class file
 	 */
 	public String getSignatureForAttribute() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (typeVariables != null) {
 			sb.append("<");
 			for (TypeVariable typeVariable : typeVariables) {
@@ -489,7 +489,7 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 	}
 
 	public String getGenericSignature() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (typeVariables != null) {
 			sb.append("<");
 			for (TypeVariable typeVariable : typeVariables) {
@@ -912,7 +912,7 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 					&& typeVariableMap.containsKey(((UnresolvedTypeVariableReferenceType) parameterizedComponentSig)
 							.getTypeVariable().getName())) { // pr250632
 				// TODO ASC bah, this code is rubbish - i should fix it properly
-				StringBuffer newsig = new StringBuffer();
+				StringBuilder newsig = new StringBuilder();
 				newsig.append("[T");
 				newsig.append(((UnresolvedTypeVariableReferenceType) parameterizedComponentSig).getTypeVariable().getName());
 				newsig.append(";");
@@ -1080,7 +1080,7 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 	}
 
 	public String getSignatureErased() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("(");
 		sb.append(getParameterSignatureErased());
 		sb.append(")");
@@ -1119,7 +1119,7 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 	 * Useful for writing tests, returns *everything* we know about this member.
 	 */
 	public String toDebugString() {
-		StringBuffer r = new StringBuffer();
+		StringBuilder r = new StringBuilder();
 
 		// modifiers
 		int mods = modifiers;
@@ -1188,7 +1188,7 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 	public static boolean showParameterNames = true;
 
 	public String toGenericString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(getGenericReturnType().getSimpleName());
 		buf.append(' ');
 		buf.append(declaringType.getName());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedPointcutDefinition.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedPointcutDefinition.java
@@ -64,7 +64,7 @@ public class ResolvedPointcutDefinition extends ResolvedMemberImpl {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("pointcut ");
 		buf.append((getDeclaringType() == null ? "<nullDeclaringType>" : getDeclaringType().getName()));
 		buf.append(".");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
@@ -1784,7 +1784,7 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 													.equals(newFieldTypeMunger.getSignature().getDeclaringType())) {
 
 										// report error on the aspect
-										StringBuffer sb = new StringBuffer();
+										StringBuilder sb = new StringBuilder();
 										sb.append("Cannot handle two aspects both attempting to use new style ITDs for the same named field ");
 										sb.append("on the same target type.  Please recompile at least one aspect with '-Xset:itdVersion=1'.");
 										sb.append(" Aspects involved: " + munger.getAspectType().getName() + " and "
@@ -2262,7 +2262,7 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 				int count = ret.getParameterTypes().length;
 				String[] paramNames = new String[count];
 				for (int i = 0; i < count; i++) {
-					paramNames[i] = new StringBuffer("dim").append(i).toString();
+					paramNames[i] = new StringBuilder("dim").append(i).toString();
 				}
 				ret.setParameterNames(paramNames);
 				return ret;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Shadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Shadow.java
@@ -657,7 +657,7 @@ public abstract class Shadow {
 	}
 
 	public String toResolvedString(World world) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(getKind());
 		sb.append("(");
 		Member m = getSignature();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/SignatureUtils.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/SignatureUtils.java
@@ -90,7 +90,7 @@ public class SignatureUtils {
 	// ---
 
 	private static String getHandlerSignatureString(Member m, World world) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(makeString(0));
 		buf.append('-');
 		// buf.append(getName());
@@ -109,7 +109,7 @@ public class SignatureUtils {
 	}
 
 	private static String getStaticInitializationSignatureString(Member m, World world) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(makeString(m.getModifiers(world)));
 		buf.append('-');
 		// buf.append(getName());
@@ -120,7 +120,7 @@ public class SignatureUtils {
 	}
 
 	protected static String getAdviceSignatureString(Member m, World world) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(makeString(m.getModifiers(world)));
 		buf.append('-');
 		buf.append(m.getName());
@@ -139,7 +139,7 @@ public class SignatureUtils {
 	}
 
 	protected static String getMethodSignatureString(Member m, World world) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(makeString(m.getModifiers(world)));
 		buf.append('-');
 		buf.append(m.getName());
@@ -158,7 +158,7 @@ public class SignatureUtils {
 	}
 
 	protected static String getMonitorSignatureString(Member m, World world) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(makeString(Modifier.STATIC)); // modifiers
 		buf.append('-');
 		buf.append(m.getName()); // name
@@ -173,7 +173,7 @@ public class SignatureUtils {
 	}
 
 	protected static String getConstructorSignatureString(Member m, World world) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(makeString(m.getModifiers(world)));
 		buf.append('-');
 		buf.append('-');
@@ -189,7 +189,7 @@ public class SignatureUtils {
 	}
 
 	protected static String getFieldSignatureString(Member m, World world) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(makeString(m.getModifiers(world)));
 		buf.append('-');
 		buf.append(m.getName());
@@ -218,7 +218,7 @@ public class SignatureUtils {
 	protected static String makeString(UnresolvedType[] types) {
 		if (types == null)
 			return "";
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		for (UnresolvedType type : types) {
 			buf.append(makeString(type));
 			buf.append(':');
@@ -229,7 +229,7 @@ public class SignatureUtils {
 	protected static String makeString(String[] names) {
 		if (names == null)
 			return "";
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		for (String name : names) {
 			buf.append(name);
 			buf.append(':');

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/StandardAnnotation.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/StandardAnnotation.java
@@ -45,7 +45,7 @@ public class StandardAnnotation extends AbstractAnnotationAJ {
 	 * {@inheritDoc}
 	 */
 	public String stringify() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("@").append(type.getClassName());
 		if (hasNameValuePairs()) {
 			sb.append("(");
@@ -58,7 +58,7 @@ public class StandardAnnotation extends AbstractAnnotationAJ {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("Anno[" + getTypeSignature() + " " + (isRuntimeVisible ? "rVis" : "rInvis"));
 		if (nvPairs != null) {
 			sb.append(" ");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
@@ -361,7 +361,7 @@ public class TypeFactory {
 	 * something with sig "Pcom/Foo&lt;Ljava/lang/String;&gt;;" signature created = "PSomeType&lt;Pcom/Foo&lt;Ljava/lang/String;&gt;;&gt;;"
 	 */
 	public static UnresolvedType createUnresolvedParameterizedType(String baseTypeSignature, UnresolvedType[] arguments) {
-		StringBuffer parameterizedSig = new StringBuffer();
+		StringBuilder parameterizedSig = new StringBuilder();
 		parameterizedSig.append(ResolvedType.PARAMETERIZED_TYPE_IDENTIFIER);
 		parameterizedSig.append(baseTypeSignature.substring(1, baseTypeSignature.length() - 1));
 		if (arguments.length > 0) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeVariable.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeVariable.java
@@ -224,7 +224,7 @@ public class TypeVariable {
 	}
 
 	public String getDisplayName() {
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		ret.append(name);
 		if (!getFirstBound().getName().equals("java.lang.Object")) {
 			ret.append(" extends ");
@@ -251,7 +251,7 @@ public class TypeVariable {
 	 * are parameterized types
 	 */
 	public String getSignature() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(name);
 		sb.append(":");
 		if (superInterfaces.length == 0 || !superclass.getSignature().equals(UnresolvedType.OBJECT.getSignature())) {
@@ -271,7 +271,7 @@ public class TypeVariable {
 	 * @return signature for inclusion in an attribute, there must be no 'P' in it signatures
 	 */
 	public String getSignatureForAttribute() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(name);
 		sb.append(":");
 		if (superInterfaces.length == 0 || !superclass.getSignature().equals(UnresolvedType.OBJECT.getSignature())) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeVariableReferenceType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeVariableReferenceType.java
@@ -117,7 +117,7 @@ public class TypeVariableReferenceType extends ReferenceType implements TypeVari
 	 */
 	@Override
 	public String getSignature() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("T");
 		sb.append(typeVariable.getName());
 		sb.append(";");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/UnresolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/UnresolvedType.java
@@ -451,7 +451,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 			name = name.substring(lastDot + 1);
 		}
 		if (isParameterizedType()) {
-			StringBuffer sb = new StringBuffer(name);
+			StringBuilder sb = new StringBuilder(name);
 			sb.append("<");
 			for (int i = 0; i < (typeParameters.length - 1); i++) {
 				sb.append(typeParameters[i].getSimpleName());
@@ -636,13 +636,13 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 			String name = signature.substring(1, signature.length() - 1).replace('/', '.');
 			return name;
 		case 'T':
-			StringBuffer nameBuff2 = new StringBuffer();
+			StringBuilder nameBuff2 = new StringBuilder();
 			int colon = signature.indexOf(";");
 			String tvarName = signature.substring(1, colon);
 			nameBuff2.append(tvarName);
 			return nameBuff2.toString();
 		case 'P': // it's one of our parameterized type sigs
-			StringBuffer nameBuff = new StringBuffer();
+			StringBuilder nameBuff = new StringBuilder();
 			// signature for parameterized types is e.g.
 			// List<String> -> Ljava/util/List<Ljava/lang/String;>;
 			// Map<String,List<Integer>> -> Ljava/util/Map<java/lang/String;Ljava/util/List<Ljava/lang/Integer;>;>;
@@ -656,7 +656,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 				case '<':
 					nameBuff.append("<");
 					paramNestLevel++;
-					StringBuffer innerBuff = new StringBuffer();
+					StringBuilder innerBuff = new StringBuilder();
 					while (paramNestLevel > 0) {
 						c = signature.charAt(++i);
 						if (c == '<') {
@@ -673,7 +673,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 							if (signature.charAt(i + 1) != '>') {
 								nameBuff.append(',');
 							}
-							innerBuff = new StringBuffer();
+							innerBuff = new StringBuilder();
 						}
 					}
 					nameBuff.append(">");
@@ -757,7 +757,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 			// not parameterized
 			return new StringBuilder("L").append(name.replace('.', '/')).append(';').toString();
 		} else {
-			StringBuffer nameBuff = new StringBuffer();
+			StringBuilder nameBuff = new StringBuilder();
 			int nestLevel = 0;
 			nameBuff.append("P");
 			for (int i = 0; i < len; i++) {
@@ -769,7 +769,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 				case '<':
 					nameBuff.append("<");
 					nestLevel++;
-					StringBuffer innerBuff = new StringBuffer();
+					StringBuilder innerBuff = new StringBuilder();
 					while (nestLevel > 0) {
 						c = name.charAt(++i);
 						if (c == '<') {
@@ -779,7 +779,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 						}
 						if (c == ',' && nestLevel == 1) {
 							nameBuff.append(nameToSignature(innerBuff.toString()));
-							innerBuff = new StringBuffer();
+							innerBuff = new StringBuilder();
 						} else {
 							if (nestLevel > 0) {
 								innerBuff.append(c);
@@ -957,7 +957,7 @@ public class UnresolvedType implements Traceable, TypeVariableDeclaringElement {
 	}
 
 	public static UnresolvedType makeArray(UnresolvedType base, int dims) {
-		StringBuffer sig = new StringBuffer();
+		StringBuilder sig = new StringBuilder();
 		for (int i = 0; i < dims; i++) {
 			sig.append("[");
 		}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/World.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/World.java
@@ -1910,7 +1910,7 @@ public abstract class World implements Dump.INode {
 					MessageUtil.info("Pointcut matching cost (total=" + (totalTime / 1000000) + "ms for " + joinpointCount
 							+ " joinpoint match calls):"));
 			for (String p : joinpointsPerPointcut.keySet()) {
-				StringBuffer sb = new StringBuffer();
+				StringBuilder sb = new StringBuilder();
 				sb.append("Time:" + (timePerPointcut.get(p) / 1000000) + "ms (jps:#" + joinpointsPerPointcut.get(p)
 						+ ") matching against " + p);
 				world.getMessageHandler().handleMessage(MessageUtil.info(sb.toString()));
@@ -1925,7 +1925,7 @@ public abstract class World implements Dump.INode {
 					MessageUtil.info("Pointcut fast matching cost (total=" + (totalTime / 1000000) + "ms for " + typeCount
 							+ " fast match calls):"));
 			for (String p : fastMatchTimesPerPointcut.keySet()) {
-				StringBuffer sb = new StringBuffer();
+				StringBuilder sb = new StringBuilder();
 				sb.append("Time:" + (fastMatchTimesPerPointcut.get(p) / 1000000) + "ms (types:#" + fastMatchTypesPerPointcut.get(p)
 						+ ") fast matching against " + p);
 				world.getMessageHandler().handleMessage(MessageUtil.info(sb.toString()));
@@ -1962,7 +1962,7 @@ public abstract class World implements Dump.INode {
 							MessageUtil.info("Pointcut matching cost (total=" + (totalTime / 1000000) + "ms for " + joinpointCount
 									+ " joinpoint match calls):"));
 					for (String p : joinpointsPerPointcut.keySet()) {
-						StringBuffer sb = new StringBuffer();
+						StringBuilder sb = new StringBuilder();
 						sb.append("Time:" + (timePerPointcut.get(p) / 1000000) + "ms (jps:#" + joinpointsPerPointcut.get(p)
 								+ ") matching against " + p);
 						world.getMessageHandler().handleMessage(MessageUtil.info(sb.toString()));
@@ -2000,7 +2000,7 @@ public abstract class World implements Dump.INode {
 							MessageUtil.info("Pointcut fast matching cost (total=" + (totalTime / 1000000) + "ms for " + typeCount
 									+ " fast match calls):"));
 					for (String p : fastMatchTimesPerPointcut.keySet()) {
-						StringBuffer sb = new StringBuffer();
+						StringBuilder sb = new StringBuilder();
 						sb.append("Time:" + (fastMatchTimesPerPointcut.get(p) / 1000000) + "ms (types:#"
 								+ fastMatchTypesPerPointcut.get(p) + ") fast matching against " + p);
 						world.getMessageHandler().handleMessage(MessageUtil.info(sb.toString()));

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AndTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AndTypePattern.java
@@ -130,7 +130,7 @@ public class AndTypePattern extends TypePattern {
 
 	@Override
 	public String toString() {
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		if (annotationPattern != AnnotationTypePattern.ANY) {
 			buff.append('(');
 			buff.append(annotationPattern.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPatternList.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPatternList.java
@@ -138,7 +138,7 @@ public class AnnotationPatternList extends PatternNode {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("(");
 		for (int i = 0, len = typePatterns.length; i < len; i++) {
 			AnnotationTypePattern type = typePatterns[i];

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPointcut.java
@@ -316,7 +316,7 @@ public class AnnotationPointcut extends NameBindingPointcut {
 	}
 
 	public void buildDeclarationText() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("@annotation(");
 		String annPatt = annotationTypePattern.toString();
 		buf.append(annPatt.startsWith("@") ? annPatt.substring(1) : annPatt);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ArgsAnnotationPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ArgsAnnotationPointcut.java
@@ -235,7 +235,7 @@ public class ArgsAnnotationPointcut extends NameBindingPointcut {
 	 * @see java.lang.Object#toString()
 	 */
 	private void buildDeclarationText() {
-		StringBuffer buf = new StringBuffer("@args");
+		StringBuilder buf = new StringBuilder("@args");
 		buf.append(arguments.toString());
 		this.declarationText = buf.toString();
 	}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/BasicTokenSource.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/BasicTokenSource.java
@@ -63,7 +63,7 @@ public class BasicTokenSource implements ITokenSource {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("[");
 		for (int i = 0; i < tokens.length; i++) {
 			IToken t = tokens[i];

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/Bindings.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/Bindings.java
@@ -69,7 +69,7 @@ public class Bindings {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer("Bindings(");
+		StringBuilder buf = new StringBuilder("Bindings(");
 		for (int i = 0, len = bindings.length; i < len; i++) {
 			if (i > 0)
 				buf.append(", ");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/CflowPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/CflowPointcut.java
@@ -316,7 +316,7 @@ public class CflowPointcut extends Pointcut {
 	}
 
 	private String getKey(Pointcut p, ResolvedType a, String stackOrCounter) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(a.getName());
 		sb.append("::");
 		sb.append(p.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareErrorOrWarning.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareErrorOrWarning.java
@@ -36,7 +36,7 @@ public class DeclareErrorOrWarning extends Declare {
 	 * returns "declare warning: &lt;message&gt;" or "declare error: &lt;message&gt;"
 	 */
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare ");
 		if (isError) {
 			buf.append("error: ");
@@ -118,7 +118,7 @@ public class DeclareErrorOrWarning extends Declare {
 	 * returns "declare warning" or "declare error"
 	 */
 	public String getName() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare ");
 		if (isError) {
 			buf.append("error");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareParents.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareParents.java
@@ -76,7 +76,7 @@ public class DeclareParents extends Declare {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare parents: ");
 		buf.append(child);
 		buf.append(isExtends ? " extends " : " implements "); // extends and implements are treated equivalently

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareParentsMixin.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareParentsMixin.java
@@ -66,7 +66,7 @@ public class DeclareParentsMixin extends DeclareParents {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare parents mixin: ");
 		buf.append(child);
 		buf.append(" implements ");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclarePrecedence.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclarePrecedence.java
@@ -47,7 +47,7 @@ public class DeclarePrecedence extends Declare {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare precedence: ");
 		buf.append(patterns);
 		buf.append(";");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareSoft.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareSoft.java
@@ -49,7 +49,7 @@ public class DeclareSoft extends Declare {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare soft: ");
 		buf.append(exception);
 		buf.append(": ");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareTypeErrorOrWarning.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareTypeErrorOrWarning.java
@@ -41,7 +41,7 @@ public class DeclareTypeErrorOrWarning extends Declare {
 	 * returns "declare warning: &lt;typepattern&gt;: &lt;message&gt;" or "declare error: &lt;typepattern&gt;: &lt;message&gt;"
 	 */
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare ");
 		if (isError) {
 			buf.append("error: ");
@@ -123,7 +123,7 @@ public class DeclareTypeErrorOrWarning extends Declare {
 	 * returns "declare type warning" or "declare type error"
 	 */
 	public String getName() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("declare type ");
 		if (isError) {
 			buf.append("error");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactAnnotationFieldTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactAnnotationFieldTypePattern.java
@@ -243,7 +243,7 @@ public class ExactAnnotationFieldTypePattern extends ExactAnnotationTypePattern 
 		if (!resolved && formalName != null) {
 			return formalName;
 		}
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		ret.append("@").append(annotationType.toString());
 		ret.append("(").append(formalName).append(")");
 		return ret.toString();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactTypePattern.java
@@ -284,7 +284,7 @@ public class ExactTypePattern extends TypePattern {
 
 	@Override
 	public String toString() {
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		if (annotationPattern != AnnotationTypePattern.ANY) {
 			buff.append('(');
 			buff.append(annotationPattern.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HandlerPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HandlerPointcut.java
@@ -84,7 +84,7 @@ public class HandlerPointcut extends Pointcut {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("handler(");
 		buf.append(exceptionType.toString());
 		buf.append(")");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePattern.java
@@ -162,7 +162,7 @@ public class HasMemberTypePattern extends TypePattern {
 
 	@Override
 	public String toString() {
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		if (signaturePattern.getKind() == Member.FIELD) {
 			buff.append("hasfield(");
 		} else {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
@@ -273,7 +273,7 @@ public class IfPointcut extends Pointcut {
 					} else {
 						if (state.size() == 0 || currentStateIndex > state.size()) {
 							String[] paramNames = testMethod.getParameterNames();
-							StringBuffer errorParameter = new StringBuffer();
+							StringBuilder errorParameter = new StringBuilder();
 							if (paramNames != null) {
 								errorParameter.append(testMethod.getParameterTypes()[i].getName()).append(" ");
 								errorParameter.append(paramNames[i]);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/KindedPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/KindedPointcut.java
@@ -309,7 +309,7 @@ public class KindedPointcut extends Pointcut {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(kind.getSimpleName());
 		buf.append("(");
 		buf.append(signature.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NotTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NotTypePattern.java
@@ -128,7 +128,7 @@ public class NotTypePattern extends TypePattern {
 
 	@Override
 	public String toString() {
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		if (annotationPattern != AnnotationTypePattern.ANY) {
 			buff.append('(');
 			buff.append(annotationPattern.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/OrTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/OrTypePattern.java
@@ -133,7 +133,7 @@ public class OrTypePattern extends TypePattern {
 	}
 
 	public String toString() {
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		if (annotationPattern != AnnotationTypePattern.ANY) {
 			buff.append('(');
 			buff.append(annotationPattern.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternParser.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/PatternParser.java
@@ -660,7 +660,7 @@ public class PatternParser {
 	private Pointcut parseDesignatorPointcut(PointcutDesignatorHandler pcdHandler) {
 		eat("(");
 		int parenCount = 1;
-		StringBuffer pointcutBody = new StringBuffer();
+		StringBuilder pointcutBody = new StringBuilder();
 		while (parenCount > 0) {
 			if (maybeEat("(")) {
 				parenCount++;
@@ -1203,7 +1203,7 @@ public class PatternParser {
 	private ExactAnnotationTypePattern parseSimpleAnnotationName() {
 		// the @ has already been eaten...
 		ExactAnnotationTypePattern p;
-		StringBuffer annotationName = new StringBuffer();
+		StringBuilder annotationName = new StringBuilder();
 		annotationName.append(parseIdentifier());
 		while (maybeEat(".")) {
 			annotationName.append('.');
@@ -1243,7 +1243,7 @@ public class PatternParser {
 
 	public List<NamePattern> parseDottedNamePattern() {
 		List<NamePattern> names = new ArrayList<>();
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		IToken previous = null;
 		boolean justProcessedEllipsis = false; // Remember if we just dealt with an ellipsis (PR61536)
 		boolean justProcessedDot = false;
@@ -1329,7 +1329,7 @@ public class PatternParser {
 
 	// supported form 'a.b.c.d' or just 'a'
 	public String parseAnnotationNameValuePattern() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		IToken tok;
 		// int startPos =
 		tokenSource.peek().getStart();
@@ -1379,7 +1379,7 @@ public class PatternParser {
 	}
 
 	public NamePattern parseNamePattern() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		IToken previous = null;
 		IToken tok;
 		int startPos = tokenSource.peek().getStart();
@@ -1765,7 +1765,7 @@ public class PatternParser {
 	}
 
 	public String parsePossibleStringSequence(boolean shouldEnd) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 
 		IToken token = tokenSource.next();
 		if (token.getLiteralKind() == null) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ReferencePointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ReferencePointcut.java
@@ -82,7 +82,7 @@ public class ReferencePointcut extends Pointcut {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		if (onType != null) {
 			buf.append(onType);
 			buf.append(".");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/SignaturePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/SignaturePattern.java
@@ -149,7 +149,7 @@ public class SignaturePattern extends PatternNode implements ISignaturePattern {
 
 	private void reportUnmatchedTargetKindMessage(AnnotationTargetKind[] annotationTargetKinds, PatternNode node, IScope scope,
 			boolean checkMatchesMemberKindName) {
-		StringBuffer targetNames = new StringBuffer("{");
+		StringBuilder targetNames = new StringBuilder("{");
 		for (int i = 0; i < annotationTargetKinds.length; i++) {
 			AnnotationTargetKind targetKind = annotationTargetKinds[i];
 			if (checkMatchesMemberKindName && kind.getName().equals(targetKind.getName())) {
@@ -819,7 +819,7 @@ public class SignaturePattern extends PatternNode implements ISignaturePattern {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		if (annotationPattern != AnnotationTypePattern.ANY) {
 			buf.append(annotationPattern.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ThisOrTargetAnnotationPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ThisOrTargetAnnotationPointcut.java
@@ -317,7 +317,7 @@ public class ThisOrTargetAnnotationPointcut extends NameBindingPointcut {
 	 * @see java.lang.Object#toString()
 	 */
 	private void buildDeclarationText() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(isThis ? "@this(" : "@target(");
 		String annPatt = annotationTypePattern.toString();
 		buf.append(annPatt.startsWith("@") ? annPatt.substring(1) : annPatt);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternList.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternList.java
@@ -72,7 +72,7 @@ public class TypePatternList extends PatternNode {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("(");
 		for (int i = 0, len = typePatterns.length; i < len; i++) {
 			TypePattern type = typePatterns[i];

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternQuestions.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternQuestions.java
@@ -51,7 +51,7 @@ public class TypePatternQuestions {
 	}
 
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("TypePatternQuestions{");
 		for (Map.Entry<Question,FuzzyBoolean> entry: questionsAndAnswers.entrySet()) {
 			Question question = (Question)entry.getKey();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypeVariablePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypeVariablePattern.java
@@ -171,7 +171,7 @@ public class TypeVariablePattern extends PatternNode {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(name);
 		sb.append(getExtendsClause());
 		if (interfaceBounds != null) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
@@ -569,7 +569,7 @@ public class WildTypePattern extends TypePattern {
 			throw new RuntimeException("bad name: " + namePatterns);
 		}
 		// System.out.println("get clean: " + this);
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		for (int i = 0, len = namePatterns.length; i < len; i++) {
 			NamePattern p = namePatterns[i];
 			String simpleName = p.maybeGetSimpleName();
@@ -1179,7 +1179,7 @@ public class WildTypePattern extends TypePattern {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		if (annotationPattern != AnnotationTypePattern.ANY) {
 			buf.append('(');
 			buf.append(annotationPattern.toString());

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WithinAnnotationPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WithinAnnotationPointcut.java
@@ -221,7 +221,7 @@ public class WithinAnnotationPointcut extends NameBindingPointcut {
 	 * @see java.lang.Object#toString()
 	 */
 	private void buildDeclarationText() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("@within(");
 		String annPatt = annotationTypePattern.toString();
 		buf.append(annPatt.startsWith("@") ? annPatt.substring(1) : annPatt);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WithinCodeAnnotationPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WithinCodeAnnotationPointcut.java
@@ -212,7 +212,7 @@ public class WithinCodeAnnotationPointcut extends NameBindingPointcut {
 	}
 
 	private void buildDeclarationText() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("@withincode(");
 		String annPatt = annotationTypePattern.toString();
 		buf.append(annPatt.startsWith("@") ? annPatt.substring(1) : annPatt);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/AbstractTrace.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/AbstractTrace.java
@@ -95,7 +95,7 @@ public abstract class AbstractTrace implements Trace {
 	 * Formatting
 	 */
 	protected String formatMessage(String kind, String className, String methodName, Object thiz, Object[] args) {
-		StringBuffer message = new StringBuffer();
+		StringBuilder message = new StringBuilder();
 		Date now = new Date();
 		message.append(formatDate(now)).append(" ");
 		message.append(Thread.currentThread().getName()).append(" ");
@@ -116,7 +116,7 @@ public abstract class AbstractTrace implements Trace {
 	}
 
 	protected String formatMessage(String kind, String text, Throwable th) {
-		StringBuffer message = new StringBuffer();
+		StringBuilder message = new StringBuilder();
 		Date now = new Date();
 		message.append(formatDate(now)).append(" ");
 		message.append(Thread.currentThread().getName()).append(" ");
@@ -193,7 +193,7 @@ public abstract class AbstractTrace implements Trace {
 	 * @return the formated list
 	 */
 	protected String formatArgs(Object[] args) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 
 		for (int i = 0; i < args.length; i++) {
 			sb.append(formatObj(args[i]));

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/PointcutParser.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/PointcutParser.java
@@ -559,7 +559,7 @@ public class PointcutParser {
 	}
 
 	private String buildUserMessageFromParserException(String pc, ParserException ex) {
-		StringBuffer msg = new StringBuffer();
+		StringBuilder msg = new StringBuilder();
 		msg.append("Pointcut is not well-formed: expecting '");
 		msg.append(ex.getMessage());
 		msg.append("'");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutParser.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutParser.java
@@ -485,7 +485,7 @@ public class StandardPointcutParser {
 	}
 
 	private String buildUserMessageFromParserException(String pc, ParserException ex) {
-		StringBuffer msg = new StringBuffer();
+		StringBuilder msg = new StringBuilder();
 		msg.append("Pointcut is not well-formed: expecting '");
 		msg.append(ex.getMessage());
 		msg.append("'");

--- a/org.aspectj.matcher/src/test/java/org/aspectj/weaver/patterns/ParserTestCase.java
+++ b/org.aspectj.matcher/src/test/java/org/aspectj/weaver/patterns/ParserTestCase.java
@@ -702,7 +702,7 @@ public class ParserTestCase extends PatternsTestCase {
 		Set<String> keys = m.keySet();
 		List<String> orderedKeys = new ArrayList<>(keys);
 		Collections.sort(orderedKeys);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (Iterator<String> iterator = orderedKeys.iterator(); iterator.hasNext();) {
 			String object = (String) iterator.next();
 			sb.append(object).append("=").append(m.get(object));

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/AdviceImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/AdviceImpl.java
@@ -118,7 +118,7 @@ public class AdviceImpl implements Advice {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (getName().length() > 0) {
 			sb.append("@AdviceName(\"");
 			sb.append(getName());

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareAnnotationImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareAnnotationImpl.java
@@ -72,7 +72,7 @@ public class DeclareAnnotationImpl implements DeclareAnnotation {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("declare @");
 		switch(getKind()) {
 		case Type:

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareErrorOrWarningImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareErrorOrWarningImpl.java
@@ -48,7 +48,7 @@ public class DeclareErrorOrWarningImpl implements DeclareErrorOrWarning {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("declare ");
 		sb.append(isError() ? "error : " : "warning : ");
 		sb.append(getPointcutExpression().asString());

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareParentsImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareParentsImpl.java
@@ -72,7 +72,7 @@ public class DeclareParentsImpl implements DeclareParents {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("declare parents : ");
 		sb.append(getTargetTypesPattern().asString());
 		sb.append(isExtends() ? " extends " : " implements ");

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareSoftImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareSoftImpl.java
@@ -53,7 +53,7 @@ public class DeclareSoftImpl implements DeclareSoft {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("declare soft : ");
 		if (this.missingTypeName != null) {
 			sb.append(this.exceptionType.getName());

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/InterTypeConstructorDeclarationImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/InterTypeConstructorDeclarationImpl.java
@@ -65,7 +65,7 @@ public class InterTypeConstructorDeclarationImpl extends
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(java.lang.reflect.Modifier.toString(getModifiers()));
 		sb.append(" ");
 		sb.append(this.targetTypeName);

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/InterTypeFieldDeclarationImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/InterTypeFieldDeclarationImpl.java
@@ -62,7 +62,7 @@ public class InterTypeFieldDeclarationImpl extends InterTypeDeclarationImpl
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(java.lang.reflect.Modifier.toString(getModifiers()));
 		sb.append(" ");
 		sb.append(getType().toString());

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/InterTypeMethodDeclarationImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/InterTypeMethodDeclarationImpl.java
@@ -101,7 +101,7 @@ public class InterTypeMethodDeclarationImpl extends InterTypeDeclarationImpl
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(java.lang.reflect.Modifier.toString(getModifiers()));
 		sb.append(" ");
 		sb.append(getReturnType().toString());

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/PointcutBasedPerClauseImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/PointcutBasedPerClauseImpl.java
@@ -35,7 +35,7 @@ public class PointcutBasedPerClauseImpl extends PerClauseImpl implements
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		switch(getKind()) {
 		case PERCFLOW: sb.append("percflow("); break;
 		case PERCFLOWBELOW: sb.append("percflowbelow("); break;

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/PointcutImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/PointcutImpl.java
@@ -81,7 +81,7 @@ public class PointcutImpl implements Pointcut {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(getName());
 		sb.append("(");
 		AjType<?>[] ptypes = getParameterTypes();

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/FieldSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/FieldSignatureImpl.java
@@ -39,7 +39,7 @@ public class FieldSignatureImpl extends MemberSignatureImpl implements FieldSign
     }
 
     protected String createToString(StringMaker sm) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append(sm.makeModifiersString(getModifiers()));
         if (sm.includeArgs) buf.append(sm.makeTypeName(getFieldType()));
         if (sm.includeArgs) buf.append(" ");

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/InitializerSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/InitializerSignatureImpl.java
@@ -36,7 +36,7 @@ class InitializerSignatureImpl extends CodeSignatureImpl implements InitializerS
     }
 
     protected String createToString(StringMaker sm) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append(sm.makeModifiersString(getModifiers()));
         buf.append(sm.makePrimaryTypeName(getDeclaringType(),getDeclaringTypeName()));
         buf.append(".");

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/JoinPointImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/JoinPointImpl.java
@@ -52,7 +52,7 @@ class JoinPointImpl implements ProceedingJoinPoint {
 		}
 
 		String toString(StringMaker sm) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(sm.makeKindName(getKind()));
 			buf.append("(");
 			buf.append(((SignatureImpl) getSignature()).toString(sm));

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc10.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc10.java
@@ -566,7 +566,7 @@ public class Ajc10 extends MatchingTask {
     /** utility to render String[] for logging */
     public static String render(String[] args) {
         if (null == args) return "";
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 		for (String arg : args) {
 			sb.append(arg);
 			sb.append(" ");

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -439,7 +439,7 @@ public class AjcTask extends MatchingTask {
 	}
 
 	protected String validCommaList(String list, List valid, String label, int max) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		StringTokenizer st = new StringTokenizer(list, ",");
 		int num = 0;
 		while (st.hasMoreTokens()) {
@@ -1253,7 +1253,7 @@ public class AjcTask extends MatchingTask {
 	 * @throws BuildException if options conflict
 	 */
 	protected void verifyOptions() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (fork && isInIncrementalMode() && !isInIncrementalFileMode()) {
 			sb.append("can fork incremental only using tag file.\n");
 		}
@@ -1333,7 +1333,7 @@ public class AjcTask extends MatchingTask {
 		{
 			IMessage[] fails = holder.getMessages(IMessage.FAIL, true);
 			if (!LangUtil.isEmpty(fails)) {
-				StringBuffer sb = new StringBuffer();
+				StringBuilder sb = new StringBuilder();
 				String prefix = "fail due to ";
 				int numThrown = 0;
 				for (IMessage fail : fails) {

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
@@ -190,7 +190,7 @@ public class Ajc extends DefaultCompilerAdapter {
 
         // Same behavior as DefaultCompilerAdapter.logAndAddFilesToCompile
         attributes.log("Compilation args: " + cmd.toString(), Project.MSG_VERBOSE);
-        StringBuffer niceSourceList = new StringBuffer("File");
+        StringBuilder niceSourceList = new StringBuilder("File");
         if (compileList.length != 1) {
             niceSourceList.append("s");
         }

--- a/testing-drivers/src/test/java/org/aspectj/testing/drivers/Harness.java
+++ b/testing-drivers/src/test/java/org/aspectj/testing/drivers/Harness.java
@@ -889,7 +889,7 @@ class TestMaker  {
 		if (fileName.endsWith(".java")) {
 			fileName = fileName.substring(0, fileName.length() - 5);
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String filePath = file.getParentFile().getAbsolutePath();
 		String dirPath = baseDir.getAbsolutePath();
 		String pack = null;
@@ -970,7 +970,7 @@ class TestMaker  {
 		} else if (null == dir) {
 			dir = new File(".");
 		}
-		StringBuffer testName = new StringBuffer();
+		StringBuilder testName = new StringBuilder();
 		int pr = spec.getBugId();
 		if (0 < pr) {
 			testName.append("PR#" + pr + " ");

--- a/testing-util/src/main/java/org/aspectj/testing/util/TestUtil.java
+++ b/testing-util/src/main/java/org/aspectj/testing/util/TestUtil.java
@@ -197,7 +197,7 @@ public final class TestUtil {
 		if ((null == entries) || (0 == entries.length)) {
 			return "";
 		}
-		StringBuffer path = new StringBuffer();
+		StringBuilder path = new StringBuilder();
 		boolean started = false;
 		for (Object entry : entries) {
 			if (null != entry) {

--- a/testing/src/test/java/org/aspectj/internal/tools/ant/taskdefs/Ajctest.java
+++ b/testing/src/test/java/org/aspectj/internal/tools/ant/taskdefs/Ajctest.java
@@ -1125,7 +1125,7 @@ public class Ajctest extends Task implements PropertyChangeListener {
                     if (null == current) {
                         oneLine = "\nRESULT=\"ERROR\" null ACJTEST";
                     } else {
-                        StringBuffer sb = new StringBuffer("\n");
+                        StringBuilder sb = new StringBuilder("\n");
                         int errs = Ajctest.allErrors.size();
                         int allFails = errs
                             + current.ajdocStats.fails

--- a/testing/src/test/java/org/aspectj/testing/CompileSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/CompileSpec.java
@@ -216,7 +216,7 @@ public class CompileSpec implements ITestStep {
 	public void setExtdirs(String extdirs) { this.extdirs = extdirs; }
 
 	protected String[] buildArgs() {
-		StringBuffer args = new StringBuffer();
+		StringBuilder args = new StringBuilder();
 		// add any set options, and then files to compile at the end
 		if (getAspectpath() != null) {
 			args.append("-aspectpath ");

--- a/testing/src/test/java/org/aspectj/testing/OutputSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/OutputSpec.java
@@ -104,7 +104,7 @@ public class OutputSpec {
 	}
 
 	private void createFailureMessage(String output, int lineNo, int sizeFound) {
-		StringBuffer failMessage = new StringBuffer();
+		StringBuilder failMessage = new StringBuilder();
 		failMessage.append("\n  expecting output:\n");
 		for (String line: expectedOutputLines) {
 			failMessage.append(line+"\n");

--- a/testing/src/test/java/org/aspectj/testing/WeaveSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/WeaveSpec.java
@@ -137,7 +137,7 @@ public class WeaveSpec extends CompileSpec {
 	}
 
 	private String[] buildWeaveArgs() {
-		StringBuffer args = new StringBuffer();
+		StringBuilder args = new StringBuilder();
 		if (getOptions() != null) {
 			StringTokenizer strTok = new StringTokenizer(getOptions(),",");
 			while (strTok.hasMoreTokens()) {

--- a/testing/src/test/java/org/aspectj/testing/XMLBasedAjcTestCase.java
+++ b/testing/src/test/java/org/aspectj/testing/XMLBasedAjcTestCase.java
@@ -429,7 +429,7 @@ public abstract class XMLBasedAjcTestCase extends AjcTestCase {
 	public String stringify(LocalVariableTable lvt, int slotIndex) {
 		LocalVariable lv[] = lvt.getLocalVariableTable();
 		LocalVariable lvEntry = lv[slotIndex];
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(lvEntry.getSignature()).append(" ").append(lvEntry.getName()).append("(").append(lvEntry.getIndex())
 				.append(") start=").append(lvEntry.getStartPC()).append(" len=").append(lvEntry.getLength());
 		return sb.toString();
@@ -437,7 +437,7 @@ public abstract class XMLBasedAjcTestCase extends AjcTestCase {
 
 	public String stringify(List<LocalVariable> l, int slotIndex) {
 		LocalVariable lvEntry = (LocalVariable) l.get(slotIndex);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(lvEntry.getSignature()).append(" ").append(lvEntry.getName()).append("(").append(lvEntry.getIndex())
 				.append(") start=").append(lvEntry.getStartPC()).append(" len=").append(lvEntry.getLength());
 		return sb.toString();
@@ -447,7 +447,7 @@ public abstract class XMLBasedAjcTestCase extends AjcTestCase {
 		if (lvt == null) {
 			return "";
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("LocalVariableTable.  Entries=#" + lvt.getTableLength()).append("\n");
 		LocalVariable lv[] = lvt.getLocalVariableTable();
 		for (LocalVariable lvEntry : lv) {

--- a/testing/src/test/java/org/aspectj/testing/ajde/CompileCommand.java
+++ b/testing/src/test/java/org/aspectj/testing/ajde/CompileCommand.java
@@ -260,7 +260,7 @@ class LoggingInvocationHandler implements InvocationHandler {
 	}
 
 	public static String render(Method method, Object[] args) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(render(method.getReturnType()));
 		sb.append(" ");
 		sb.append(method.getName());

--- a/testing/src/test/java/org/aspectj/testing/harness/bridge/AjcSpecTest.java
+++ b/testing/src/test/java/org/aspectj/testing/harness/bridge/AjcSpecTest.java
@@ -118,7 +118,7 @@ public class AjcSpecTest extends TestCase {
 
 	/** @return normal form for list items */
 	static String normal(List list) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("[");
 		boolean first = true;
 		for (Object o : list) {

--- a/testing/src/test/java/org/aspectj/testing/harness/bridge/CompilerRunSpecTest.java
+++ b/testing/src/test/java/org/aspectj/testing/harness/bridge/CompilerRunSpecTest.java
@@ -202,7 +202,7 @@ public class CompilerRunSpecTest extends TestCase {
         CRSOptions crsOptions = CompilerRun.Spec.testAccessToCRSOptions();
         Set options = crsOptions.compilerOptions();
         assertTrue(null != options);
-        StringBuffer notLoaded = new StringBuffer();
+        StringBuilder notLoaded = new StringBuilder();
 		for (Object option : options) {
 			Option compilerOption = (Option) option;
 			if (!(crsOptions.compilerIsLoadable(compilerOption))) {

--- a/testing/src/test/java/org/aspectj/testing/harness/bridge/DirChangesTest.java
+++ b/testing/src/test/java/org/aspectj/testing/harness/bridge/DirChangesTest.java
@@ -180,7 +180,7 @@ public class DirChangesTest extends TestCase {
                 actual[i] = null;
             }
 		}
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         {
             IMessage[] expNotFound = (IMessage[])
                 LangUtil.safeCopy(expected, new IMessage[0]);

--- a/testing/src/test/java/org/aspectj/testing/run/RunStatus.java
+++ b/testing/src/test/java/org/aspectj/testing/run/RunStatus.java
@@ -423,7 +423,7 @@ public class RunStatus implements IRunStatus {
 	}
 
 	public String toLongString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(BridgeUtil.toShortString(this));
 		if ((null != children) && (0 < children.size())) {
 			String label = "### --------- " + name;

--- a/testing/src/test/java/org/aspectj/testing/util/BridgeUtil.java
+++ b/testing/src/test/java/org/aspectj/testing/util/BridgeUtil.java
@@ -443,7 +443,7 @@ public class BridgeUtil {
         if (0 > numIncomplete) {
             numIncomplete = 0;
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (RunValidator.NORMAL.runPassed(runStatus)) {
             sb.append("PASS ");
         } else {
@@ -500,7 +500,7 @@ public class BridgeUtil {
         if (null == runStatus) {
             return "((RunStatus) null)";
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (RunValidator.NORMAL.runPassed(runStatus)) {
             sb.append("PASS ");
         } else {

--- a/testing/src/test/java/org/aspectj/testing/util/LangUtil.java
+++ b/testing/src/test/java/org/aspectj/testing/util/LangUtil.java
@@ -242,7 +242,7 @@ public class LangUtil {
         } else if (0 == ra.length) {
             return null;
         }
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         final String cname = LangUtil.unqualifiedClassName(superType);
 //        int index = 0;
         for (int i = 0; i < ra.length; i++) {
@@ -478,7 +478,7 @@ public class LangUtil {
      * @param errs the StringBuffer for error messages (if any)
      */
     public static String unsplit(String[] input, StringBuffer errs) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(SPLIT_START);
         for (int i = 0; i < input.length; i++) {
             if (input[i].contains(SPLIT_DELIM)) {
@@ -604,7 +604,7 @@ public class LangUtil {
         }
         boolean longFormat = (args.length < 10);
         String sep = (longFormat ? ", " : "\n\t");
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (!longFormat) sb.append("[");
         for (int i = 0; i < args.length; i++) {
             if (0 < i) sb.append(sep);
@@ -693,7 +693,7 @@ public class LangUtil {
         Class c = o.getClass();
         if (c.isArray()) {
             Object[] ra = (Object[]) o;
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append("[");
             for (int i = 0; i < ra.length; i++) {
                 if (i > 0) {
@@ -808,7 +808,7 @@ public class LangUtil {
         if (null == suffix) {
             suffix = SPLIT_END;
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (null != source) {
             sb.append(org.aspectj.util.LangUtil.unqualifiedClassName(source));
         }

--- a/testing/src/test/java/org/aspectj/testing/util/LineReader.java
+++ b/testing/src/test/java/org/aspectj/testing/util/LineReader.java
@@ -135,7 +135,7 @@ public class LineReader extends LineNumberReader {
      * @return the String containing all lines skipped (delimited with RETURN)
      */
     public String readToBlankLine() throws IOException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         String input;
         while (null != (input = nextLine(false))) { // get next empty line to restart
             sb.append(input);

--- a/testing/src/test/java/org/aspectj/testing/util/LinkCheck.java
+++ b/testing/src/test/java/org/aspectj/testing/util/LinkCheck.java
@@ -127,7 +127,7 @@ public class LinkCheck {
             long numChecked = me.checkedUrls.size();
             if (numChecked > 0) {
                 float cps = (float) duration  / (float) numChecked;
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append("DONE. Checked " + numChecked);
                 sb.append(" URL's in " + duration);
                 sb.append(" seconds (" + cps);

--- a/testing/src/test/java/org/aspectj/testing/util/UtilLineReader.java
+++ b/testing/src/test/java/org/aspectj/testing/util/UtilLineReader.java
@@ -135,7 +135,7 @@ public class UtilLineReader extends LineNumberReader {
      * @return the String containing all lines skipped (delimited with RETURN)
      */
     public String readToBlankLine() throws IOException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         String input;
         while (null != (input = nextLine(false))) { // get next empty line to restart
             sb.append(input);

--- a/testing/src/test/java/org/aspectj/testing/util/WebInstall.java
+++ b/testing/src/test/java/org/aspectj/testing/util/WebInstall.java
@@ -183,7 +183,7 @@ public class WebInstall {
         ms.invoke(null, new Object[] { args });
     }
     public static final String render(String[] args) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("[");
         for (int i = 0; i < args.length; i++) {
             if (0 < i) sb.append(", ");

--- a/testing/src/test/java/org/aspectj/testing/util/options/Options.java
+++ b/testing/src/test/java/org/aspectj/testing/util/options/Options.java
@@ -48,7 +48,7 @@ public class Options {
         if (0 == missed.length) {
             return null;
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("missed values: [");
         for (int i = 0; i < missed.length; i++) {
             if (i > 0) {

--- a/testing/src/test/java/org/aspectj/testing/util/options/Values.java
+++ b/testing/src/test/java/org/aspectj/testing/util/options/Values.java
@@ -680,7 +680,7 @@ public class Values {
             if (null == input) {
                 return "null";
             }
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append("[");
             for (int i = 0; i < input.length; i++) {
                 if (i > 0) {

--- a/testing/src/test/java/org/aspectj/testing/xml/MessageListXmlReader.java
+++ b/testing/src/test/java/org/aspectj/testing/xml/MessageListXmlReader.java
@@ -36,7 +36,7 @@ public class MessageListXmlReader {
     private static final String INLINE_DOCTYPE;
     static {
         final String EOL = LangUtil.EOL;
-        final StringBuffer r = new StringBuffer();
+        final StringBuilder r = new StringBuilder();
 
         r.append("<!DOCTYPE ");
         r.append(MessageList.XMLNAME);

--- a/testing/src/test/java/org/aspectj/testing/xml/SoftMessage.java
+++ b/testing/src/test/java/org/aspectj/testing/xml/SoftMessage.java
@@ -309,7 +309,7 @@ public class SoftMessage implements IMessage {
 	}
 
 	public String toString() {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 
 		result.append(null == getKind() ? "<null kind>" : getKind().toString());
 

--- a/testing/src/test/java/org/aspectj/testing/xml/XMLWriter.java
+++ b/testing/src/test/java/org/aspectj/testing/xml/XMLWriter.java
@@ -121,7 +121,7 @@ public class XMLWriter {
      * @throws IllegalArgumentException if list[i].toString() contains a comma
      */
     public static String flattenList(Object[] list) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (null != list) {
             boolean printed = false;
 			for (Object o : list) {
@@ -228,7 +228,7 @@ public class XMLWriter {
         if (0 < stack.size()) {
             indent += TAB;
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(indent);
         sb.append("<");
         sb.append(name);

--- a/tests/src/test/java/org/aspectj/systemtest/ajc150/GenericsTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc150/GenericsTests.java
@@ -880,7 +880,7 @@ public class GenericsTests extends XMLBasedAjcTestCase {
 	 */
 	public void checkMethodsExist(String classname,String[] methods) {
 		Set<String> methodsFound = new HashSet<>();
-		StringBuffer debugString = new StringBuffer();
+		StringBuilder debugString = new StringBuilder();
 		try {
 			ClassLoader cl = new URLClassLoader(new URL[]{ajc.getSandboxDirectory().toURI().toURL()});
 			Class<?> clz = Class.forName(classname,false,cl);
@@ -906,7 +906,7 @@ public class GenericsTests extends XMLBasedAjcTestCase {
 				fail("Couldn't find [" + string + "] in the set of methods in " + classname + " => " + debugString);
 			}
 		}
-		StringBuffer unexpectedMethods = new StringBuffer();
+		StringBuilder unexpectedMethods = new StringBuilder();
 		if (!methodsFound.isEmpty()) {
 			for (String element: methodsFound) {
 				unexpectedMethods.append("[").append(element).append("]");
@@ -959,7 +959,7 @@ public class GenericsTests extends XMLBasedAjcTestCase {
 		JavaClass clazz = getClass(ajc,classname);
 		Attribute[] attrs = clazz.getAttributes();
 		int signatureCount = 0;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (Attribute attribute : attrs) {
 			if (attribute.getName().equals("Signature")) {
 				signatureCount++;
@@ -979,7 +979,7 @@ public class GenericsTests extends XMLBasedAjcTestCase {
 
 	private static String stringify(Class<?>[] clazzes) {
 		if (clazzes==null) return "";
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < clazzes.length; i++) {
 			if (i>0) sb.append(",");
 			sb.append(clazzes[i].getName());

--- a/tests/src/test/java/org/aspectj/systemtest/ajc152/SynchronizationTransformTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc152/SynchronizationTransformTests.java
@@ -255,7 +255,7 @@ public class SynchronizationTransformTests extends XMLBasedAjcTestCase {
 	}
 
 	private String stringify(List<String> l) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		for (String str : l) {
 			result.append(str);
 			result.append("\n");

--- a/tests/src/test/java/org/aspectj/systemtest/ajc169/TransparentWeavingTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc169/TransparentWeavingTests.java
@@ -159,7 +159,7 @@ public class TransparentWeavingTests extends org.aspectj.testing.XMLBasedAjcTest
 		try {
 			JavaClass jc = getClassFrom(ajc.getSandboxDirectory(), clazzname);
 			Field[] fs = jc.getFields();
-			StringBuffer fields = new StringBuffer();
+			StringBuilder fields = new StringBuilder();
 			for (Field f : fs) {
 				fields.append(f.getName()).append(" ");
 				if (f.getName().equals(name)) {
@@ -175,7 +175,7 @@ public class TransparentWeavingTests extends org.aspectj.testing.XMLBasedAjcTest
 	private Field checkForField(String clazzname, int modifiers, String name) throws Exception {
 		JavaClass jc = getClassFrom(ajc.getSandboxDirectory(), clazzname);
 		Field[] fs = jc.getFields();
-		StringBuffer fields = new StringBuffer();
+		StringBuilder fields = new StringBuilder();
 		for (Field f : fs) {
 			fields.append(f.getName()).append(" ");
 			if (f.getName().equals(name)) {
@@ -192,7 +192,7 @@ public class TransparentWeavingTests extends org.aspectj.testing.XMLBasedAjcTest
 	private Method checkForMethod(String clazzname, int modifiers, String name) throws Exception {
 		JavaClass jc = getClassFrom(ajc.getSandboxDirectory(), clazzname);
 		Method[] fs = jc.getMethods();
-		StringBuffer methods = new StringBuffer();
+		StringBuilder methods = new StringBuilder();
 		methods.append("\n");
 		for (Method f : fs) {
 			methods.append(f.getName()).append("\n");

--- a/tests/src/test/java/org/aspectj/systemtest/incremental/tools/AjdeInteractionTestbed.java
+++ b/tests/src/test/java/org/aspectj/systemtest/incremental/tools/AjdeInteractionTestbed.java
@@ -386,7 +386,7 @@ public class AjdeInteractionTestbed extends TestCase {
 	 * Helper method for dumping info about which files were compiled and woven during the last build.
 	 */
 	public String printCompiledAndWovenFiles(String projectName) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (getCompiledFiles(projectName).size() == 0 && getWovenClasses(projectName).size() == 0) {
 			sb.append("No files were compiled or woven\n");
 		}

--- a/tests/src/test/java/org/aspectj/systemtest/incremental/tools/MultiProjTestCompilerConfiguration.java
+++ b/tests/src/test/java/org/aspectj/systemtest/incremental/tools/MultiProjTestCompilerConfiguration.java
@@ -62,7 +62,7 @@ public class MultiProjTestCompilerConfiguration implements ICompilerConfiguratio
 	public String getClasspath() {
 		log("ICompilerConfiguration.getClasspath()");
 		// AJDT has all the output directories on it's classpath
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		List<File> allOutputPaths = getOutputLocationManager().getAllOutputLocations();
 		for (File dir: allOutputPaths) {
 			sb.append(File.pathSeparator + dir.getAbsolutePath());

--- a/tests/src/test/java/org/aspectj/systemtest/incremental/tools/MultiProjectIncrementalTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/incremental/tools/MultiProjectIncrementalTests.java
@@ -2208,7 +2208,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 	}
 
 	private String toString(List<ResolvedMember> list) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (ResolvedMember m : list) {
 			sb.append(m).append("\n");
 		}
@@ -2216,7 +2216,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 	}
 
 	private String typeListToString(List<String> list) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (String m : list) {
 			sb.append(m).append("\n");
 		}
@@ -2224,7 +2224,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 	}
 
 	private String toString(List<ResolvedMember> one, List<ResolvedMember> two, boolean shouldIncludeGenerics) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("Through iterator\n");
 		for (ResolvedMember m : one) {
 			sb.append(m).append("\n");
@@ -2237,7 +2237,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 	}
 
 	private String typeListsToString(List<String> one, List<String> two) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("Through iterator\n");
 		for (String m : one) {
 			sb.append(">" + m).append("\n");
@@ -3901,7 +3901,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 	 */
 	private List<String> getRelatedElements(AsmManager model, IProgramElement programElement, int expected) {
 		List<String> relatedElements = getRelatedElements(model, programElement);
-		StringBuffer debugString = new StringBuffer();
+		StringBuilder debugString = new StringBuilder();
 		if (relatedElements != null) {
 			for (String element : relatedElements) {
 				debugString.append(model.getHierarchy().findElementForHandle(element).toLabelString()).append("\n");

--- a/util/src/main/java/org/aspectj/util/FileUtil.java
+++ b/util/src/main/java/org/aspectj/util/FileUtil.java
@@ -336,7 +336,7 @@ public class FileUtil {
 		if (null == infix) {
 			infix = File.pathSeparator;
 		}
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		boolean first = true;
         for (String path : paths) {
             if (null == path) {
@@ -1131,7 +1131,7 @@ public class FileUtil {
 	 */
 	public static String readAsString(File file) throws IOException {
 		BufferedReader r = new BufferedReader(new FileReader(file));
-		StringBuffer b = new StringBuffer();
+		StringBuilder b = new StringBuilder();
 		while (true) {
 			int ch = r.read();
 			if (ch == -1) {

--- a/util/src/main/java/org/aspectj/util/GenericSignature.java
+++ b/util/src/main/java/org/aspectj/util/GenericSignature.java
@@ -27,7 +27,7 @@ public class GenericSignature {
 		public ClassTypeSignature[] superInterfaceSignatures = ClassTypeSignature.NONE;
 
 		public String toString() {
-			StringBuffer ret = new StringBuffer();
+			StringBuilder ret = new StringBuilder();
 			ret.append(formalTypeParameters.toString());
 			ret.append(superclassSignature.toString());
 			for (ClassTypeSignature superInterfaceSignature : superInterfaceSignatures) {
@@ -52,7 +52,7 @@ public class GenericSignature {
 		}
 
 		public String toString() {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			if (formalTypeParameters.length > 0) {
 				sb.append("<");
 				for (FormalTypeParameter formalTypeParameter : formalTypeParameters) {
@@ -84,7 +84,7 @@ public class GenericSignature {
 		public FieldTypeSignature[] interfaceBounds;
 
 		public String toString() {
-			StringBuffer ret = new StringBuffer();
+			StringBuilder ret = new StringBuilder();
 			ret.append("T");
 			ret.append(identifier);
 			ret.append(":");
@@ -208,7 +208,7 @@ public class GenericSignature {
 		}
 
 		public String toString() {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(identifier);
 			if (typeArguments.length > 0) {
 				sb.append("<");
@@ -240,7 +240,7 @@ public class GenericSignature {
 		public String toString() {
 			if (isWildcard)
 				return "*";
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			if (isPlus)
 				sb.append("+");
 			if (isMinus)

--- a/util/src/main/java/org/aspectj/util/GenericSignatureParser.java
+++ b/util/src/main/java/org/aspectj/util/GenericSignatureParser.java
@@ -318,7 +318,7 @@ public class GenericSignatureParser {
 		char[] chars = signatureString.toCharArray();
 		int index = 0;
 		List<String> tokens = new ArrayList<>();
-		StringBuffer identifier = new StringBuffer();
+		StringBuilder identifier = new StringBuilder();
 		boolean inParens = false;
 		boolean inArray = false;
 		boolean couldSeePrimitive = false;
@@ -327,32 +327,32 @@ public class GenericSignatureParser {
 			case '<':
 				if (identifier.length() > 0)
 					tokens.add(identifier.toString());
-				identifier = new StringBuffer();
+				identifier = new StringBuilder();
 				tokens.add("<");
 				break;
 			case '>':
 				if (identifier.length() > 0)
 					tokens.add(identifier.toString());
-				identifier = new StringBuffer();
+				identifier = new StringBuilder();
 				tokens.add(">");
 				break;
 			case ':':
 				if (identifier.length() > 0)
 					tokens.add(identifier.toString());
-				identifier = new StringBuffer();
+				identifier = new StringBuilder();
 				tokens.add(":");
 				break;
 			case '/':
 				if (identifier.length() > 0)
 					tokens.add(identifier.toString());
-				identifier = new StringBuffer();
+				identifier = new StringBuilder();
 				tokens.add("/");
 				couldSeePrimitive = false;
 				break;
 			case ';':
 				if (identifier.length() > 0)
 					tokens.add(identifier.toString());
-				identifier = new StringBuffer();
+				identifier = new StringBuilder();
 				tokens.add(";");
 				couldSeePrimitive = true;
 				inArray = false;
@@ -360,7 +360,7 @@ public class GenericSignatureParser {
 			case '^':
 				if (identifier.length() > 0)
 					tokens.add(identifier.toString());
-				identifier = new StringBuffer();
+				identifier = new StringBuilder();
 				tokens.add("^");
 				break;
 			case '+':
@@ -375,7 +375,7 @@ public class GenericSignatureParser {
 			case '.':
 				if (identifier.length() > 0)
 					tokens.add(identifier.toString());
-				identifier = new StringBuffer();
+				identifier = new StringBuilder();
 				couldSeePrimitive = false;
 				tokens.add(".");
 				break;

--- a/util/src/main/java/org/aspectj/util/LangUtil.java
+++ b/util/src/main/java/org/aspectj/util/LangUtil.java
@@ -805,7 +805,7 @@ public class LangUtil {
 		if (LangUtil.isEmpty(in) || LangUtil.isEmpty(sought)) {
 			return in;
 		}
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		final int len = sought.length();
 		int start = 0;
 		int loc;

--- a/util/src/test/java/org/aspectj/util/FileUtilTest.java
+++ b/util/src/test/java/org/aspectj/util/FileUtilTest.java
@@ -487,7 +487,7 @@ public class FileUtilTest extends TestCase {
 		final String prefix = new File(tempDir, "testLineSeek").getPath();
 		// setup files 0..MAX with 2*MAX lines
 		String[] sources = new String[MAX];
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < sources.length; i++) {
 			sources[i] = new File(prefix + i).getPath();
 			sb.append("not matched");
@@ -604,7 +604,7 @@ public class FileUtilTest extends TestCase {
 
 	public void testPipe() {
 		String str = "The quick brown fox jumped over the lazy dog";
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < 4096; i++) {
 			sb.append(str);
 		}

--- a/util/src/test/java/org/aspectj/util/GenericSignatureParserTest.java
+++ b/util/src/test/java/org/aspectj/util/GenericSignatureParserTest.java
@@ -216,7 +216,7 @@ public class GenericSignatureParserTest extends TestCase {
 	}
 
 	private String tokensToString(String[] tokens) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(tokens[0]);
 		for (int i = 1; i < tokens.length; i++) {
 			sb.append(",");

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
@@ -856,7 +856,7 @@ public class AtAjAttributes {
 	 * @return a nicely formatted method string, for example: int X.foo(java.lang.String)
 	 */
 	public static String getMethodForMessage(AjAttributeMethodStruct methodstructure) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("Method '");
 		sb.append(methodstructure.method.getReturnType().toString());
 		sb.append(" ").append(methodstructure.enclosingType).append(".").append(methodstructure.method.getName());
@@ -1533,7 +1533,7 @@ public class AtAjAttributes {
 	 * @return a readable representation of a method
 	 */
 	private static String methodToString(Method method) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(method.getName());
 		sb.append(method.getSignature());
 		return sb.toString();
@@ -1811,7 +1811,7 @@ public class AtAjAttributes {
 			args.add(st.nextToken());
 		}
 		if (args.size() != method.getArgumentTypes().length) {
-			StringBuffer shortString = new StringBuffer().append(lastbit(method.getReturnType().toString())).append(" ")
+			StringBuilder shortString = new StringBuilder().append(lastbit(method.getReturnType().toString())).append(" ")
 					.append(method.getName());
 			if (method.getArgumentTypes().length > 0) {
 				shortString.append("(");

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelAnnotation.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelAnnotation.java
@@ -45,7 +45,7 @@ public class BcelAnnotation extends AbstractAnnotationAJ {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		List<NameValuePair> nvPairs = bcelAnnotation.getValues();
 		sb.append("Anno[" + getTypeSignature() + " " + (isRuntimeVisible() ? "rVis" : "rInvis"));
 		if (nvPairs.size() > 0) {
@@ -104,7 +104,7 @@ public class BcelAnnotation extends AbstractAnnotationAJ {
 	 */
 	@Override
 	public String stringify() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("@").append(type.getClassName());
 		List<NameValuePair> values = bcelAnnotation.getValues();
 		if (values != null && values.size() != 0) {

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
@@ -856,7 +856,7 @@ class BcelClassWeaver implements IClassWeaver {
 				checkForOverride(interfaceType, name, psig, rsig, bridgeToCandidate.getAccessFlags(),
 						clazz.getPackageName(), bm, overriddenMethodsCollector);
 				for (ResolvedMember overriddenMethod : overriddenMethodsCollector) {
-					String key = new StringBuffer().append(overriddenMethod.getName()).append(overriddenMethod.getSignatureErased()).toString(); // pr237419
+					String key = new StringBuilder().append(overriddenMethod.getName()).append(overriddenMethod.getSignatureErased()).toString(); // pr237419
 					boolean alreadyHaveABridgeMethod = methodsSet.contains(key);
 					if (!alreadyHaveABridgeMethod) {
 						if (bridges== null) {
@@ -1103,7 +1103,7 @@ class BcelClassWeaver implements IClassWeaver {
 	private void reportMethodCtorWeavingMessage(LazyClassGen clazz, ResolvedMember member, DeclareAnnotation decaM,
 			int memberLineNumber) {
 		if (!getWorld().getMessageHandler().isIgnoring(IMessage.WEAVEINFO)) {
-			StringBuffer parmString = new StringBuffer("(");
+			StringBuilder parmString = new StringBuilder("(");
 			UnresolvedType[] paramTypes = member.getParameterTypes();
 			for (int i = 0; i < paramTypes.length; i++) {
 				UnresolvedType type = paramTypes[i];
@@ -1118,7 +1118,7 @@ class BcelClassWeaver implements IClassWeaver {
 			}
 			parmString.append(")");
 			String methodName = member.getName();
-			StringBuffer sig = new StringBuffer();
+			StringBuilder sig = new StringBuilder();
 			sig.append(org.aspectj.apache.bcel.classfile.Utility.accessToString(member.getModifiers()));
 			sig.append(" ");
 			sig.append(member.getReturnType().toString());
@@ -1128,7 +1128,7 @@ class BcelClassWeaver implements IClassWeaver {
 			sig.append(methodName.equals("<init>") ? "new" : methodName);
 			sig.append(parmString);
 
-			StringBuffer loc = new StringBuffer();
+			StringBuilder loc = new StringBuilder();
 			if (clazz.getFileName() == null) {
 				loc.append("no debug info available");
 			} else {

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelGenericSignatureToTypeXConverter.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelGenericSignatureToTypeXConverter.java
@@ -52,7 +52,7 @@ public class BcelGenericSignatureToTypeXConverter {
 		// each type in the hierarchy may have type arguments
 
 		// first build the 'raw type' signature
-		StringBuffer sig = new StringBuffer();
+		StringBuilder sig = new StringBuilder();
 		sig.append(aClassTypeSignature.outerType.identifier.replace(';', ' ').trim());
 		for (int i = 0; i < aClassTypeSignature.nestedTypes.length; i++) {
 			sig.append("$");

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
@@ -2403,7 +2403,7 @@ public class BcelShadow extends Shadow {
 				// rather than fail. If a bug is raised reporting unknown as a local variable name
 				// then investigate the joinpoint giving rise to the ResolvedMember and why it has
 				// no parameter names specified
-				argumentName = new StringBuffer("unknown").append(argNumber).toString();
+				argumentName = new StringBuilder("unknown").append(argNumber).toString();
 			} else {
 				argumentName = parameterNames.get(argNumber);
 			}

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
@@ -616,7 +616,7 @@ public class BcelTypeMunger extends ConcreteTypeMunger {
 	 * Creates a nice signature for the ctor, something like "(int,Integer,String)"
 	 */
 	private String createReadableCtorSig(ResolvedType newParent, ConstantPool cpg, InvokeInstruction invokeSpecial) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		Type[] ctorArgs = invokeSpecial.getArgumentTypes(cpg);
 		sb.append(newParent.getClassName());
 		sb.append("(");
@@ -1338,7 +1338,7 @@ public class BcelTypeMunger extends ConcreteTypeMunger {
 
 	// Unlike toString() on a member, this does not include the declaring type
 	private String stringifyMember(ResolvedMember member) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(member.getReturnType().getName());
 		buf.append(' ');
 		buf.append(member.getName());

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWeaver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWeaver.java
@@ -400,7 +400,7 @@ public class BcelWeaver {
 
 						if (filename.endsWith(".class")) {
 							ReferenceType type = this.addClassFile(classFile, false);
-							StringBuffer sb = new StringBuffer();
+							StringBuilder sb = new StringBuilder();
 							sb.append(inFile.getAbsolutePath());
 							sb.append("!");
 							sb.append(entry.getName());
@@ -472,7 +472,7 @@ public class BcelWeaver {
 		if (filename.endsWith(".class")) {
 			// System.err.println(
 			// "BCELWeaver: processing class from input directory "+classFile);
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(inPathDir.getAbsolutePath());
 			sb.append("!");
 			sb.append(filename);

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWorld.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWorld.java
@@ -229,7 +229,7 @@ public class BcelWorld extends World implements Repository {
 	 * Ensure we report a nice source location - particular in the case where the source info is missing (binary weave).
 	 */
 	private String beautifyLocation(ISourceLocation isl) {
-		StringBuffer nice = new StringBuffer();
+		StringBuilder nice = new StringBuilder();
 		if (isl == null || isl.getSourceFile() == null || isl.getSourceFile().getName().contains("no debug info available")) {
 			nice.append("no debug info available");
 		} else {
@@ -464,7 +464,7 @@ public class BcelWorld extends World implements Repository {
 
 		if (resolvedTypeFromTypeMap != null && !(resolvedTypeFromTypeMap instanceof ReferenceType)) {
 			// what on earth is it then? See pr 112243
-			StringBuffer exceptionText = new StringBuffer();
+			StringBuilder exceptionText = new StringBuilder();
 			exceptionText.append("Found invalid (not a ReferenceType) entry in the type map. ");
 			exceptionText.append("Signature=[" + signature + "] Found=[" + resolvedTypeFromTypeMap + "] Class=[" + resolvedTypeFromTypeMap.getClass() + "]");
 			throw new BCException(exceptionText.toString());
@@ -500,7 +500,7 @@ public class BcelWorld extends World implements Repository {
 
 		if (resolvedTypeFromTypeMap != null && !(resolvedTypeFromTypeMap instanceof ReferenceType)) {
 			// what on earth is it then? See pr 112243
-			StringBuffer exceptionText = new StringBuffer();
+			StringBuilder exceptionText = new StringBuilder();
 			exceptionText.append("Found invalid (not a ReferenceType) entry in the type map. ");
 			exceptionText.append("Signature=[" + signature + "] Found=[" + resolvedTypeFromTypeMap + "] Class=[" + resolvedTypeFromTypeMap.getClass() + "]");
 			throw new BCException(exceptionText.toString());
@@ -686,7 +686,7 @@ public class BcelWorld extends World implements Repository {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("BcelWorld(");
 		// buf.append(shadowMungerMap);
 		buf.append(")");

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/ClassPathManager.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/ClassPathManager.java
@@ -156,7 +156,7 @@ public class ClassPathManager {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		boolean start = true;
 		for (Entry entry : entries) {
 			if (start) {

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
@@ -675,7 +675,7 @@ public final class LazyClassGen {
 		}
 
 		if (needAttribute) {
-			StringBuffer signature = new StringBuffer();
+			StringBuilder signature = new StringBuilder();
 			// first, the type variables...
 			if (myType != null) {
 				TypeVariable[] tVars = myType.getTypeVariables();

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/LazyMethodGen.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/LazyMethodGen.java
@@ -553,7 +553,7 @@ public final class LazyMethodGen implements Traceable {
 	public String toShortString() {
 		String access = org.aspectj.apache.bcel.classfile.Utility.accessToString(getAccessFlags());
 
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		if (!access.equals("")) {
 			buf.append(access);

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/Utility.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/Utility.java
@@ -111,7 +111,7 @@ public class Utility {
 	 * Ensure we report a nice source location - particular in the case where the source info is missing (binary weave).
 	 */
 	public static String beautifyLocation(ISourceLocation isl) {
-		StringBuffer nice = new StringBuffer();
+		StringBuilder nice = new StringBuilder();
 		if (isl == null || isl.getSourceFile() == null || isl.getSourceFile().getName().contains("no debug info available")) {
 			nice.append("no debug info available");
 		} else {

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/LightXMLParser.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/LightXMLParser.java
@@ -411,7 +411,7 @@ public class LightXMLParser {
 
 	private void mapEntity(StringBuffer buf) throws Exception {
 		char c = this.NULL_CHAR;
-		StringBuffer keyBuf = new StringBuffer();
+		StringBuilder keyBuf = new StringBuilder();
 		while (true) {
 			c = this.getNextChar();
 			if (c == ';') {

--- a/weaver/src/main/java/org/aspectj/weaver/model/AsmRelationshipProvider.java
+++ b/weaver/src/main/java/org/aspectj/weaver/model/AsmRelationshipProvider.java
@@ -221,7 +221,7 @@ public class AsmRelationshipProvider {
 			} else {
 				IProgramElement programElement = model.getHierarchy().getRoot();
 				// =Foo/,<g(G.class[G
-				StringBuffer phantomHandle = new StringBuffer();
+				StringBuilder phantomHandle = new StringBuilder();
 
 				// =Foo
 				phantomHandle.append(programElement.getHandleIdentifier());

--- a/weaver/src/main/java/org/aspectj/weaver/model/AsmRelationshipUtils.java
+++ b/weaver/src/main/java/org/aspectj/weaver/model/AsmRelationshipUtils.java
@@ -52,7 +52,7 @@ public class AsmRelationshipUtils {
 	 * and a named pointcut called p() will return 'p()..'
 	 */
 	public static String genPointcutDetails(Pointcut pcd) {
-		StringBuffer details = new StringBuffer();
+		StringBuilder details = new StringBuilder();
 		if (pcd instanceof ReferencePointcut) {
 			ReferencePointcut rp = (ReferencePointcut) pcd;
 			details.append(rp.name).append(DOUBLE_DOTS);

--- a/weaver/src/test/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegateTest.java
+++ b/weaver/src/test/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegateTest.java
@@ -255,7 +255,7 @@ public abstract class ReflectionBasedReferenceTypeDelegateTest extends TestCase 
 		ReferenceType rawReflectType = (ReferenceType) world.resolve(javaUtilHashMap);
 		ResolvedMember[] rms1 = rawType.getDelegate().getDeclaredMethods();
 		ResolvedMember[] rms2 = rawReflectType.getDelegate().getDeclaredMethods();
-		StringBuffer errors = new StringBuffer();
+		StringBuilder errors = new StringBuilder();
 		Set one = new HashSet();
 		for (ResolvedMember item : rms1) {
 			one.add(item.toString());

--- a/weaver/src/test/java/org/aspectj/weaver/tools/Java15PointcutExpressionTest.java
+++ b/weaver/src/test/java/org/aspectj/weaver/tools/Java15PointcutExpressionTest.java
@@ -295,7 +295,7 @@ public class Java15PointcutExpressionTest extends TestCase {
 		  expected.remove(nextToken);
 	  }
 	  if (expected.size()>0) { // we have excess ones!
-		  StringBuffer excessTokens = new StringBuffer();
+		  StringBuilder excessTokens = new StringBuilder();
 		  for (String string : expected) {
 			  excessTokens.append(string).append(" ");
 		  }
@@ -313,7 +313,7 @@ public class Java15PointcutExpressionTest extends TestCase {
 		  expected.remove(nextToken);
 	  }
 	  if (expected.size()>0) { // we have excess ones!
-		  StringBuffer excessTokens = new StringBuffer();
+		  StringBuilder excessTokens = new StringBuilder();
 		  for (String string : expected) {
 			  excessTokens.append(string).append(" ");
 		  }


### PR DESCRIPTION
`StringBuffer` is a legacy class which was in JDK from first versions of java.
`StringBuffer` is safe to use by multiple threads. While this thread-safety can be handy sometimes, such synchronization is not free.
As of release JDK 5, this class has been supplemented with an equivalent class designed for use by a single thread, StringBuilder. The StringBuilder class should generally be used in preference to this one, as it supports all of the same operations but it is faster, as it performs no synchronization.
It's especially matter with new versions of JDK, where biased locking is disabled. See https://openjdk.java.net/jeps/374
See similar cleanup in JDK: https://bugs.openjdk.java.net/browse/JDK-8041679

In this PR I updated only usages which are _definitely_ safe to migrate: where instances of StringBuffer don't cross methods/threads boundaries.
Found them by IntelliJ IDEA inspection `'StringBuffer' may be 'StringBuilder'`