### PR TITLE
Trim trailing whitespaces.

### DIFF
--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/Repository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/Repository.java
@@ -63,10 +63,10 @@ import org.aspectj.apache.bcel.util.SyntheticRepository;
 /**
  * The repository maintains informations about class interdependencies, e.g., whether a class is a sub-class of another. Delegates
  * actual class loading to SyntheticRepository with current class path by default.
- * 
+ *
  * @see org.aspectj.apache.bcel.util.Repository
  * @see org.aspectj.apache.bcel.util.SyntheticRepository
- * 
+ *
  * @version $Id: Repository.java,v 1.6 2009/09/09 22:18:20 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -92,7 +92,7 @@ public abstract class Repository {
 
 	/**
 	 * Lookup class somewhere found on your CLASSPATH, or whereever the repository instance looks for it.
-	 * 
+	 *
 	 * @return class object for given fully qualified class name, or null if the class could not be found or parsed correctly
 	 */
 	public static JavaClass lookupClass(String class_name) {
@@ -143,7 +143,7 @@ public abstract class Repository {
 
 	/**
 	 * Add clazz to repository if there isn't an equally named class already in there.
-	 * 
+	 *
 	 * @return old entry in repository
 	 */
 	public static JavaClass addClass(JavaClass clazz) {
@@ -201,7 +201,7 @@ public abstract class Repository {
 
 	/**
 	 * Equivalent to runtime "instanceof" operator.
-	 * 
+	 *
 	 * @return true, if clazz is an instance of super_class
 	 */
 	public static boolean instanceOf(JavaClass clazz, JavaClass super_class) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Attribute.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Attribute.java
@@ -71,7 +71,7 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeVisTypeAnnos;
  * Abstract super class for <em>Attribute</em> objects. Currently the <em>ConstantValue</em>, <em>SourceFile</em>, <em>Code</em>,
  * <em>Exceptiontable</em>, <em>LineNumberTable</em>, <em>LocalVariableTable</em>, <em>InnerClasses</em> and <em>Synthetic</em>
  * attributes are supported. The <em>Unknown</em> attribute stands for non-standard-attributes.
- * 
+ *
  * @version $Id: Attribute.java,v 1.9 2009/12/09 18:01:31 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see ConstantValue

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/BootstrapMethods.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/BootstrapMethods.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * Represents the BootstrapMethods attribute in Java 7 classes.
- * 
+ *
  * @author Andy Clement
  */
 public final class BootstrapMethods extends Attribute {
@@ -98,7 +98,7 @@ public final class BootstrapMethods extends Attribute {
 		file.readFully(data);
 		isInPackedState = true;
 	}
-	
+
 	public static class BootstrapMethod {
 		private int bootstrapMethodRef;
 		private int[] bootstrapArguments;
@@ -106,7 +106,7 @@ public final class BootstrapMethods extends Attribute {
 		BootstrapMethod(DataInputStream file) throws IOException {
 			this(file.readUnsignedShort(), readBootstrapArguments(file));
 		}
-		
+
 		private static int[] readBootstrapArguments(DataInputStream dis) throws IOException {
 			int numBootstrapMethods = dis.readUnsignedShort();
 			int[] bootstrapArguments = new int[numBootstrapMethods];
@@ -115,16 +115,16 @@ public final class BootstrapMethods extends Attribute {
 			}
 			return bootstrapArguments;
 		}
-		
+
 		public BootstrapMethod(int bootstrapMethodRef, int[] bootstrapArguments) {
 			this.bootstrapMethodRef = bootstrapMethodRef;
 			this.bootstrapArguments = bootstrapArguments;
 		}
-		
+
 		public int getBootstrapMethodRef() {
 			return bootstrapMethodRef;
 		}
-		
+
 		public int[] getBootstrapArguments() {
 			return bootstrapArguments;
 		}
@@ -137,15 +137,15 @@ public final class BootstrapMethods extends Attribute {
 				file.writeShort(bootstrapArgument);
 			}
 		}
-		
+
 		public final int getLength() {
 			return 2 /*bootstrapMethodRef*/+
 					2 /*number of arguments*/+
 					2 * bootstrapArguments.length;
 		}
-		
+
 	}
-	
+
 	// Unpacks the byte array into the table
 	private void unpack() {
 		if (isInPackedState) {
@@ -169,7 +169,7 @@ public final class BootstrapMethods extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -180,7 +180,7 @@ public final class BootstrapMethods extends Attribute {
 
 	/**
 	 * Dump line number table attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -228,8 +228,8 @@ public final class BootstrapMethods extends Attribute {
 					line.append(arg).append("(").append(getConstantPool().getConstant(arg)).append(") ");
 				}
 			}
-			
-			
+
+
 			if (i < numBootstrapMethods - 1) {
 				line.append(", ");
 			}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ClassFormatException.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ClassFormatException.java
@@ -54,7 +54,7 @@ package org.aspectj.apache.bcel.classfile;
  * <http://www.apache.org/>.
  */
 
-/** 
+/**
  * Thrown when the BCEL attempts to read a class file and determines
  * that the file is malformed or otherwise cannot be interpreted as a
  * class file.

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ClassParser.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ClassParser.java
@@ -76,14 +76,14 @@ import org.aspectj.apache.bcel.Constants;
  * further details about the structure of a bytecode file.
  *
  * @version $Id: ClassParser.java,v 1.6 2008/05/30 17:29:14 aclement Exp $
- * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A> 
+ * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
 public final class ClassParser {
   private DataInputStream file;
   private String          filename;
   private int             classnameIndex;
   private int             superclassnameIndex;
-  private int             major, minor; 
+  private int             major, minor;
   private int             accessflags;
   private int[]           interfaceIndices;
   private ConstantPool    cpool;
@@ -106,7 +106,7 @@ public final class ClassParser {
   }
 
   /** Parse class from given .class file */
-  public ClassParser(String file_name) throws IOException {    
+  public ClassParser(String file_name) throws IOException {
     this.filename = file_name;
     file = new DataInputStream(new BufferedInputStream(new FileInputStream(file_name),BUFSIZE));
   }
@@ -117,7 +117,7 @@ public final class ClassParser {
    * A <em>ClassFormatException</em> is raised, if the file is not a valid
    * .class file. (This does not include verification of the byte code as it
    * is performed by the java interpreter).
-   */    
+   */
   public JavaClass parse() throws IOException, ClassFormatException {
     /****************** Read headers ********************************/
     // Check magic tag of class file
@@ -136,7 +136,7 @@ public final class ClassParser {
     // Get interface information, i.e., implemented interfaces
     readInterfaces();
 
-    /****************** Read class fields and methods ***************/ 
+    /****************** Read class fields and methods ***************/
     // Read class fields, i.e., the variables of the class
     readFields();
 
@@ -150,13 +150,13 @@ public final class ClassParser {
     file.close();
 
     // Return the information we have gathered in a new object
-    JavaClass jc= new JavaClass(classnameIndex, superclassnameIndex, 
+    JavaClass jc= new JavaClass(classnameIndex, superclassnameIndex,
 			 filename, major, minor, accessflags,
 			 cpool, interfaceIndices, fields,
 			 methods, attributes);
     return jc;
   }
-  
+
   /** Read information about the attributes of the class */
   private final void readAttributes() {
 	  attributes = AttributeUtils.readAttributes(file,cpool);
@@ -172,14 +172,14 @@ public final class ClassParser {
       accessflags |= Constants.ACC_ABSTRACT;
 
     // don't police it like this... leave higher level verification code to check it.
-//    if(((access_flags & Constants.ACC_ABSTRACT) != 0) && 
+//    if(((access_flags & Constants.ACC_ABSTRACT) != 0) &&
 //       ((access_flags & Constants.ACC_FINAL)    != 0 ))
 //      throw new ClassFormatException("Class can't be both final and abstract");
 
     classnameIndex      = file.readUnsignedShort();
     superclassnameIndex = file.readUnsignedShort();
   }
-  
+
   private final void readConstantPool() throws IOException {
     try {
 		cpool = new ConstantPool(file);
@@ -192,7 +192,7 @@ public final class ClassParser {
 		}
 		throw cfe;
 	}
-  }    
+  }
 
   /** Read information about the fields of the class */
   private final void readFields() throws IOException, ClassFormatException {
@@ -204,16 +204,16 @@ public final class ClassParser {
     	for(int i=0; i < fieldCount; i++)
     		fields[i] = new Field(file, cpool);
     }
-  }    
+  }
 
-  /** Check whether the header of the file is ok. Of course, this has 
+  /** Check whether the header of the file is ok. Of course, this has
    *  to be the first action on successive file reads */
   private final void readID() throws IOException {
     int magic = 0xCAFEBABE;
-    if (file.readInt() != magic) 
+    if (file.readInt() != magic)
       throw new ClassFormatException(filename + " is not a Java .class file");
-  }   
-  
+  }
+
   private static final int[] NO_INTERFACES = new int[0];
 
   /** Read information about the interfaces implemented by this class */
@@ -226,8 +226,8 @@ public final class ClassParser {
 	    for(int i=0; i < interfacesCount; i++)
 	      interfaceIndices[i] = file.readUnsignedShort();
     }
-  }     
-  
+  }
+
   /** Read information about the methods of the class */
   private final void readMethods() throws IOException {
     int methodsCount = file.readUnsignedShort();
@@ -238,12 +238,12 @@ public final class ClassParser {
 	    for(int i=0; i < methodsCount; i++)
 	      methods[i] = new Method(file, cpool);
     }
-  }      
-  
+  }
+
   /** Read major and minor version of compiler which created the file */
   private final void readVersion() throws IOException {
     minor = file.readUnsignedShort();
     major = file.readUnsignedShort();
-  }    
-  
+  }
+
 }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Code.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Code.java
@@ -64,10 +64,10 @@ import org.aspectj.apache.bcel.Constants;
  * This class represents a chunk of Java byte code contained in a method. It is instantiated by the
  * <em>Attribute.readAttribute()</em> method. A <em>Code</em> attribute contains informations about operand stack, local variables,
  * byte code and the exceptions handled within this method.
- * 
+ *
  * This attribute has attributes itself, namely <em>LineNumberTable</em> which is used for debugging purposes and
  * <em>LocalVariableTable</em> which contains information about the local variables.
- * 
+ *
  * @version $Id: Code.java,v 1.9 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -149,7 +149,7 @@ public final class Code extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -159,7 +159,7 @@ public final class Code extends Attribute {
 
 	/**
 	 * Dump code attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -348,7 +348,7 @@ public final class Code extends Attribute {
 	// Code c = (Code)clone();
 	// c.code = (byte[])code.clone();
 	// c.cpool = constant_pool;
-	//  
+	//
 	// c.exceptionTable = new CodeException[exceptionTable.length];
 	// for(int i=0; i < exceptionTable.length; i++)
 	// c.exceptionTable[i] = exceptionTable[i].copy();

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/CodeException.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/CodeException.java
@@ -101,7 +101,7 @@ public final class CodeException implements Cloneable, Constants, Node, Serializ
 
   public void accept(ClassVisitor v) {
     v.visitCodeException(this);
-  }    
+  }
 
   public final void dump(DataOutputStream file) throws IOException {
     file.writeShort(start_pc);
@@ -113,17 +113,17 @@ public final class CodeException implements Cloneable, Constants, Node, Serializ
   /**
    * @return 0, if the handler catches any exception, otherwise it points to
    * the exception class which is to be caught.
-   */  
-  public final int getCatchType() { return catch_type; }    
+   */
+  public final int getCatchType() { return catch_type; }
 
   /**
    * @return Exclusive end index of the region where the handler is active.
-   */  
+   */
   public final int getEndPC() { return end_pc; }
 
   /**
    * @return Starting address of exception handler, relative to the code.
-   */  
+   */
   public final int getHandlerPC() { return handler_pc; }
 
   /**
@@ -157,20 +157,20 @@ public final class CodeException implements Cloneable, Constants, Node, Serializ
    */
   public final void setStartPC(int start_pc) {
     this.start_pc = start_pc;
-  }    
+  }
 
   /**
    * @return String representation.
-   */ 
+   */
   public final String toString() {
-    return "CodeException(start_pc = " + start_pc + 
+    return "CodeException(start_pc = " + start_pc +
       ", end_pc = " + end_pc +
       ", handler_pc = " + handler_pc + ", catch_type = " + catch_type + ")";
-  }    
+  }
 
   /**
    * @return String representation.
-   */ 
+   */
   public final String toString(ConstantPool cp, boolean verbose) {
     String str;
 

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Constant.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Constant.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * Abstract superclass for classes to represent the different constant types in the constant pool of a class file. The classes keep
  * closely to the JVM specification.
- * 
+ *
  * @version $Id: Constant.java,v 1.5 2009/09/10 15:35:04 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantCP.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantCP.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * Abstract super class for Fieldref and Methodref constants.
- * 
+ *
  * @version $Id: ConstantCP.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see ConstantFieldref

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantClass.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantClass.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to a (external) class.
- * 
+ *
  * @version $Id: ConstantClass.java,v 1.6 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author Andy Clement

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantDouble.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantDouble.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to a Double object.
- * 
+ *
  * @version $Id: ConstantDouble.java,v 1.6 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author Andy Clement

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantDynamic.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantDynamic.java
@@ -63,15 +63,15 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to the name and signature of a field or method.
- * 
+ *
  * http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4.10
- * 
+ *
  * @author Andy Clement
  * @see Constant
  */
 public final class ConstantDynamic extends Constant {
 	private final int bootstrapMethodAttrIndex;
-	private final int nameAndTypeIndex; 
+	private final int nameAndTypeIndex;
 
 	ConstantDynamic(DataInputStream file) throws IOException {
 		this(file.readUnsignedShort(), file.readUnsignedShort());
@@ -89,11 +89,11 @@ public final class ConstantDynamic extends Constant {
 		file.writeShort(bootstrapMethodAttrIndex);
 		file.writeShort(nameAndTypeIndex);
 	}
-	
+
 	public final int getNameAndTypeIndex() {
 		return nameAndTypeIndex;
 	}
-	
+
 	public final int getBootstrapMethodAttrIndex() {
 		return bootstrapMethodAttrIndex;
 	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantFieldref.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantFieldref.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * This class represents a constant pool reference to a field.
- * 
+ *
  * @version $Id: ConstantFieldref.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantFloat.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantFloat.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to a float object.
- * 
+ *
  * @version $Id: ConstantFloat.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Constant

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantInteger.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantInteger.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to an int object.
- * 
+ *
  * @version $Id: ConstantInteger.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Constant

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantInterfaceMethodref.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantInterfaceMethodref.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * This class represents a constant pool reference to an interface method.
- * 
+ *
  * @version $Id: ConstantInterfaceMethodref.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantInvokeDynamic.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantInvokeDynamic.java
@@ -63,15 +63,15 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to the name and signature of a field or method.
- * 
+ *
  * http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4.10
- * 
+ *
  * @author Andy Clement
  * @see Constant
  */
 public final class ConstantInvokeDynamic extends Constant {
 	private final int bootstrapMethodAttrIndex;
-	private final int nameAndTypeIndex; 
+	private final int nameAndTypeIndex;
 
 	ConstantInvokeDynamic(DataInputStream file) throws IOException {
 		this(file.readUnsignedShort(), file.readUnsignedShort());
@@ -101,15 +101,15 @@ public final class ConstantInvokeDynamic extends Constant {
 //	public final int getSignatureIndex() {
 //		return referenceIndex;
 //	}
-//	
+//
 //	public final String getSignature(ConstantPool cp) {
 //		return cp.constantToString(getSignatureIndex(), Constants.CONSTANT_Utf8);
 //	}
-	
+
 	public final int getNameAndTypeIndex() {
 		return nameAndTypeIndex;
 	}
-	
+
 	public final int getBootstrapMethodAttrIndex() {
 		return bootstrapMethodAttrIndex;
 	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantLong.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantLong.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to a long object.
- * 
+ *
  * @version $Id: ConstantLong.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Constant

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantMethodHandle.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantMethodHandle.java
@@ -63,15 +63,15 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to the name and signature of a field or method.
- * 
+ *
  * http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4.8
- * 
+ *
  * @author Andy Clement
  * @see Constant
  */
 public final class ConstantMethodHandle extends Constant {
 	private byte referenceKind;
-	private int referenceIndex; 
+	private int referenceIndex;
 
 	ConstantMethodHandle(DataInputStream file) throws IOException {
 		this(file.readByte(), file.readUnsignedShort());
@@ -93,7 +93,7 @@ public final class ConstantMethodHandle extends Constant {
 	public final byte getReferenceKind() {
 		return referenceKind;
 	}
-	
+
 	public final int getReferenceIndex() {
 		return referenceIndex;
 	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantMethodType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantMethodType.java
@@ -63,9 +63,9 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to the name and signature of a field or method.
- * 
+ *
  * http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4.9
- * 
+ *
  * @author Andy Clement
  * @see Constant
  */
@@ -98,7 +98,7 @@ public final class ConstantMethodType extends Constant {
 //	public final int getSignatureIndex() {
 //		return referenceIndex;
 //	}
-//	
+//
 //	public final String getSignature(ConstantPool cp) {
 //		return cp.constantToString(getSignatureIndex(), Constants.CONSTANT_Utf8);
 //	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantMethodref.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantMethodref.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * This class represents a constant pool reference to a method.
- * 
+ *
  * @version $Id: ConstantMethodref.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantModule.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantModule.java
@@ -61,9 +61,9 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * Represents a module.
- * 
+ *
  * See http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jvms-diffs.pdf 4.4.11
- * 
+ *
  * @author Andy Clement
  */
 public final class ConstantModule extends Constant {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantNameAndType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantNameAndType.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to the name and signature of a field or method.
- * 
+ *
  * @version $Id: ConstantNameAndType.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Constant
@@ -74,7 +74,7 @@ public final class ConstantNameAndType extends Constant {
 
 	/**
 	 * Initialize instance from file data.
-	 * 
+	 *
 	 * @param file Input stream
 	 * @throws IOException
 	 */
@@ -95,7 +95,7 @@ public final class ConstantNameAndType extends Constant {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -105,7 +105,7 @@ public final class ConstantNameAndType extends Constant {
 
 	/**
 	 * Dump name and signature index to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantPackage.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantPackage.java
@@ -61,9 +61,9 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * Represents a module.
- * 
+ *
  * See http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jvms-diffs.pdf 4.4.12
- * 
+ *
  * @author Andy Clement
  */
 public final class ConstantPackage extends Constant {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantPool.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantPool.java
@@ -136,7 +136,7 @@ public class ConstantPool implements Node {
 	/**
 	 * Get string from constant pool and bypass the indirection of `ConstantClass' and `ConstantString' objects. I.e. these classes
 	 * have an index field that points to another entry of the constant pool of type `ConstantUtf8' which contains the real data.
-	 * 
+	 *
 	 * @param index Index in constant pool
 	 * @param tag Tag of expected constant, either ConstantClass or ConstantString
 	 * @return Contents of string reference
@@ -207,7 +207,7 @@ public class ConstantPool implements Node {
 			str = (constantToString(((ConstantCP) c).getClassIndex(), Constants.CONSTANT_Class) + "." + constantToString(
 					((ConstantCP) c).getNameAndTypeIndex(), Constants.CONSTANT_NameAndType));
 			break;
-			
+
 		case Constants.CONSTANT_InvokeDynamic:
 			ConstantInvokeDynamic cID = ((ConstantInvokeDynamic)c);
 			return "#"+cID.getBootstrapMethodAttrIndex()+"."+constantToString(cID.getNameAndTypeIndex(), Constants.CONSTANT_NameAndType);
@@ -296,7 +296,7 @@ public class ConstantPool implements Node {
 		assert c.tag == Constants.CONSTANT_Utf8;
 		return (ConstantUtf8) c;
 	}
-	
+
 	public ConstantModule getConstantModule(int index) {
 		Constant c = getConstant(index);
 		assert c != null;
@@ -621,7 +621,7 @@ public class ConstantPool implements Node {
 
 			return addNameAndType(u8.getValue(), u8_2.getValue());
 		}
-		
+
 		case Constants.CONSTANT_InvokeDynamic: {
 			ConstantInvokeDynamic cid = (ConstantInvokeDynamic)c;
 			int index1 = cid.getBootstrapMethodAttrIndex();
@@ -631,7 +631,7 @@ public class ConstantPool implements Node {
 			int index2 = addNameAndType(name.getValue(), signature.getValue());
 			return addInvokeDynamic(index1,index2);
 		}
-		
+
 		case Constants.CONSTANT_MethodHandle:
 			ConstantMethodHandle cmh = (ConstantMethodHandle)c;
 			return addMethodHandle(cmh.getReferenceKind(),addConstant(constants[cmh.getReferenceIndex()],cp));
@@ -650,7 +650,7 @@ public class ConstantPool implements Node {
 
 		case Constants.CONSTANT_Integer:
 			return addInteger(((ConstantInteger) c).getValue());
-			
+
 		case Constants.CONSTANT_MethodType:
 			ConstantMethodType cmt = (ConstantMethodType)c;
 			return addMethodType(addConstant(constants[cmt.getDescriptorIndex()],cp));
@@ -689,14 +689,14 @@ public class ConstantPool implements Node {
 			throw new RuntimeException("Unknown constant type " + c);
 		}
 	}
-	
+
 	public int addMethodHandle(byte referenceKind, int referenceIndex) {
 		adjustSize();
 		int ret = poolSize;
 		pool[poolSize++] = new ConstantMethodHandle(referenceKind, referenceIndex);
 		return ret;
 	}
-	
+
 	public int addMethodType(int descriptorIndex) {
 		adjustSize();
 		int ret = poolSize;
@@ -718,7 +718,7 @@ public class ConstantPool implements Node {
 		pool[poolSize++] = new ConstantMethodref(class_index, name_and_type_index);
 		return ret;
 	}
-	
+
 	public int addInvokeDynamic(int bootstrapMethodIndex, int constantNameAndTypeIndex) {
 		adjustSize();
 		int ret = poolSize;

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantString.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantString.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to a String object.
- * 
+ *
  * @version $Id: ConstantString.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Constant

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantUtf8.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantUtf8.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from the abstract <A HREF="org.aspectj.apache.bcel.classfile.Constant.html">Constant</A> class and
  * represents a reference to a Utf8 encoded string.
- * 
+ *
  * @version $Id: ConstantUtf8.java,v 1.5 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Constant

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantValue.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ConstantValue.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from <em>Attribute</em> and represents a constant value, i.e., a default value for initializing a class
  * field. This class is instantiated by the <em>Attribute.readAttribute()</em> method.
- * 
+ *
  * @version $Id: ConstantValue.java,v 1.6 2009/09/16 00:43:49 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Deprecated.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Deprecated.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from <em>Attribute</em> and denotes that this is a deprecated method. It is instantiated from the
  * <em>Attribute.readAttribute()</em> method.
- * 
+ *
  * @version $Id: Deprecated.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -92,7 +92,7 @@ public final class Deprecated extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -112,7 +112,7 @@ public final class Deprecated extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -122,7 +122,7 @@ public final class Deprecated extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ExceptionTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ExceptionTable.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.Constants;
  * This class represents the table of exceptions that are thrown by a method. This attribute may be used once per method. The name
  * of this class is <em>ExceptionTable</em> for historical reasons; The Java Virtual Machine Specification, Second Edition defines
  * this attribute using the name <em>Exceptions</em> (which is inconsistent with the other classes).
- * 
+ *
  * @version $Id: ExceptionTable.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Code
@@ -94,7 +94,7 @@ public final class ExceptionTable extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -114,7 +114,7 @@ public final class ExceptionTable extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -124,7 +124,7 @@ public final class ExceptionTable extends Attribute {
 
 	/**
 	 * Dump exceptions attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Field.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Field.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.generic.Type;
 /**
  * This class represents the field info structure, i.e., the representation for a variable in the class. See JVM specification for
  * details.
- * 
+ *
  * @version $Id: Field.java,v 1.6 2009/09/15 03:33:52 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/FieldOrMethod.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/FieldOrMethod.java
@@ -65,7 +65,7 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeAnnos;
 
 /**
  * Abstract super class for fields and methods.
- * 
+ *
  * @version $Id: FieldOrMethod.java,v 1.12 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/InnerClass.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/InnerClass.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class represents a inner class attribute, i.e., the class indices of the inner and outer classes, the name and the
  * attributes of the inner class.
- * 
+ *
  * @version $Id: InnerClass.java,v 1.4 2009/09/10 15:35:05 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see InnerClasses
@@ -83,7 +83,7 @@ public final class InnerClass implements Cloneable, Node {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param file Input stream
 	 * @throws IOException
 	 */
@@ -107,7 +107,7 @@ public final class InnerClass implements Cloneable, Node {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	public void accept(ClassVisitor v) {
@@ -116,7 +116,7 @@ public final class InnerClass implements Cloneable, Node {
 
 	/**
 	 * Dump inner class attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/InnerClasses.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/InnerClasses.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from <em>Attribute</em> and denotes that this class is an Inner class of another. to the source file of
  * this class. It is instantiated from the <em>Attribute.readAttribute()</em> method.
- * 
+ *
  * @version $Id: InnerClasses.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -94,7 +94,7 @@ public final class InnerClasses extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -114,7 +114,7 @@ public final class InnerClasses extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -124,7 +124,7 @@ public final class InnerClasses extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
@@ -77,10 +77,10 @@ import org.aspectj.apache.bcel.util.SyntheticRepository;
 /**
  * Represents a Java class, i.e., the data structures, constant pool, fields, methods and commands contained in a Java .class file.
  * See <a href="ftp://java.sun.com/docs/specs/">JVM specification</a> for details.
- * 
+ *
  * The intent of this class is to represent a parsed or otherwise existing class file. Those interested in programatically
  * generating classes should see the <a href="../generic/ClassGen.html">ClassGen</a> class.
- * 
+ *
  * @version $Id: JavaClass.java,v 1.22 2009/09/15 19:40:14 aclement Exp $
  * @see org.aspectj.apache.bcel.generic.ClassGen
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
@@ -185,7 +185,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	public void accept(ClassVisitor v) {
@@ -194,7 +194,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	/**
 	 * Dump class to a file.
-	 * 
+	 *
 	 * @param file Output file
 	 * @throws IOException
 	 */
@@ -209,7 +209,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	/**
 	 * Dump class to a file named file_name.
-	 * 
+	 *
 	 * @param file_name Output file name
 	 * @exception IOException
 	 */
@@ -671,7 +671,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	/**
 	 * Equivalent to runtime "instanceof" operator.
-	 * 
+	 *
 	 * @return true if this JavaClass is derived from teh super class
 	 */
 	public final boolean instanceOf(JavaClass super_class) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LineNumber.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LineNumber.java
@@ -61,7 +61,7 @@ import java.io.IOException;
 /**
  * This class represents a (PC offset, line number) pair, i.e., a line number in the source that corresponds to a relative address
  * in the byte code. This is used for debugging purposes.
- * 
+ *
  * @version $Id: LineNumber.java,v 1.6 2009/09/09 21:26:54 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author Andy Clement

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LineNumberTable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LineNumberTable.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class represents a table of line numbers for debugging purposes. This attribute is used by the <em>Code</em> attribute. It
  * contains pairs of PCs and line numbers.
- * 
+ *
  * @version $Id: LineNumberTable.java,v 1.8 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Code changes: asc Feb06 Made unpacking lazy
@@ -94,7 +94,7 @@ public final class LineNumberTable extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index of name
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -132,7 +132,7 @@ public final class LineNumberTable extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -143,7 +143,7 @@ public final class LineNumberTable extends Attribute {
 
 	/**
 	 * Dump line number table attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -208,7 +208,7 @@ public final class LineNumberTable extends Attribute {
 
 	/**
 	 * Map byte code positions to source code lines.
-	 * 
+	 *
 	 * @param pos byte code offset
 	 * @return corresponding line in source code
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariable.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/LocalVariable.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * This class represents a local variable within a method. It contains its scope, name, signature and index on the method's frame.
- * 
+ *
  * @version $Id: LocalVariable.java,v 1.5 2009/09/10 15:35:05 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see LocalVariableTable
@@ -89,7 +89,7 @@ public final class LocalVariable implements Constants, Cloneable, Node {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param file Input stream
 	 * @throws IOException
 	 */
@@ -118,7 +118,7 @@ public final class LocalVariable implements Constants, Cloneable, Node {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	public void accept(ClassVisitor v) {
@@ -127,7 +127,7 @@ public final class LocalVariable implements Constants, Cloneable, Node {
 
 	/**
 	 * Dump local variable to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Method.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Method.java
@@ -67,7 +67,7 @@ import org.aspectj.apache.bcel.generic.Type;
 /**
  * This class represents the method info structure, i.e., the representation for a method in the class. See JVM specification for
  * details. A method has access flags, a name, a signature and a number of attributes.
- * 
+ *
  * @version $Id: Method.java,v 1.11 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Modifiers.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Modifiers.java
@@ -60,7 +60,7 @@ import org.aspectj.apache.bcel.Constants;
  * Super class for all objects that have modifiers like private, final, ... I.e.
  * classes, fields, and methods.
  * was AccessFlags
- * 
+ *
  * @version $Id: Modifiers.java,v 1.2 2008/05/28 23:53:01 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -77,7 +77,7 @@ public abstract class Modifiers {
 	public final int getModifiers() {
 		return modifiers;
 	}
-	
+
 	public final void setModifiers(int modifiers) {
 		this.modifiers = modifiers;
 	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Module.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Module.java
@@ -64,13 +64,13 @@ import org.aspectj.apache.bcel.Constants;
  * information captured in a class file.
  * http://cr.openjdk.java.net/~mr/jigsaw/spec/lang-vm.html
  * http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jvms-diffs.pdf 4.7.25
- * 
+ *
  * @author Andy Clement
  */
 public final class Module extends Attribute {
 
 	private static final String[] NO_MODULE_NAMES = {};
-	
+
 	private int moduleNameIndex;    // u2 module_name_index
 	private int moduleFlags;        // u2 module_flags
 	private int moduleVersionIndex; // u2 module_version_index
@@ -88,18 +88,18 @@ public final class Module extends Attribute {
 		super(module.getTag(), module.getNameIndex(), module.getLength(), module.getConstantPool());
 		moduleInfo = module.getBytes();
 	}
-	
+
 	public Module(int nameIndex, int length, byte[] data, ConstantPool cp) {
 		super(Constants.ATTR_MODULE, nameIndex, length, cp);
 	}
-	
+
 	Module(int nameIndex, int length, DataInputStream stream, ConstantPool cp) throws IOException {
 		this(nameIndex, length, (byte[])null, cp);
 		moduleInfo = new byte[length];
 		stream.read(moduleInfo);
 		unpacked = false;
 	}
-	
+
 	public class Require {
 
 		private final int moduleIndex;
@@ -111,19 +111,19 @@ public final class Module extends Attribute {
 			this.flags = flags;
 			this.versionIndex = versionIndex;
 		}
-		
+
 		public String getModuleName() {
 			return cpool.getModuleName(moduleIndex);
 		}
-		
+
 		public int getFlags() {
 			return flags;
 		}
-		
+
 		public int getVersionIndex() {
 			return versionIndex;
 		}
-		
+
 		public String getVersionString() {
 			if (versionIndex == 0) {
 				return null;
@@ -148,13 +148,13 @@ public final class Module extends Attribute {
 			}
 			return s.toString();
 		}
-		
+
 		public String toString() {
 			return "requires"+getFlagsAsString()+" "+getModuleName()+(versionIndex==0?"":" "+getVersionString());
 		}
 	}
 
-	
+
 	public class Export {
 
 		private final int packageIndex;
@@ -170,19 +170,19 @@ public final class Module extends Attribute {
 		public int getPackageIndex() {
 			return packageIndex;
 		}
-		
+
 		public int getFlags() {
 			return flags;
 		}
-		
+
 		public int[] getToModuleIndices() {
 			return toModuleIndices;
 		}
-		
+
 		public String getPackage() {
 			return cpool.getPackageName(packageIndex);
-		}		
-		
+		}
+
 		public String getFlagsAsString() {
 			StringBuilder s = new StringBuilder();
 			if ((flags & Constants.MODULE_ACC_SYNTHETIC)!=0) {
@@ -204,7 +204,7 @@ public final class Module extends Attribute {
 			}
 			return toModuleNames;
 		}
-		
+
 		public String toString() {
 			StringBuilder s =new StringBuilder();
 			s.append("exports").append(getFlagsAsString()).append(" ").append(getPackage().replace('/', '.'));
@@ -221,7 +221,7 @@ public final class Module extends Attribute {
 			return s.toString().trim();
 		}
 	}
-	
+
 
 	public class Open {
 
@@ -238,19 +238,19 @@ public final class Module extends Attribute {
 		public int getPackageIndex() {
 			return packageIndex;
 		}
-		
+
 		public int getFlags() {
 			return flags;
 		}
-		
+
 		public int[] getToModuleIndices() {
 			return toModuleIndices;
 		}
-		
+
 		public String getPackage() {
 			return cpool.getPackageName(packageIndex);
-		}		
-		
+		}
+
 		public String getFlagsAsString() {
 			StringBuilder s = new StringBuilder();
 			if ((flags & Constants.MODULE_ACC_SYNTHETIC)!=0) {
@@ -272,7 +272,7 @@ public final class Module extends Attribute {
 			}
 			return toModuleNames;
 		}
-		
+
 		public String toString() {
 			StringBuilder s =new StringBuilder();
 			s.append("opens").append(getFlagsAsString()).append(" ").append(getPackage().replace('/', '.'));
@@ -289,7 +289,7 @@ public final class Module extends Attribute {
 			return s.toString().trim();
 		}
 	}
-	
+
 	public class Provide {
 		private final int providedTypeIndex;
 		private final int[] withTypeIndices;
@@ -298,11 +298,11 @@ public final class Module extends Attribute {
 			this.providedTypeIndex = providedTypeIndex;
 			this.withTypeIndices = withTypeIndices;
 		}
-		
+
 		public String getProvidedType() {
 			return cpool.getConstantString_CONSTANTClass(providedTypeIndex);
 		}
-		
+
 		public int getProvidedTypeIndex() {
 			return providedTypeIndex;
 		}
@@ -334,7 +334,7 @@ public final class Module extends Attribute {
 
 	public class Uses {
 		private final int typeNameIndex;
-		
+
 		public Uses(int typeNameIndex) {
 			this.typeNameIndex = typeNameIndex;
 		}
@@ -346,14 +346,14 @@ public final class Module extends Attribute {
 		public int getTypeNameIndex() {
 			return typeNameIndex;
 		}
-		
+
 		public String toString() {
 			StringBuilder s =new StringBuilder();
 			s.append("uses ").append(getTypeName().replace('/', '.'));
 			return s.toString().trim();
 		}
 	}
-	
+
 	private final int readInt() {
 		return ((moduleInfo[ptr++] & 0xFF) << 24) + ((moduleInfo[ptr++] & 0xFF) << 16)
 				+ ((moduleInfo[ptr++] & 0xFF) << 8) + (moduleInfo[ptr++] & 0xFF);
@@ -374,13 +374,13 @@ public final class Module extends Attribute {
 			moduleNameIndex = readUnsignedShort();
 			moduleFlags = readUnsignedShort();
 			moduleVersionIndex = readUnsignedShort();
-			
+
 			int count = readUnsignedShort();
 			requires = new Require[count];
 			for (int i = 0; i < count; i++) {
 				requires[i] = new Require(readUnsignedShort(), readUnsignedShort(), readUnsignedShort());
 			}
-			
+
 			count = readUnsignedShort();
 			exports = new Export[count];
 			for (int i = 0; i < count; i++) {
@@ -393,7 +393,7 @@ public final class Module extends Attribute {
 				}
 				exports[i] = new Export(index, flags, to);
 			}
-			
+
 			count = readUnsignedShort();
 			opens = new Open[count];
 			for (int i = 0; i < count; i++) {
@@ -436,7 +436,7 @@ public final class Module extends Attribute {
 			file.writeShort(moduleNameIndex);
 			file.writeShort(moduleFlags);
 			file.writeShort(moduleVersionIndex);
-			
+
 			file.writeShort(requires.length);
 			for (Require require : requires) {
 				file.writeShort(require.moduleIndex);
@@ -507,7 +507,7 @@ public final class Module extends Attribute {
 		}
 		return s.toString();
 	}
-	
+
 	public String toStringOpens() {
 		StringBuilder s = new StringBuilder();
 		s.append('#').append(opens.length);
@@ -598,12 +598,12 @@ public final class Module extends Attribute {
 //	 public Attribute copy(ConstantPool constant_pool) {
 //		 return (Module) clone();
 //	 }
-	
+
 	@Override
 	public void accept(ClassVisitor v) {
 		v.visitModule(this);
 	}
-	
+
 	public Require[] getRequires() {
 		ensureUnpacked();
 		return requires;
@@ -617,7 +617,7 @@ public final class Module extends Attribute {
 		}
 		return results;
 	}
-	
+
 	public byte[] getBytes() {
 		return moduleInfo;
 	}
@@ -626,7 +626,7 @@ public final class Module extends Attribute {
 		ensureUnpacked();
 		return exports;
 	}
-	
+
 	public Open[] getOpens() {
 		ensureUnpacked();
 		return opens;
@@ -641,18 +641,18 @@ public final class Module extends Attribute {
 		ensureUnpacked();
 		return provides;
 	}
-	
+
 	public String getModuleName() {
 		return ((ConstantModule)cpool.getConstant(moduleNameIndex)).getModuleName(cpool);
 	}
-	
+
 	public int getModuleFlags() {
 		// 0x0020 (ACC_OPEN) - Indicates that this module is open.
 		// 0x1000 (ACC_SYNTHETIC) - Indicates that this module was not explicitly or implicitly declared.
 		// 0x8000 (ACC_MANDATED) - Indicates that this module was implicitly declared
 		return moduleFlags;
 	}
-	
+
 	/** @return the module version or null if no version information specified */
 	public String getModuleVersion() {
 		if (moduleVersionIndex == 0) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ModuleMainClass.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ModuleMainClass.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * Indicates the main class of a module.
  * http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jvms-diffs.pdf 4.7.26
- * 
+ *
  * @author Andy Clement
  */
 public final class ModuleMainClass extends Attribute {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ModulePackages.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/ModulePackages.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * Indicates all the packages of a module that are exported or opened by the module attribute.
  * http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jvms-diffs.pdf 4.7.26
- * 
+ *
  * @author Andy Clement
  */
 public final class ModulePackages extends Attribute {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestHost.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestHost.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.28
- * 
+ *
  * @see Attribute
  */
 public final class NestHost extends Attribute {
@@ -100,7 +100,7 @@ public final class NestHost extends Attribute {
 	public final void setHostClassIndex(int hostClassIndex) {
 		this.hostClassIndex = hostClassIndex;
 	}
-	
+
 	public final String getHostClassName() {
 		ConstantClass constantClass = (ConstantClass)cpool.getConstant(hostClassIndex,Constants.CONSTANT_Class);
 		return constantClass.getClassname(cpool);

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestMembers.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/NestMembers.java
@@ -62,7 +62,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.29
- * 
+ *
  * @see Attribute
  */
 public final class NestMembers extends Attribute {
@@ -109,7 +109,7 @@ public final class NestMembers extends Attribute {
 		this.classes = inner_classes;
 		numberOfClasses = (inner_classes == null) ? 0 : inner_classes.length;
 	}
-	
+
 	public final String[] getClassesNames() {
 		String[] result = new String[numberOfClasses];
 		for (int i = 0; i < numberOfClasses; i++) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Signature.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Signature.java
@@ -52,7 +52,7 @@ package org.aspectj.apache.bcel.classfile;
  * individuals on behalf of the Apache Software Foundation.  For more
  * information on the Apache Software Foundation, please see
  * <http://www.apache.org/>.
- * 
+ *
  * Extended by Adrian Colyer, June 2005 to support unpacking of Signature
  * attribute
  */
@@ -67,7 +67,7 @@ import org.aspectj.apache.bcel.Constants;
 /**
  * This class is derived from <em>Attribute</em> and represents a reference to a <href="http://wwwipd.ira.uka.de/~pizza/gj/">GJ</a>
  * attribute.
- * 
+ *
  * @version $Id: Signature.java,v 1.11 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -85,7 +85,7 @@ public final class Signature extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -110,7 +110,7 @@ public final class Signature extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -121,7 +121,7 @@ public final class Signature extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/SourceFile.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/SourceFile.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.Constants;
  * This class is derived from <em>Attribute</em> and represents a reference to the source file of this class. At most one SourceFile
  * attribute should appear per classfile. The intention of this class is that it is instantiated from the
  * <em>Attribute.readAttribute()</em> method.
- * 
+ *
  * @version $Id: SourceFile.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -82,7 +82,7 @@ public final class SourceFile extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -109,7 +109,7 @@ public final class SourceFile extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -119,7 +119,7 @@ public final class SourceFile extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMap.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMap.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.Constants;
  * This class represents a stack map attribute used for preverification of Java classes for the <a href="http://java.sun.com/j2me/">
  * Java 2 Micro Edition</a> (J2ME). This attribute is used by the <a href="http://java.sun.com/products/cldc/">KVM</a> and contained
  * within the Code attribute of a method. See CLDC specification 5.3.1.2
- * 
+ *
  * @version $Id: StackMap.java,v 1.6 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Code
@@ -77,11 +77,11 @@ public final class StackMap extends Attribute {
 
 	/*
 	 * @param name_index Index of name
-	 * 
+	 *
 	 * @param length Content length in bytes
-	 * 
+	 *
 	 * @param map Table of stack map entries
-	 * 
+	 *
 	 * @param constant_pool Array of constants
 	 */
 	public StackMap(int name_index, int length, StackMapEntry[] map, ConstantPool constant_pool) {
@@ -92,7 +92,7 @@ public final class StackMap extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index of name
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -111,7 +111,7 @@ public final class StackMap extends Attribute {
 
 	/**
 	 * Dump line number table attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */
@@ -176,7 +176,7 @@ public final class StackMap extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMapEntry.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMapEntry.java
@@ -113,7 +113,7 @@ public final class StackMapEntry implements Cloneable {
    *
    * @param file Output file stream
    * @throws IOException
-   */ 
+   */
   public final void dump(DataOutputStream file) throws IOException
   {
     file.writeShort(byte_code_offset);
@@ -129,7 +129,7 @@ public final class StackMapEntry implements Cloneable {
 
   /**
    * @return String representation.
-   */ 
+   */
   public final String toString() {
     StringBuffer buf = new StringBuffer("(offset=" + byte_code_offset);
 
@@ -159,7 +159,7 @@ public final class StackMapEntry implements Cloneable {
 
     buf.append(")");
 
-    return buf.toString();    
+    return buf.toString();
   }
 
 
@@ -198,12 +198,12 @@ public final class StackMapEntry implements Cloneable {
 
   /**
    * @return Constant pool used by this object.
-   */   
+   */
   public final ConstantPool getConstantPool() { return constant_pool; }
 
   /**
    * @param constant_pool Constant pool to be used for this object.
-   */   
+   */
   public final void setConstantPool(ConstantPool constant_pool) {
     this.constant_pool = constant_pool;
   }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMapType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/StackMapType.java
@@ -113,19 +113,19 @@ public final class StackMapType implements Cloneable {
    * in byte code, if type == ITEM_NewObject, and -1 otherwise
    */
   public int  getIndex()      { return index; }
-  
+
   /**
    * Dump type entries to file.
    *
    * @param file Output file stream
    * @throws IOException
-   */ 
+   */
   public final void dump(DataOutputStream file) throws IOException
   {
     file.writeByte(type);
     if(hasIndex())
       file.writeShort(getIndex());
-  }    
+  }
 
   /** @return true, if type is either ITEM_Object or ITEM_NewObject
    */
@@ -145,10 +145,10 @@ public final class StackMapType implements Cloneable {
 
   /**
    * @return String representation
-   */ 
+   */
   public final String toString() {
     return "(type=" + Constants.ITEM_NAMES[type] + printIndex() + ")";
-  }    
+  }
 
   /**
    * @return deep copy of this object
@@ -163,12 +163,12 @@ public final class StackMapType implements Cloneable {
 
   /**
    * @return Constant pool used by this object.
-   */   
+   */
   public final ConstantPool getConstantPool() { return constant_pool; }
 
   /**
    * @param constant_pool Constant pool to be used for this object.
-   */   
+   */
   public final void setConstantPool(ConstantPool constant_pool) {
     this.constant_pool = constant_pool;
   }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Synthetic.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Synthetic.java
@@ -65,7 +65,7 @@ import org.aspectj.apache.bcel.Constants;
  * specification states "A class member that does not appear in the source code must be marked using a Synthetic attribute." It may
  * appear in the ClassFile attribute table, a field_info table or a method_info table. This class is intended to be instantiated
  * from the <em>Attribute.readAttribute()</em> method.
- * 
+ *
  * @version $Id: Synthetic.java,v 1.5 2009/09/15 19:40:12 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Attribute
@@ -81,7 +81,7 @@ public final class Synthetic extends Attribute {
 		this(c.getNameIndex(), c.getLength(), c.getBytes(), c.getConstantPool());
 	}
 
-	//  
+	//
 	// public Synthetic(ConstantPoolGen cpool) {
 	// super(Constants.ATTR_SYNTHETIC, cpool.addUtf8("Synthetic"), 0, cpool);
 	// ConstantPoolGen cpg = myGen.getConstantPool();
@@ -102,7 +102,7 @@ public final class Synthetic extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool to CONSTANT_Utf8
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -122,7 +122,7 @@ public final class Synthetic extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -132,7 +132,7 @@ public final class Synthetic extends Attribute {
 
 	/**
 	 * Dump source file attribute to file stream in binary format.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Unknown.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Unknown.java
@@ -66,8 +66,8 @@ import org.aspectj.apache.bcel.Constants;
  * href="./AttributeReader.html">AttributeReader</a> implementation and attach it via <a
  * href="./Attribute.html#addAttributeReader(java.lang.String,
  * org.aspectj.apache.bcel.classfile.AttributeReader)">Attribute.addAttributeReader</a>.
- * 
- * 
+ *
+ *
  * @version $Id: Unknown.java,v 1.6 2009/09/15 19:40:12 aclement Exp $
  * @see org.aspectj.apache.bcel.classfile.Attribute
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
@@ -102,7 +102,7 @@ public final class Unknown extends Attribute {
 
 	/**
 	 * Create a non-standard attribute.
-	 * 
+	 *
 	 * @param name_index Index in constant pool
 	 * @param length Content length in bytes
 	 * @param bytes Attribute contents
@@ -118,7 +118,7 @@ public final class Unknown extends Attribute {
 
 	/**
 	 * Construct object from file stream.
-	 * 
+	 *
 	 * @param name_index Index in constant pool
 	 * @param length Content length in bytes
 	 * @param file Input stream
@@ -137,7 +137,7 @@ public final class Unknown extends Attribute {
 	/**
 	 * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class. I.e., the
 	 * hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
-	 * 
+	 *
 	 * @param v Visitor object
 	 */
 	@Override
@@ -147,7 +147,7 @@ public final class Unknown extends Attribute {
 
 	/**
 	 * Dump unknown bytes to file stream.
-	 * 
+	 *
 	 * @param file Output file stream
 	 * @throws IOException
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Utility.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Utility.java
@@ -74,10 +74,10 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * Utility functions that do not really belong to any class in particular.
- * 
+ *
  * @version $Id: Utility.java,v 1.14 2009/09/28 16:39:46 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
- * 
+ *
  *         modified: Andy Clement 2-mar-05 Removed unnecessary static and optimized
  */
 public abstract class Utility {
@@ -91,7 +91,7 @@ public abstract class Utility {
 
 	/**
 	 * Convert bit field of flags into string such as 'static final'.
-	 * 
+	 *
 	 * @param access_flags Access flags
 	 * @return String representation of flags
 	 */
@@ -101,10 +101,10 @@ public abstract class Utility {
 
 	/**
 	 * Convert bit field of flags into string such as 'static final'.
-	 * 
+	 *
 	 * Special case: Classes compiled with new compilers and with the 'ACC_SUPER' flag would be said to be "synchronized". This is
 	 * because SUN used the same value for the flags 'ACC_SUPER' and 'ACC_SYNCHRONIZED'.
-	 * 
+	 *
 	 * @param access_flags Access flags
 	 * @param for_class access flags are for class qualifiers ?
 	 * @return String representation of flags
@@ -136,7 +136,7 @@ public abstract class Utility {
 	/**
 	 * Disassemble a byte array of JVM byte codes starting from code line 'index' and return the disassembled string representation.
 	 * Decode only 'num' opcodes (including their operands), use -1 if you want to decompile everything.
-	 * 
+	 *
 	 * @param code byte code array
 	 * @param constant_pool Array of constants
 	 * @param index offset in `code' array <EM>(number of opcodes, not bytes!)</EM>
@@ -182,7 +182,7 @@ public abstract class Utility {
 
 	/**
 	 * Shorten long class names, <em>java/lang/String</em> becomes <em>String</em>.
-	 * 
+	 *
 	 * @param str The long class name
 	 * @return Compacted class name
 	 */
@@ -193,7 +193,7 @@ public abstract class Utility {
 	/**
 	 * Shorten long class name <em>str</em>, i.e., chop off the <em>prefix</em>, if the class name starts with this string and the
 	 * flag <em>chopit</em> is true. Slashes <em>/</em> are converted to dots <em>.</em>.
-	 * 
+	 *
 	 * @param str The long class name
 	 * @param prefix The prefix the get rid off
 	 * @param chopit Flag that determines whether chopping is executed or not
@@ -217,7 +217,7 @@ public abstract class Utility {
 	/**
 	 * Shorten long class names, <em>java/lang/String</em> becomes <em>java.lang.String</em>, e.g.. If <em>chopit</em> is
 	 * <em>true</em> the prefix <em>java.lang</em> is also removed.
-	 * 
+	 *
 	 * @param str The long class name
 	 * @param chopit Flag that determines whether chopping is executed or not
 	 * @return Compacted class name
@@ -298,7 +298,7 @@ public abstract class Utility {
 
 	/**
 	 * Replace all occurences of <em>old</em> in <em>str</em> with <em>new</em>.
-	 * 
+	 *
 	 * @param str String to permute
 	 * @param old String to be replaced
 	 * @param new Replacement string
@@ -332,7 +332,7 @@ public abstract class Utility {
 
 	/**
 	 * Converts signature to string with all class names compacted.
-	 * 
+	 *
 	 * @param signature to convert
 	 * @return Human readable signature
 	 */
@@ -426,7 +426,7 @@ public abstract class Utility {
 
 	/**
 	 * Return type of method signature as a byte value as defined in <em>Constants</em>
-	 * 
+	 *
 	 * @param signature in format described above
 	 * @return type of method signature
 	 * @see Constants
@@ -453,7 +453,7 @@ public abstract class Utility {
 
 	/**
 	 * Convert bytes into hexidecimal string
-	 * 
+	 *
 	 * @return bytes as hexidecimal string, e.g. 00 FA 12 ...
 	 */
 	public static final String toHexString(byte[] bytes) {
@@ -480,7 +480,7 @@ public abstract class Utility {
 
 	/**
 	 * Return a string for an integer justified left or right and filled up with 'fill' characters if necessary.
-	 * 
+	 *
 	 * @param i integer to format
 	 * @param length length of desired string
 	 * @param left_justify format left or right
@@ -493,7 +493,7 @@ public abstract class Utility {
 
 	/**
 	 * Fillup char with up to length characters with char `fill' and justify it left or right.
-	 * 
+	 *
 	 * @param str string to format
 	 * @param length length of desired string
 	 * @param left_justify format left or right
@@ -550,7 +550,7 @@ public abstract class Utility {
 
 	/**
 	 * Converts a list of AnnotationGen objects into a set of attributes that can be attached to the class file.
-	 * 
+	 *
 	 * @param cp The constant pool gen where we can create the necessary name refs
 	 * @param annotations A list of AnnotationGen objects
 	 */
@@ -747,7 +747,7 @@ public abstract class Utility {
 
 	/**
 	 * Return type of signature as a byte value as defined in <em>Constants</em>
-	 * 
+	 *
 	 * @param signature in format described above
 	 * @return type of signature
 	 * @see Constants
@@ -816,7 +816,7 @@ public abstract class Utility {
 
 	/**
 	 * Disassemble a stream of byte codes and return the string representation.
-	 * 
+	 *
 	 * @param bytes stream of bytes
 	 * @param constant_pool Array of constants
 	 * @param verbose be verbose, e.g. print constant pool index
@@ -995,13 +995,13 @@ public abstract class Utility {
 					+ bytes.readUnsignedByte()); // Last byte is a reserved
 			// space
 			break;
-			
+
 		case Constants.INVOKEDYNAMIC://http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-6.html#jvms-6.5.invokedynamic
 			index = bytes.readUnsignedShort();
 			bytes.readUnsignedShort(); // zeroes
 			buf.append("\t" + constant_pool.constantToString(index) + (verbose ? " (" + index + ")" : ""));
 			break;
-			
+
 		// Operands are references to items in constant pool
 		case Constants.LDC_W:
 		case Constants.LDC2_W:
@@ -1076,7 +1076,7 @@ public abstract class Utility {
 
 	/**
 	 * Convert type to Java method signature, e.g. int[] f(java.lang.String x) becomes (Ljava/lang/String;)[I
-	 * 
+	 *
 	 * @param returnType what the method returns
 	 * @param argTypes what are the argument types
 	 * @return method signature for given type(s).

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ArrayType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ArrayType.java
@@ -55,7 +55,7 @@ package org.aspectj.apache.bcel.generic;
  */
 import org.aspectj.apache.bcel.Constants;
 
-/** 
+/**
  * Denotes array type, such as int[][]
  *
  * @version $Id: ArrayType.java,v 1.4 2008/08/26 15:02:04 aclement Exp $
@@ -69,7 +69,7 @@ public final class ArrayType extends ReferenceType {
    * Convenience constructor for array type, e.g. int[]
    *
    * @param type array type, e.g. T_INT
-   */ 
+   */
   public ArrayType(byte type, int dimensions) {
     this(BasicType.getType(type), dimensions);
   }
@@ -78,7 +78,7 @@ public final class ArrayType extends ReferenceType {
    * Convenience constructor for reference array type, e.g. Object[]
    *
    * @param class_name complete name of class (java.lang.String, e.g.)
-   */ 
+   */
   public ArrayType(String class_name, int dimensions) {
     this(new ObjectType(class_name), dimensions);
   }
@@ -87,7 +87,7 @@ public final class ArrayType extends ReferenceType {
    * Constructor for array of given type
    *
    * @param type type of array (may be an array itself)
-   */ 
+   */
   public ArrayType(Type type, int dimensions) {
     super(Constants.T_ARRAY, "<dummy>");
 
@@ -100,7 +100,7 @@ public final class ArrayType extends ReferenceType {
       this.dimensions = dimensions + array.dimensions;
       basic_type      = array.basic_type;
       break;
-      
+
     case Constants.T_VOID:
       throw new ClassGenException("Invalid type: void[]");
 

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/BasicType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/BasicType.java
@@ -57,14 +57,14 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * Denotes basic type such as int.
- * 
+ *
  * @version $Id: BasicType.java,v 1.4 2008/08/28 00:05:57 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
 public final class BasicType extends Type {
 	/**
 	 * Constructor for basic types such as int, long, `void'
-	 * 
+	 *
 	 * @param type one of T_INT, T_BOOLEAN, ..., T_VOID
 	 * @see org.aspectj.apache.bcel.Constants
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/BranchHandle.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/BranchHandle.java
@@ -57,7 +57,7 @@ package org.aspectj.apache.bcel.generic;
 /**
  * BranchHandle is returned by specialized InstructionList.append() whenever a BranchInstruction is appended. This is useful when
  * the target of this instruction is not known at time of creation and must be set later via setTarget().
- * 
+ *
  * @see InstructionHandle
  * @see Instruction
  * @see InstructionList
@@ -92,7 +92,7 @@ public final class BranchHandle extends InstructionHandle {
 	 * Called by InstructionList.setPositions when setting the position for every instruction. In the presence of variable length
 	 * instructions 'setPositions()' performs multiple passes over the instruction list to calculate the correct (byte) positions
 	 * and offsets by calling this function.
-	 * 
+	 *
 	 * @param offset additional offset caused by preceding (variable length) instructions
 	 * @param max_offset the maximum offset that may be caused by these instructions
 	 * @return additional offset caused by possible change of this instruction's length

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ClassGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ClassGen.java
@@ -79,11 +79,11 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeVisAnnos;
 
 /**
  * Template class for building up a java class. May be initialized with an existing java class.
- * 
+ *
  * @see JavaClass
  * @version $Id: ClassGen.java,v 1.15 2009/09/15 19:40:14 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
- * 
+ *
  *         Upgraded, Andy Clement 9th Mar 06 - calculates SUID
  */
 public class ClassGen extends Modifiers implements Cloneable {
@@ -236,9 +236,9 @@ public class ClassGen extends Modifiers implements Cloneable {
 
 	/**
 	 * Convenience method.
-	 * 
+	 *
 	 * Add an empty constructor to this class that does nothing but calling super().
-	 * 
+	 *
 	 * @param access rights for constructor
 	 */
 	public void addEmptyConstructor(int access_flags) {
@@ -255,7 +255,7 @@ public class ClassGen extends Modifiers implements Cloneable {
 
 	/**
 	 * Add a field to this class.
-	 * 
+	 *
 	 * @param f field to add
 	 */
 	public void addField(Field f) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ClassGenException.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ClassGenException.java
@@ -54,7 +54,7 @@ package org.aspectj.apache.bcel.generic;
  * <http://www.apache.org/>.
  */
 
-/** 
+/**
  * Thrown on internal errors. Extends RuntimeException so it hasn't to be declared
  * in the throws clause every time.
  *

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/CodeExceptionGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/CodeExceptionGen.java
@@ -57,7 +57,7 @@ package org.aspectj.apache.bcel.generic;
 import org.aspectj.apache.bcel.classfile.CodeException;
 import org.aspectj.apache.bcel.classfile.ConstantPool;
 
-/** 
+/**
  * This class represents an exception handler, i.e., specifies the  region where
  * a handler is active and an instruction where the actual handling is done.
  * pool as parameters. Opposed to the JVM specification the end of the handled
@@ -78,7 +78,7 @@ public final class CodeExceptionGen
   private InstructionHandle end_pc;
   private InstructionHandle handler_pc;
   private ObjectType        catch_type;
-  
+
   /**
    * Add an exception handler, i.e., specify region where a handler is active and an
    * instruction where the actual handling is done.
@@ -112,15 +112,15 @@ public final class CodeExceptionGen
 			     (catch_type == null)? 0 : cp.addClass(catch_type));
   }
 
-  /* Set start of handler 
+  /* Set start of handler
    * @param start_pc Start of handled region (inclusive)
    */
   public void setStartPC(InstructionHandle start_pc) {
 	  InstructionBranch.notifyTarget(this.start_pc, start_pc, this);
-    this.start_pc = start_pc; 
+    this.start_pc = start_pc;
   }
 
-  /* Set end of handler 
+  /* Set end of handler
    * @param end_pc End of handled region (inclusive)
    */
   public void setEndPC(InstructionHandle end_pc) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldGen.java
@@ -75,7 +75,7 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeAnnos;
 /**
  * Template class for building up a field. The only extraordinary thing one can do is to add a constant value attribute to a field
  * (which must of course be compatible with the declared type).
- * 
+ *
  * @version $Id: FieldGen.java,v 1.11 2011/10/03 22:41:24 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Field
@@ -86,7 +86,7 @@ public class FieldGen extends FieldGenOrMethodGen {
 	/**
 	 * Declare a field. If it is static (isStatic() == true) and has a basic type like int or String it may have an initial value
 	 * associated with it as defined by setInitValue().
-	 * 
+	 *
 	 * @param modifiers access qualifiers
 	 * @param type field type
 	 * @param name field name
@@ -101,7 +101,7 @@ public class FieldGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Instantiate from existing field.
-	 * 
+	 *
 	 * @param field Field object
 	 * @param cp constant pool (must contain the same entries as the field's constant pool)
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldGenOrMethodGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldGenOrMethodGen.java
@@ -67,7 +67,7 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeAnnos;
 
 /**
  * Super class for FieldGen and MethodGen objects, since they have some methods in common!
- * 
+ *
  * @version $Id: FieldGenOrMethodGen.java,v 1.8 2009/09/15 19:40:14 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldInstruction.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldInstruction.java
@@ -58,7 +58,7 @@ import org.aspectj.apache.bcel.classfile.ConstantPool;
 
 /**
  * Super class for the GET/PUTxxx family of instructions.
- * 
+ *
  * @version $Id: FieldInstruction.java,v 1.7 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldOrMethod.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/FieldOrMethod.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.classfile.ConstantUtf8;
 
 /**
  * Super class for InvokeInstruction and FieldInstruction, since they have some methods in common!
- * 
+ *
  * @version $Id: FieldOrMethod.java,v 1.8 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/IINC.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/IINC.java
@@ -60,7 +60,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * IINC - Increment local variable by constant
- * 
+ *
  * @version $Id: IINC.java,v 1.5 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/INVOKEINTERFACE.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/INVOKEINTERFACE.java
@@ -61,11 +61,11 @@ import org.aspectj.apache.bcel.classfile.ConstantPool;
 
 /**
  * INVOKEINTERFACE - Invoke interface method
- * 
+ *
  * <PRE>
  * Stack: ..., objectref, [arg1, [arg2 ...]] -&gt; ...
  * </PRE>
- * 
+ *
  * @version $Id: INVOKEINTERFACE.java,v 1.4 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -84,7 +84,7 @@ public final class INVOKEINTERFACE extends InvokeInstruction {
 
 	/**
 	 * Dump instruction as byte code to stream out.
-	 * 
+	 *
 	 * @param out Output stream
 	 */
 	public void dump(DataOutputStream out) throws IOException {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Instruction.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Instruction.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * Abstract super class for all Java byte codes.
- * 
+ *
  * @version $Id: Instruction.java,v 1.10 2011/04/05 15:15:33 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -86,7 +86,7 @@ public class Instruction implements Cloneable, Serializable, Constants {
 	/**
 	 * Use with caution, since 'BranchInstruction's have a 'target' reference which is not copied correctly (only basic types are).
 	 * This also applies for 'Select' instructions with their multiple branch targets.
-	 * 
+	 *
 	 * @return (shallow) copy of an instruction
 	 */
 	// GET RID OF THIS - make it throw an exception and track the callers
@@ -107,7 +107,7 @@ public class Instruction implements Cloneable, Serializable, Constants {
 
 	/**
 	 * Read an instruction bytecode from an input stream and return the appropriate object.
-	 * 
+	 *
 	 * @param file file to read from
 	 * @return instruction object being read
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionBranch.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionBranch.java
@@ -63,7 +63,7 @@ import org.aspectj.apache.bcel.classfile.ConstantPool;
  * Abstract super class for branching instructions like GOTO, IFEQ, etc.. Branch instructions may have a variable length, namely
  * GOTO, JSR, LOOKUPSWITCH and TABLESWITCH. A branch instruction may be talking in terms of absolute destination (targetIndex) or
  * about an instruction it doesnt yet know the position if (targetInstruction). targetInstruction (if set) overrides targetIndex
- * 
+ *
  * @see InstructionList
  * @version $Id: InstructionBranch.java,v 1.6 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
@@ -153,7 +153,7 @@ public class InstructionBranch extends Instruction implements InstructionTargete
 	 * Called by InstructionList.setPositions when setting the position for every instruction. In the presence of variable length
 	 * instructions `setPositions' performs multiple passes over the instruction list to calculate the correct (byte) positions and
 	 * offsets by calling this function.
-	 * 
+	 *
 	 * @param offset additional offset caused by preceding (variable length) instructions
 	 * @param max_offset the maximum offset that may be caused by these instructions
 	 * @return additional offset caused by possible change of this instruction's length
@@ -183,7 +183,7 @@ public class InstructionBranch extends Instruction implements InstructionTargete
 
 	/**
 	 * Long output format:
-	 * 
+	 *
 	 * @param verbose long/short format switch
 	 * @return mnemonic for instruction
 	 */
@@ -227,7 +227,7 @@ public class InstructionBranch extends Instruction implements InstructionTargete
 
 	/**
 	 * Set branch target
-	 * 
+	 *
 	 * @param target branch target
 	 */
 	public void setTarget(InstructionHandle target) {
@@ -250,7 +250,7 @@ public class InstructionBranch extends Instruction implements InstructionTargete
 	/**
 	 * Update the target destination for this instruction. If an oldHandle is provided it is checked to verify that is where the
 	 * target currently points to before changing it.
-	 * 
+	 *
 	 * @param oldHandle old target
 	 * @param newHandle new target
 	 */
@@ -289,7 +289,7 @@ public class InstructionBranch extends Instruction implements InstructionTargete
 	 * Returns an InstructionHandle to the physical successor of this JsrInstruction. <B>For this method to work, this
 	 * JsrInstruction object must not be shared between multiple InstructionHandle objects!</B> Formally, there must not be
 	 * InstructionHandle objects i, j where i != j and i.getInstruction() == this == j.getInstruction().
-	 * 
+	 *
 	 * @return an InstructionHandle to the "next" instruction that will be executed when RETurned from a subroutine.
 	 */
 	public InstructionHandle physicalSuccessor() {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionByte.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionByte.java
@@ -78,7 +78,7 @@ public class InstructionByte extends Instruction {
 
 	/**
 	 * For supporting NEWARRAY
-	 * 
+	 *
 	 * @return typecode of the array
 	 */
 	public final byte getTypecode() {
@@ -87,7 +87,7 @@ public class InstructionByte extends Instruction {
 
 	/**
 	 * For supporting NEWARRAY
-	 * 
+	 *
 	 * @return type of the array
 	 */
 	public final Type getType() {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionCLV.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionCLV.java
@@ -9,11 +9,11 @@ public class InstructionCLV extends InstructionLV {
 	public InstructionCLV(short opcode) {
 		super(opcode);
 	}
-	
+
 	public InstructionCLV(short opcode,int localVariableIndex) {
 		super(opcode,localVariableIndex);
 	}
-	
+
 	public void setIndex(int localVariableIndex) {
 		if (localVariableIndex!=getIndex()) {
 			throw new ClassGenException("Do not attempt to modify the index to '"+localVariableIndex+"' for this constant instruction: "+this);

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionCP.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionCP.java
@@ -70,7 +70,7 @@ import org.aspectj.apache.bcel.classfile.ConstantUtf8;
 
 /**
  * Class for instructions that use an index into the constant pool such as LDC, INVOKEVIRTUAL, etc.
- * 
+ *
  * @version $Id: InstructionCP.java,v 1.6 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -111,10 +111,10 @@ public class InstructionCP extends Instruction {
 
 	/**
 	 * Long output format:
-	 * 
+	 *
 	 * &lt;name of opcode&gt; "["&lt;opcode number&gt;"]" "("&lt;length of instruction&gt;")" "&lt;"&lt; constant pool
 	 * index&gt;"&gt;"
-	 * 
+	 *
 	 * @param verbose long/short format switch
 	 * @return mnemonic for instruction
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionFactory.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionFactory.java
@@ -60,7 +60,7 @@ import org.aspectj.apache.bcel.classfile.Utility;
 /**
  * Instances of this class may be used, e.g., to generate typed versions of instructions. Its main purpose is to be used as the byte
  * code generating backend of a compiler. You can subclass it to add your own create methods.
- * 
+ *
  * @version $Id: InstructionFactory.java,v 1.7 2010/08/23 20:44:10 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Constants
@@ -85,10 +85,10 @@ public class InstructionFactory implements InstructionConstants {
 	public InvokeInstruction createInvoke(String class_name, String name, Type ret_type, Type[] arg_types, short kind) {
 		return createInvoke(class_name, name, ret_type, arg_types, kind, false);
 	}
-		
+
 	/**
 	 * Create an invoke instruction.
-	 * 
+	 *
 	 * @param class_name name of the called class
 	 * @param name name of the called method
 	 * @param ret_type return type of method
@@ -173,7 +173,7 @@ public class InstructionFactory implements InstructionConstants {
 
 	/**
 	 * Uses PUSH to push a constant value onto the stack.
-	 * 
+	 *
 	 * @param value must be of type Number, Boolean, Character or String
 	 */
 	// OPTIMIZE callers should use the PUSH methods where possible if they know the types
@@ -199,7 +199,7 @@ public class InstructionFactory implements InstructionConstants {
 
 	/**
 	 * Create a field instruction.
-	 * 
+	 *
 	 * @param class_name name of the accessed class
 	 * @param name name of the referenced field
 	 * @param type type of field
@@ -520,7 +520,7 @@ public class InstructionFactory implements InstructionConstants {
 
 	/**
 	 * Create new array of given size and type.
-	 * 
+	 *
 	 * @return an instruction that creates the corresponding array at runtime, i.e. is an AllocationInstruction
 	 */
 	public Instruction createNewArray(Type t, short dim) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionHandle.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionHandle.java
@@ -63,11 +63,11 @@ import org.aspectj.apache.bcel.classfile.Utility;
 /**
  * Instances of this class give users a handle to the instructions contained in an InstructionList. Instruction objects may be used
  * more than once within a list, this is useful because it saves memory and may be much faster.
- * 
+ *
  * Within an InstructionList an InstructionHandle object is wrapped around all instructions, i.e., it implements a cell in a
  * doubly-linked list. From the outside only the next and the previous instruction (handle) are accessible. One can traverse the
  * list via an Enumeration returned by InstructionList.elements().
- * 
+ *
  * @version $Id: InstructionHandle.java,v 1.9 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see Instruction

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionLV.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionLV.java
@@ -60,7 +60,7 @@ import org.aspectj.apache.bcel.Constants;
 
 /**
  * Abstract super class for instructions dealing with local variables.
- * 
+ *
  * @version $Id: InstructionLV.java,v 1.5 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -128,7 +128,7 @@ public class InstructionLV extends Instruction {
 
 	/**
 	 * Long output format:
-	 * 
+	 *
 	 * 'name of opcode' "[" 'opcode number' "]" "(" 'length of instruction' ")" "<" 'local variable index' ">"
 	 */
 	public String toString(boolean verbose) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionList.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionList.java
@@ -74,9 +74,9 @@ import org.aspectj.apache.bcel.util.ByteSequence;
  * inserted, moved, deleted, etc.. Instructions are being wrapped into <a href="InstructionHandle.html">InstructionHandles</a>
  * objects that are returned upon append/insert operations. They give the user (read only) access to the list structure, such that
  * it can be traversed and manipulated in a controlled way.
- * 
+ *
  * A list is finally dumped to a byte code array with <a href="#getByteCode()">getByteCode</a>.
- * 
+ *
  * @version $Id: InstructionList.java,v 1.12 2011/09/02 22:33:04 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author Abraham Nevado
@@ -106,7 +106,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Find the target instruction (handle) that corresponds to the given target position (byte code offset).
-	 * 
+	 *
 	 * @param ihs array of instruction handles, i.e. il.getInstructionHandles()
 	 * @param pos array of positions corresponding to ihs, i.e. il.getInstructionPositions()
 	 * @param count length of arrays
@@ -143,7 +143,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Get instruction handle for instruction at byte code position pos. This only works properly, if the list is freshly
 	 * initialized from a byte array or setPositions() has been called before this method.
-	 * 
+	 *
 	 * @param pos byte code position to search for
 	 * @return target position's instruction handle if available
 	 */
@@ -166,7 +166,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Initialize instruction list from byte array.
-	 * 
+	 *
 	 * @param code byte array containing the instructions
 	 */
 	public InstructionList(byte[] code) {
@@ -248,7 +248,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append another list after instruction (handle) ih contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param appendTo where to append the instruction list
 	 * @param appendee Instruction list to append to this one
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -283,7 +283,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append another list after instruction i contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param i where to append the instruction list
 	 * @param il Instruction list to append to this one
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -300,7 +300,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append another list to this one. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param il list to append to end of this list
 	 * @return instruction handle of the <B>first</B> appended instruction
 	 */
@@ -326,7 +326,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction to the end of this list.
-	 * 
+	 *
 	 * @param ih instruction to append
 	 */
 	private void append(InstructionHandle ih) {
@@ -345,7 +345,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction to the end of this list.
-	 * 
+	 *
 	 * @param i instruction to append
 	 * @return instruction handle of the appended instruction
 	 */
@@ -376,7 +376,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append a branch instruction to the end of this list.
-	 * 
+	 *
 	 * @param i branch instruction to append
 	 * @return branch instruction handle of the appended instruction
 	 */
@@ -389,7 +389,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append a single instruction j after another instruction i, which must be in this list of course!
-	 * 
+	 *
 	 * @param i Instruction in list
 	 * @param j Instruction to append after i in list
 	 * @return instruction handle of the first appended instruction
@@ -400,7 +400,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction after instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to append the instruction list
 	 * @param i Instruction to append
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -411,7 +411,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Append an instruction after instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to append the instruction list
 	 * @param i Instruction to append
 	 * @return instruction handle pointing to the <B>first</B> appended instruction
@@ -428,7 +428,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert another list before Instruction handle ih contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param i where to append the instruction list
 	 * @param il Instruction list to insert
 	 * @return instruction handle of the first inserted instruction
@@ -464,7 +464,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert another list.
-	 * 
+	 *
 	 * @param il list to insert before start of this list
 	 * @return instruction handle of the first inserted instruction
 	 */
@@ -479,7 +479,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction at start of this list.
-	 * 
+	 *
 	 * @param ih instruction to insert
 	 */
 	private void insert(InstructionHandle ih) {
@@ -498,7 +498,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert another list before Instruction i contained in this list. Consumes argument list, i.e., it becomes empty.
-	 * 
+	 *
 	 * @param i where to append the instruction list
 	 * @param il Instruction list to insert
 	 * @return instruction handle pointing to the first inserted instruction, i.e., il.getStart()
@@ -515,7 +515,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction at start of this list.
-	 * 
+	 *
 	 * @param i instruction to insert
 	 * @return instruction handle of the inserted instruction
 	 */
@@ -528,7 +528,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert a branch instruction at start of this list.
-	 * 
+	 *
 	 * @param i branch instruction to insert
 	 * @return branch instruction handle of the appended instruction
 	 */
@@ -540,7 +540,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert a single instruction j before another instruction i, which must be in this list of course!
-	 * 
+	 *
 	 * @param i Instruction in list
 	 * @param j Instruction to insert before i in list
 	 * @return instruction handle of the first inserted instruction
@@ -551,7 +551,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction before instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to insert to the instruction list
 	 * @param i Instruction to insert
 	 * @return instruction handle of the first inserted instruction
@@ -562,7 +562,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Insert an instruction before instruction (handle) ih contained in this list.
-	 * 
+	 *
 	 * @param ih where to insert to the instruction list
 	 * @param i Instruction to insert
 	 * @return instruction handle of the first inserted instruction
@@ -582,7 +582,7 @@ public class InstructionList implements Serializable {
 	 * be after "start" and target must not be located withing this range. If you want to move something to the start of the list
 	 * use null as value for target.<br>
 	 * Any instruction targeters pointing to handles within the block, keep their targets.
-	 * 
+	 *
 	 * @param start of moved block
 	 * @param end of moved block
 	 * @param target of moved block
@@ -644,7 +644,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Move a single instruction (handle) to a new location.
-	 * 
+	 *
 	 * @param ih moved instruction
 	 * @param target new location of moved instruction
 	 */
@@ -654,10 +654,10 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Remove from instruction 'prev' to instruction 'next' both contained in this list.
-	 * 
+	 *
 	 * If careAboutLostTargeters is true then this method will throw a TargetLostException when one of the removed instruction
 	 * handles is still being targeted.
-	 * 
+	 *
 	 * @param prev where to start deleting (predecessor, exclusive)
 	 * @param next where to end deleting (successor, exclusive)
 	 */
@@ -757,7 +757,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Remove instruction from this list. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param ih instruction (handle) to remove
 	 */
 	public void delete(InstructionHandle ih) throws TargetLostException {
@@ -766,7 +766,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Remove instruction from this list. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param i instruction to remove
 	 */
 	// public void delete(Instruction i) throws TargetLostException {
@@ -780,7 +780,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Remove instructions from instruction `from' to instruction `to' contained in this list. The user must ensure that `from' is
 	 * an instruction before `to', or risk havoc. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param from where to start deleting (inclusive)
 	 * @param to where to end deleting (inclusive)
 	 */
@@ -791,7 +791,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Remove instructions from instruction `from' to instruction `to' contained in this list. The user must ensure that `from' is
 	 * an instruction before `to', or risk havoc. The corresponding Instruction handles must not be reused!
-	 * 
+	 *
 	 * @param from where to start deleting (inclusive)
 	 * @param to where to end deleting (inclusive)
 	 */
@@ -810,7 +810,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Search for given Instruction reference, start at beginning of list.
-	 * 
+	 *
 	 * @param i instruction to search for
 	 * @return instruction found on success, null otherwise
 	 */
@@ -826,7 +826,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Search for given Instruction reference, start at end of list
-	 * 
+	 *
 	 * @param i instruction to search for
 	 * @return instruction found on success, null otherwise
 	 */
@@ -864,7 +864,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Give all instructions their position number (offset in byte stream), i.e., make the list ready to be dumped.
-	 * 
+	 *
 	 * @param check Perform sanity checks, e.g. if all targeted instructions really belong to this list
 	 */
 	public void setPositions(boolean check) {
@@ -972,7 +972,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * When everything is finished, use this method to convert the instruction list into an array of bytes.
-	 * 
+	 *
 	 * @return the byte code ready to be dumped
 	 */
 	public byte[] getByteCode() {
@@ -1079,7 +1079,7 @@ public class InstructionList implements Serializable {
 	/**
 	 * Get positions (offsets) of all instructions in the list. This relies on that the list has been freshly created from an byte
 	 * code array, or that setPositions() has been called. Otherwise this may be inaccurate.
-	 * 
+	 *
 	 * @return array containing all instruction's offset in byte code
 	 */
 	public int[] getInstructionPositions() {
@@ -1208,7 +1208,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Redirect all references from old_target to new_target, i.e., update targets of branch instructions.
-	 * 
+	 *
 	 * @param old_target the old target instruction handle
 	 * @param new_target the new target instruction handle
 	 */
@@ -1239,7 +1239,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Redirect all references of local variables from old_target to new_target.
-	 * 
+	 *
 	 * @param lg array of local variables
 	 * @param old_target the old target instruction handle
 	 * @param new_target the new target instruction handle
@@ -1261,7 +1261,7 @@ public class InstructionList implements Serializable {
 
 	/**
 	 * Redirect all references of exception handlers from old_target to new_target.
-	 * 
+	 *
 	 * @param exceptions array of exception handlers
 	 * @param old_target the old target instruction handle
 	 * @param new_target the new target instruction handle

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionSelect.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InstructionSelect.java
@@ -60,7 +60,7 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * Select - Abstract super class for LOOKUPSWITCH and TABLESWITCH instructions.
- * 
+ *
  * @version $Id: InstructionSelect.java,v 1.4 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see LOOKUPSWITCH
@@ -79,7 +79,7 @@ public abstract class InstructionSelect extends InstructionBranch {
 
 	/**
 	 * (Match, target) pairs for switch. `Match' and `targets' must have the same length of course.
-	 * 
+	 *
 	 * @param match array of matching values
 	 * @param targets instruction targets
 	 * @param target default instruction target
@@ -119,11 +119,11 @@ public abstract class InstructionSelect extends InstructionBranch {
 	/**
 	 * Since this is a variable length instruction, it may shift the following instructions which then need to update their
 	 * position.
-	 * 
+	 *
 	 * Called by InstructionList.setPositions when setting the position for every instruction. In the presence of variable length
 	 * instructions `setPositions' performs multiple passes over the instruction list to calculate the correct (byte) positions and
 	 * offsets by calling this function.
-	 * 
+	 *
 	 * @param offset additional offset caused by preceding (variable length) instructions
 	 * @param max_offset the maximum offset that may be caused by these instructions
 	 * @return additional offset caused by possible change of this instruction's length
@@ -146,7 +146,7 @@ public abstract class InstructionSelect extends InstructionBranch {
 
 	/**
 	 * Dump instruction as byte code to stream out.
-	 * 
+	 *
 	 * @param out Output stream
 	 */
 	public void dump(DataOutputStream out) throws IOException {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InvokeDynamic.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InvokeDynamic.java
@@ -64,7 +64,7 @@ import org.aspectj.apache.bcel.classfile.ConstantPool;
 
 /**
  * INVOKEDYNAMIC
- * 
+ *
  * @author Andy Clement
  */
 public final class InvokeDynamic extends InvokeInstruction {
@@ -78,7 +78,7 @@ public final class InvokeDynamic extends InvokeInstruction {
 		out.writeShort(index);
 		out.writeShort(0);
 	}
-	
+
 	public String toString(ConstantPool cp) {
 		return super.toString(cp) + " " + index;
 	}
@@ -94,7 +94,7 @@ public final class InvokeDynamic extends InvokeInstruction {
 	public int hashCode() {
 		return opcode * 37 + index;
 	}
-	
+
 	public Type getReturnType(ConstantPool cp) {
 		return Type.getReturnType(getSignature(cp));
 	}
@@ -102,7 +102,7 @@ public final class InvokeDynamic extends InvokeInstruction {
 	public Type[] getArgumentTypes(ConstantPool cp) {
 		return Type.getArgumentTypes(getSignature(cp));
 	}
-	
+
 	public String getSignature(ConstantPool cp) {
 		if (signature == null) {
 			ConstantInvokeDynamic cid = (ConstantInvokeDynamic)cp.getConstant(index);
@@ -111,7 +111,7 @@ public final class InvokeDynamic extends InvokeInstruction {
 		}
 		return signature;
 	}
-	
+
 	@Override
 	public String getName(ConstantPool cp) {
 		if (name == null) {
@@ -121,7 +121,7 @@ public final class InvokeDynamic extends InvokeInstruction {
 		}
 		return name;
 	}
-	
+
 	public String getClassName(ConstantPool cp) {
 		throw new IllegalStateException("there is no classname for invokedynamic");
 	}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InvokeInstruction.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/InvokeInstruction.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.classfile.ConstantPool;
 
 /**
  * Super class for the INVOKExxx family of instructions.
- * 
+ *
  * @version $Id: InvokeInstruction.java,v 1.6 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -86,7 +86,7 @@ public class InvokeInstruction extends FieldOrMethod {
 
 	/**
 	 * Also works for instructions whose stack effect depends on the constant pool entry they reference.
-	 * 
+	 *
 	 * @return Number of words consumed from stack by this instruction
 	 */
 	public int consumeStack(ConstantPool cpg) {
@@ -100,7 +100,7 @@ public class InvokeInstruction extends FieldOrMethod {
 
 	/**
 	 * Also works for instructions whose stack effect depends on the constant pool entry they reference.
-	 * 
+	 *
 	 * @return Number of words produced onto stack by this instruction
 	 */
 	public int produceStack(ConstantPool cpg) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/LOOKUPSWITCH.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/LOOKUPSWITCH.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * LOOKUPSWITCH - Switch with unordered set of values
- * 
+ *
  * @version $Id: LOOKUPSWITCH.java,v 1.5 2011/04/05 15:15:33 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -76,7 +76,7 @@ public class LOOKUPSWITCH extends InstructionSelect {
 
 	/**
 	 * Dump instruction as byte code to stream out.
-	 * 
+	 *
 	 * @param out Output stream
 	 */
 	public void dump(DataOutputStream out) throws IOException {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/LineNumberGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/LineNumberGen.java
@@ -56,7 +56,7 @@ package org.aspectj.apache.bcel.generic;
 
 import org.aspectj.apache.bcel.classfile.LineNumber;
 
-/** 
+/**
  * This class represents a line number within a method, i.e., give an instruction
  * a line number corresponding to the source code line.
  *

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/LocalVariableGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/LocalVariableGen.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.classfile.LocalVariable;
 /**
  * This class represents a local variable within a method. It contains its scope, name and type. The generated LocalVariable object
  * can be obtained with getLocalVariable which needs the instruction list and the constant pool as parameters.
- * 
+ *
  * @version $Id: LocalVariableGen.java,v 1.7 2008/08/28 00:04:23 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see LocalVariable
@@ -76,7 +76,7 @@ public class LocalVariableGen implements InstructionTargeter, Cloneable, java.io
 	/**
 	 * Generate a local variable that with index `index'. Note that double and long variables need two indexs. Index indices have to
 	 * be provided by the user.
-	 * 
+	 *
 	 * @param index index of local variable
 	 * @param name its name
 	 * @param type its type
@@ -97,14 +97,14 @@ public class LocalVariableGen implements InstructionTargeter, Cloneable, java.io
 
 	/**
 	 * Get LocalVariable object.
-	 * 
+	 *
 	 * This relies on that the instruction list has already been dumped to byte code or or that the `setPositions' methods has been
 	 * called for the instruction list.
-	 * 
+	 *
 	 * Note that for local variables whose scope end at the last instruction of the method's code, the JVM specification is
 	 * ambiguous: both a start_pc+length ending at the last instruction and start_pc+length ending at first index beyond the end of
 	 * the code are valid.
-	 * 
+	 *
 	 * @param il instruction list (byte code) which this variable belongs to
 	 * @param cp constant pool
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/MULTIANEWARRAY.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/MULTIANEWARRAY.java
@@ -62,11 +62,11 @@ import org.aspectj.apache.bcel.classfile.ConstantPool;
 
 /**
  * MULTIANEWARRAY - Create new mutidimensional array of references
- * 
+ *
  * <PRE>
  * Stack: ..., count1, [count2, ...] -&gt; ..., arrayref
  * </PRE>
- * 
+ *
  * @version $Id: MULTIANEWARRAY.java,v 1.4 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */
@@ -80,7 +80,7 @@ public class MULTIANEWARRAY extends InstructionCP {
 
 	/**
 	 * Dump instruction as byte code to stream out.
-	 * 
+	 *
 	 * @param out Output stream
 	 */
 	public void dump(DataOutputStream out) throws IOException {
@@ -123,7 +123,7 @@ public class MULTIANEWARRAY extends InstructionCP {
 
 	/**
 	 * Also works for instructions whose stack effect depends on the constant pool entry they reference.
-	 * 
+	 *
 	 * @return Number of words consumed from stack by this instruction
 	 */
 	public int consumeStack(ConstantPool cpg) {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/MethodGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/MethodGen.java
@@ -79,10 +79,10 @@ import org.aspectj.apache.bcel.classfile.annotation.RuntimeParamAnnos;
  * Template class for building up a method. This is done by defining exception handlers, adding thrown exceptions, local variables
  * and attributes, whereas the 'LocalVariableTable' and 'LineNumberTable' attributes will be set automatically for the code. Use
  * stripAttributes() if you don't like this.
- * 
+ *
  * While generating code it may be necessary to insert NOP operations. You can use the `removeNOPs' method to get rid off them. The
  * resulting method object can be obtained via the `getMethod()' method.
- * 
+ *
  * @version $Id: MethodGen.java,v 1.17 2011/05/19 23:23:46 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author <A HREF="http://www.vmeng.com/beard">Patrick C. Beard</A> [setMaxStack()]
@@ -115,10 +115,10 @@ public class MethodGen extends FieldGenOrMethodGen {
 	 * Declare method. If the method is non-static the constructor automatically declares a local variable `$this' in slot 0. The
 	 * actual code is contained in the `il' parameter, which may further manipulated by the user. But he must take care not to
 	 * remove any instruction (handles) that are still referenced from this object.
-	 * 
+	 *
 	 * For example one may not add a local variable and later remove the instructions it refers to without causing havoc. It is safe
 	 * however if you remove that local variable, too.
-	 * 
+	 *
 	 * @param access_flags access qualifiers
 	 * @param return_type method type
 	 * @param arg_types argument types
@@ -164,7 +164,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 		// throw new ClassGenException("'void' is an illegal argument type for a method");
 		// }
 		// }
-		//	
+		//
 		// if(arg_names != null) { // Names for variables provided?
 		// if(size != arg_names.length)
 		// throw new ClassGenException("Mismatch in argument array lengths: " +
@@ -192,7 +192,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Instantiate from existing method.
-	 * 
+	 *
 	 * @param m method
 	 * @param class_name class name containing this method
 	 * @param cp constant pool
@@ -362,7 +362,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Adds a local variable to this method and assigns an index automatically.
-	 * 
+	 *
 	 * @param name variable name
 	 * @param type variable type
 	 * @param start from where the variable is valid, if this is null, it is valid from the start
@@ -424,7 +424,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	/*
 	 * If the range of the variable has not been set yet, it will be set to be valid from the start to the end of the instruction
 	 * list.
-	 * 
+	 *
 	 * @return array of declared local variables sorted by index
 	 */
 	public LocalVariableGen[] getLocalVariables() {
@@ -466,7 +466,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Give an instruction a line number corresponding to the source code line.
-	 * 
+	 *
 	 * @param ih instruction to tag
 	 * @return new line number object
 	 * @see LineNumber
@@ -517,7 +517,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	/**
 	 * Add an exception handler, i.e., specify region where a handler is active and an instruction where the actual handling is
 	 * done.
-	 * 
+	 *
 	 * @param start_pc Start of region (inclusive)
 	 * @param end_pc End of region (inclusive)
 	 * @param handler_pc Where handling is done
@@ -578,7 +578,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Add an exception possibly thrown by this method.
-	 * 
+	 *
 	 * @param class_name (fully qualified) name of exception
 	 */
 	public void addException(String class_name) {
@@ -629,7 +629,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	 * Add an attribute to the code. Currently, the JVM knows about the LineNumberTable, LocalVariableTable and StackMap attributes,
 	 * where the former two will be generated automatically and the latter is used for the MIDP only. Other attributes will be
 	 * ignored by the JVM but do no harm.
-	 * 
+	 *
 	 * @param a attribute to be added
 	 */
 	public void addCodeAttribute(Attribute a) {
@@ -674,7 +674,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 	/**
 	 * Get method object. Never forget to call setMaxStack() or setMaxStack(max), respectively, before calling this method (the same
 	 * applies for max locals).
-	 * 
+	 *
 	 * @return method object
 	 */
 	public Method getMethod() {
@@ -879,10 +879,10 @@ public class MethodGen extends FieldGenOrMethodGen {
 	public void setMaxLocals() {
 		setMaxLocals(false);
 	}
-	
+
 	/**
 	 * Compute maximum number of local variables.
-	 * 
+	 *
 	 * @param respectLocalVariableTable if true and the local variable table indicates more are in use
 	 * than the code suggests, respect the higher value from the local variable table data.
 	 */
@@ -966,7 +966,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Computes stack usage of an instruction list by performing control flow analysis.
-	 * 
+	 *
 	 * @return maximum stack depth used by method
 	 */
 	public static int getMaxStack(ConstantPool cp, InstructionList il, CodeExceptionGen[] et) {
@@ -1050,7 +1050,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 	/**
 	 * Return string representation close to declaration format, `public static void main(String[]) throws IOException', e.g.
-	 * 
+	 *
 	 * @return String representation of the method.
 	 */
 	@Override

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ObjectType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ObjectType.java
@@ -59,7 +59,7 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
 
 /**
  * Denotes reference such as java.lang.String.
- * 
+ *
  * @version $Id: ObjectType.java,v 1.7 2009/09/28 16:39:46 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/RET.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/RET.java
@@ -61,11 +61,11 @@ import org.aspectj.apache.bcel.classfile.ConstantPool;
 
 /**
  * RET - Return from subroutine
- * 
+ *
  * <PRE>
  * Stack: ..., -&gt; ..., address
  * </PRE>
- * 
+ *
  * @version $Id: RET.java,v 1.5 2009/10/05 17:35:36 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ReferenceType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ReferenceType.java
@@ -60,7 +60,7 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
 
 /**
  * Super class for object and array types.
- * 
+ *
  * @version $Id: ReferenceType.java,v 1.6 2009/09/09 22:18:20 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ReturnaddressType.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ReturnaddressType.java
@@ -55,7 +55,7 @@ package org.aspectj.apache.bcel.generic;
  */
 import org.aspectj.apache.bcel.Constants;
 
-/** 
+/**
  * Returnaddress, the type JSR or JSR_W instructions push upon the stack.
  *
  * see vmspec2 3.3.3
@@ -66,14 +66,14 @@ public class ReturnaddressType extends Type {
 
   public static final ReturnaddressType NO_TARGET = new ReturnaddressType();
   private InstructionHandle returnTarget;
- 
+
   /**
    * A Returnaddress [that doesn't know where to return to].
    */
   private ReturnaddressType(){
     super(Constants.T_ADDRESS, "<return address>");
   }
- 	
+
   /**
    * Creates a ReturnaddressType object with a target.
    */
@@ -81,7 +81,7 @@ public class ReturnaddressType extends Type {
     super(Constants.T_ADDRESS, "<return address targeting "+returnTarget+">");
   	this.returnTarget = returnTarget;
   }
-	
+
   /**
    * Returns if the two Returnaddresses refer to the same target.
    */
@@ -90,7 +90,7 @@ public class ReturnaddressType extends Type {
       return false;
 
     return ((ReturnaddressType)rat).returnTarget.equals(this.returnTarget);
-  }	
+  }
 
   /**
    * @return the target of this ReturnaddressType

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/SwitchBuilder.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/SwitchBuilder.java
@@ -54,7 +54,7 @@ package org.aspectj.apache.bcel.generic;
  * <http://www.apache.org/>.
  */
 
-/** 
+/**
  * SWITCH - Branch depending on int value, generates either LOOKUPSWITCH or
  * TABLESWITCH instruction, depending on whether the match values (int[]) can be
  * sorted with no gaps between the numbers.
@@ -74,7 +74,7 @@ public final class SwitchBuilder {
    * between the numbers, a TABLESWITCH instruction is generated, and
    * a LOOKUPSWITCH otherwise. The former may be more efficient, but
    * needs more space.
-   * 
+   *
    * Note, that the key array always will be sorted, though we leave
    * the original arrays unaltered.
    *
@@ -95,7 +95,7 @@ public final class SwitchBuilder {
       }
     else {
       sort(0, match_length - 1);
-      
+
       if(matchIsOrdered(max_gap)) {
 	fillup(max_gap, target);
 
@@ -109,7 +109,7 @@ public final class SwitchBuilder {
   public SwitchBuilder(int[] match, InstructionHandle[] targets, InstructionHandle target) {
     this(match, targets, target, 1);
   }
-  
+
   private final void fillup(int max_gap, InstructionHandle target) {
     int                 max_size = match_length + match_length * max_gap;
     int[]               m_vec    = new int[max_size];
@@ -121,7 +121,7 @@ public final class SwitchBuilder {
 
     for(int i=1; i < match_length; i++) {
       int prev = match[i-1];
-      int gap  = match[i] - prev; 
+      int gap  = match[i] - prev;
 
       for(int j=1; j < gap; j++) {
 	m_vec[count] = prev + j;
@@ -132,7 +132,7 @@ public final class SwitchBuilder {
       m_vec[count] = match[i];
       t_vec[count] = targets[i];
       count++;
-    }	
+    }
 
     match   = new int[count];
     targets = new InstructionHandle[count];

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/TABLESWITCH.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/TABLESWITCH.java
@@ -61,7 +61,7 @@ import org.aspectj.apache.bcel.util.ByteSequence;
 
 /**
  * TABLESWITCH - Switch within given range of values, i.e., low..high
- * 
+ *
  * @version $Id: TABLESWITCH.java,v 1.5 2008/08/28 00:05:29 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @see SWITCH
@@ -87,7 +87,7 @@ public class TABLESWITCH extends InstructionSelect {
 
 	/**
 	 * Dump instruction as byte code to stream out.
-	 * 
+	 *
 	 * @param out Output stream
 	 */
 	public void dump(DataOutputStream out) throws IOException {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/TargetLostException.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/TargetLostException.java
@@ -72,7 +72,7 @@ package org.aspectj.apache.bcel.generic;
  *       InstructionHandle[] targets = e.getTargets();
  *	 for(int i=0; i < targets.length; i++) {
  *	   InstructionTargeter[] targeters = targets[i].getTargeters();
- *     
+ *
  *	   for(int j=0; j < targeters.length; j++)
  *	     targeters[j].updateTarget(targets[i], new_target);
  *       }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Type.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/Type.java
@@ -67,10 +67,10 @@ import org.aspectj.apache.bcel.classfile.Utility;
 /**
  * Abstract super class for all possible java types, namely basic types such as int, object types like String and array types, e.g.
  * int[]
- * 
+ *
  * @version $Id: Type.java,v 1.14 2011/09/28 01:14:54 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
- * 
+ *
  *         modified: AndyClement 2-mar-05: Removed unnecessary static and optimized
  */
 public abstract class Type {
@@ -233,7 +233,7 @@ public abstract class Type {
 
 	/**
 	 * Convert signature to a Type object.
-	 * 
+	 *
 	 * @param signature signature string such as Ljava/lang/String;
 	 * @return type object
 	 */
@@ -292,7 +292,7 @@ public abstract class Type {
 
 	/**
 	 * Convert return value of a method (signature) to a Type object.
-	 * 
+	 *
 	 * @param signature signature string such as (Ljava/lang/String;)V
 	 * @return return type
 	 */
@@ -308,7 +308,7 @@ public abstract class Type {
 
 	/**
 	 * Convert arguments of a method (signature) to an array of Type objects.
-	 * 
+	 *
 	 * @param signature signature string such as (Ljava/lang/String;)V
 	 * @return array of argument types
 	 */
@@ -419,7 +419,7 @@ public abstract class Type {
 
 	/**
 	 * Convert runtime java.lang.Class to BCEL Type object.
-	 * 
+	 *
 	 * @param cl Java class
 	 * @return corresponding Type object
 	 */

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ByteSequence.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ByteSequence.java
@@ -58,7 +58,7 @@ import java.io.DataInputStream;
 
 /**
  * Utility class that implements a sequence of bytes which can be read
- * via the `readByte()' method. This is used to implement a wrapper for the 
+ * via the `readByte()' method. This is used to implement a wrapper for the
  * Java byte code stream to gain some more readability.
  *
  * @version $Id: ByteSequence.java,v 1.3 2008/05/28 23:52:53 aclement Exp $
@@ -67,12 +67,12 @@ import java.io.DataInputStream;
 public final class ByteSequence extends DataInputStream {
   private ByteArrayStream byte_stream;
 
-  public ByteSequence(byte[] bytes) { 
+  public ByteSequence(byte[] bytes) {
     super(new ByteArrayStream(bytes));
     byte_stream = (ByteArrayStream)in;
   }
 
-  public final int getIndex()   { return byte_stream.getPosition(); }    
+  public final int getIndex()   { return byte_stream.getPosition(); }
   final  void      unreadByte() { byte_stream.unreadByte(); }
 
   private static final class ByteArrayStream extends ByteArrayInputStream {

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderReference.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderReference.java
@@ -63,5 +63,5 @@ package org.aspectj.apache.bcel.util;
 public interface ClassLoaderReference {
 
     java.lang.ClassLoader getClassLoader();
-    
+
 }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
@@ -73,11 +73,11 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
 
 /**
  * The repository maintains information about which classes have been loaded.
- * 
+ *
  * It loads its data from the ClassLoader implementation passed into its constructor.
- * 
+ *
  * @see org.aspectj.apache.bcel.Repository
- * 
+ *
  * @version $Id: ClassLoaderRepository.java,v 1.13 2009/09/09 19:56:20 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author David Dixon-Peugh

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/DefaultClassLoaderReference.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/DefaultClassLoaderReference.java
@@ -57,13 +57,13 @@ package org.aspectj.apache.bcel.util;
 /**
  * Simplistic ClassLoaderReference that merely delegates to a classloader. More sophisticated ones could allow for the
  * loader to be weakly referenced.
- * 
+ *
  * @author Andy Clement
  */
 public class DefaultClassLoaderReference implements ClassLoaderReference {
 
     private java.lang.ClassLoader loader;
- 
+
     public DefaultClassLoaderReference(java.lang.ClassLoader classLoader) {
         this.loader = classLoader;
     }

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/NonCachingClassLoaderRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/NonCachingClassLoaderRepository.java
@@ -70,15 +70,15 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
 
 /**
  * The repository maintains information about which classes have been loaded.
- * 
+ *
  * It loads its data from the ClassLoader implementation passed into its constructor.
- * 
+ *
  * @see org.aspectj.apache.bcel.Repository
- * 
+ *
  * @version $Id: NonCachingClassLoaderRepository.java,v 1.6 2009/09/09 19:56:20 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author David Dixon-Peugh
- * 
+ *
  */
 public class NonCachingClassLoaderRepository implements Repository {
 	private static java.lang.ClassLoader bootClassLoader = null;

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/SyntheticRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/SyntheticRepository.java
@@ -67,12 +67,12 @@ import org.aspectj.apache.bcel.classfile.JavaClass;
  * file systems using the paths specified in the given class path. By default, this is the value returned by
  * ClassPath.getClassPath(). <br>
  * It is designed to be used as a singleton, however it can also be used with custom classpaths.
- * 
+ *
  * /** Abstract definition of a class repository. Instances may be used to load classes from different sources and may be used in
  * the Repository.setRepository method.
- * 
+ *
  * @see org.aspectj.apache.bcel.Repository
- * 
+ *
  * @version $Id: SyntheticRepository.java,v 1.8 2009/09/09 19:56:20 aclement Exp $
  * @author <A HREF="mailto:markus.dahm@berlin.de">M. Dahm</A>
  * @author David Dixon-Peugh
@@ -147,7 +147,7 @@ public class SyntheticRepository implements Repository {
 
 	/**
 	 * Try to find class source via getResourceAsStream().
-	 * 
+	 *
 	 * @see Class
 	 * @return JavaClass object for given runtime class
 	 */

--- a/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/ClassloaderRepositoryTest.java
+++ b/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/ClassloaderRepositoryTest.java
@@ -14,7 +14,7 @@ import junit.framework.TestCase;
 public class ClassloaderRepositoryTest extends TestCase {
 
 	private ClassLoaderRepository rep1,rep2;
-	
+
 	public void setUp() throws Exception {
 		super.setUp();
 		ClassLoader cl = Thread.currentThread().getContextClassLoader();
@@ -25,7 +25,7 @@ public class ClassloaderRepositoryTest extends TestCase {
 	}
 
 	// Retrieve string 5 times from same repository, 4 hits should be from local cache
-	public void testLocalCacheWorks() throws ClassNotFoundException {		
+	public void testLocalCacheWorks() throws ClassNotFoundException {
 		ClassLoaderRepository.useSharedCache=false;
 		JavaClass jc = rep1.loadClass("java.lang.String");
 		jc = rep1.loadClass("java.lang.String");
@@ -36,7 +36,7 @@ public class ClassloaderRepositoryTest extends TestCase {
 	}
 
 	// Retrieve string 5 times from same repository, 4 hits should be from local cache
-	public void testSharedCacheWorksOnOne() throws ClassNotFoundException {		
+	public void testSharedCacheWorksOnOne() throws ClassNotFoundException {
 		ClassLoaderRepository.useSharedCache=true;
 		JavaClass jc = rep1.loadClass("java.lang.String");
 		jc = rep1.loadClass("java.lang.String");
@@ -47,16 +47,16 @@ public class ClassloaderRepositoryTest extends TestCase {
 	}
 
 	// Retrieve String through one repository then load again through another, should be shared cache hit
-	public void testSharedCacheWorks() throws ClassNotFoundException {		
+	public void testSharedCacheWorks() throws ClassNotFoundException {
 		ClassLoaderRepository.useSharedCache=true;
 		JavaClass jc = rep1.loadClass("java.lang.String");
 		jc = rep2.loadClass("java.lang.String");
 		assertTrue("Should have retrieved String from shared cache: "+reportSharedCacheHits(rep1),
 				reportSharedCacheHits(rep1)==1);
 	}
-	
+
 	// Shared cache OFF, shouldn't get a shared cache hit
-	public void testSharedCacheCanBeDeactivated() throws ClassNotFoundException {		
+	public void testSharedCacheCanBeDeactivated() throws ClassNotFoundException {
 		try {
 			ClassLoaderRepository.useSharedCache=false;
 			JavaClass jc = rep1.loadClass("java.lang.String");
@@ -68,7 +68,7 @@ public class ClassloaderRepositoryTest extends TestCase {
 			ClassLoaderRepository.useSharedCache=true;
 		}
 	}
-	
+
 	public void tearDown() throws Exception {
 		super.tearDown();
 		System.err.println("Rep1: "+rep1.reportStats());

--- a/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/Fundamentals.java
+++ b/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/Fundamentals.java
@@ -22,10 +22,10 @@ import junit.framework.TestCase;
 
 // Check things that have to be true based on the specification
 public class Fundamentals extends TestCase {
-  
+
 	// Checking: opcode, length, consumed stack entries, produced stack entries
 	public void testInstructions() {
-		
+
 		// Instructions 000-009
 		checkInstruction(InstructionConstants.NOP,0,1,0,0);
 		checkInstruction(InstructionConstants.ACONST_NULL,1,1,0,1);
@@ -49,7 +49,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(new InstructionShort(Constants.SIPUSH,s0),17,3,0,1);
 		checkInstruction(new InstructionCP(Constants.LDC,b0),18,2,0,1);
 		checkInstruction(new InstructionCP(Constants.LDC_W,s0),19,2,0,1);
-		
+
 		// Instructions 020-029
 		checkInstruction(new InstructionCP(Constants.LDC2_W,s0),20,3,0,2);
 		checkInstruction(new InstructionLV(Constants.ILOAD,s20),21,2,0,1);
@@ -61,7 +61,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.ILOAD_1,27,1,0,1);
 		checkInstruction(InstructionConstants.ILOAD_2,28,1,0,1);
 		checkInstruction(InstructionConstants.ILOAD_3,29,1,0,1);
-		
+
 		// Instructions 030-039
 		checkInstruction(InstructionConstants.LLOAD_0,30,1,0,2);
 		checkInstruction(InstructionConstants.LLOAD_1,31,1,0,2);
@@ -73,7 +73,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.FLOAD_3,37,1,0,1);
 		checkInstruction(InstructionConstants.DLOAD_0,38,1,0,2);
 		checkInstruction(InstructionConstants.DLOAD_1,39,1,0,2);
-		
+
 		// Instructions 040-049
 		checkInstruction(InstructionConstants.DLOAD_2,40,1,0,2);
 		checkInstruction(InstructionConstants.DLOAD_3,41,1,0,2);
@@ -97,7 +97,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(new InstructionLV(Constants.DSTORE,s20),57,2,2,0);
 		checkInstruction(new InstructionLV(Constants.ASTORE,s20),58,2,1,0);
 		checkInstruction(InstructionConstants.ISTORE_0,59,1,1,0);
-		
+
 		// Instructions 060-069
 		checkInstruction(InstructionConstants.ISTORE_1,60,1,1,0);
 		checkInstruction(InstructionConstants.ISTORE_2,61,1,1,0);
@@ -109,7 +109,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.FSTORE_0,67,1,1,0);
 		checkInstruction(InstructionConstants.FSTORE_1,68,1,1,0);
 		checkInstruction(InstructionConstants.FSTORE_2,69,1,1,0);
-		
+
 		// Instructions 070-079
 		checkInstruction(InstructionConstants.FSTORE_3,70,1,1,0);
 		checkInstruction(InstructionConstants.DSTORE_0,71,1,2,0);
@@ -121,7 +121,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.ASTORE_2,77,1,1,0);
 		checkInstruction(InstructionConstants.ASTORE_3,78,1,1,0);
 		checkInstruction(InstructionConstants.IASTORE,79,1,3,0);
-		
+
 		// Instructions 080-089
 		checkInstruction(InstructionConstants.LASTORE,80,1,4,0);
 		checkInstruction(InstructionConstants.FASTORE,81,1,3,0);
@@ -133,7 +133,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.POP,87,1,1,0);
 		checkInstruction(InstructionConstants.POP2,88,1,2,0);
 		checkInstruction(InstructionConstants.DUP,89,1,1,2);
-		
+
 		// Instructions 090-099
 		checkInstruction(InstructionConstants.DUP_X1,90,1,2,3);
 		checkInstruction(InstructionConstants.DUP_X2,91,1,3,4);
@@ -157,7 +157,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.DMUL,107,1,4,2);
 		checkInstruction(InstructionConstants.IDIV,108,1,2,1);
 		checkInstruction(InstructionConstants.LDIV,109,1,4,2);
-		
+
 		// Instructions 110-119
 		checkInstruction(InstructionConstants.FDIV,110,1,2,1);
 		checkInstruction(InstructionConstants.DDIV,111,1,4,2);
@@ -169,7 +169,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.LNEG,117,1,2,2);
 		checkInstruction(InstructionConstants.FNEG,118,1,1,1);
 		checkInstruction(InstructionConstants.DNEG,119,1,2,2);
-		
+
 		// Instructions 120-129
 		checkInstruction(InstructionConstants.ISHL,120,1,2,1);
 		checkInstruction(InstructionConstants.LSHL,121,1,3,2);
@@ -181,7 +181,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(InstructionConstants.LAND,127,1,4,2);
 		checkInstruction(InstructionConstants.IOR,128,1,2,1);
 		checkInstruction(InstructionConstants.LOR,129,1,4,2);
-		
+
 		// Instructions 130-139
 		checkInstruction(InstructionConstants.IXOR,130,1,2,1);
 		checkInstruction(InstructionConstants.LXOR,131,1,4,2);
@@ -229,7 +229,7 @@ public class Fundamentals extends TestCase {
 		checkInstruction(new InstructionBranch(Constants.GOTO,s0),167,3,0,0);
 		checkInstruction(new InstructionBranch(Constants.JSR,s0),168,3,0,1);
 		checkInstruction(new RET(0,false),169,2,0,0);
-		
+
 		// Instructions 170-179
 		checkInstruction(new TABLESWITCH(new int[]{},new InstructionHandle[]{},null),170,VARIES,1,0);
 		checkInstruction(new LOOKUPSWITCH(new int[]{},new InstructionHandle[]{},null),171,VARIES,1,0);
@@ -265,19 +265,19 @@ public class Fundamentals extends TestCase {
 		checkInstruction(new MULTIANEWARRAY(s0,b0),197,4,VARIES,1);
 		checkInstruction(new InstructionBranch(Constants.IFNULL,s0),198,3,1,0);
 		checkInstruction(new InstructionBranch(Constants.IFNONNULL,s0),199,3,1,0);
-		
-		// Instructions 200-209		
+
+		// Instructions 200-209
 		checkInstruction(new InstructionBranch(Constants.GOTO_W,0),200,5,0,0);
 		checkInstruction(new InstructionBranch(Constants.JSR_W,0),201,5,0,1);
-		
+
 		// Internally used instructions skipped
 	}
-	
+
 	public void checkInstruction(Instruction i,int opcode, int length, int stackConsumed, int stackProduced) {
 		String header = new String("Checking instruction '"+i+"' ");
 		if (i.opcode!=opcode)
 			fail(header+" expected opcode "+opcode+" but it is "+i.opcode);
-		
+
 		if (length!=VARIES && i.getLength()!=length)
 			fail(header+" expected length "+length+" but it is "+i.getLength());
 //		if (stackConsumed>0) {
@@ -290,7 +290,7 @@ public class Fundamentals extends TestCase {
 		if (stackConsumed==VARIES) {
 			if (Constants.CONSUME_STACK[opcode]!=Constants.UNPREDICTABLE)
 				fail("Instruction '"+i+"' should be consuming some unpredictable number of stack entries but it says it will consume "+Constants.CONSUME_STACK[opcode]);
-			
+
 		} else {
 			if (Constants.CONSUME_STACK[opcode]!=stackConsumed)
 				fail("Instruction '"+i+"' should be consuming "+stackConsumed+" stack entries but it says it will consume "+Constants.CONSUME_STACK[opcode]);
@@ -305,8 +305,8 @@ public class Fundamentals extends TestCase {
 		if (stackProduced==VARIES) {
 			if (Constants.stackEntriesProduced[opcode]!=Constants.UNPREDICTABLE)
 				fail(header+" should be producing some unpredictable number of stack entries but it says it will produce "+Constants.stackEntriesProduced[opcode]);
-		
-		} else {	
+
+		} else {
 			if (Constants.stackEntriesProduced[opcode]!=stackProduced)
 				fail(header+" should be producing "+stackProduced+" stack entries but it says it will produce "+Constants.stackEntriesProduced[opcode]);
 		}

--- a/bcel-builder/src/test/java/org/aspectj/apache/bcel/util/Play.java
+++ b/bcel-builder/src/test/java/org/aspectj/apache/bcel/util/Play.java
@@ -11,7 +11,7 @@ import org.aspectj.apache.bcel.classfile.Method;
 import org.aspectj.apache.bcel.classfile.annotation.RuntimeAnnos;
 
 public class Play {
-	
+
 	public static void printBytes(byte[] bs) {
 		StringBuilder sb = new StringBuilder("Bytes:"+bs.length+"[");
 		for (int i=0;i<bs.length;i++) {
@@ -21,7 +21,7 @@ public class Play {
 		sb.append("]");
 		System.out.println(sb);
 	}
-	
+
 	public static void main(String[] args) throws Exception {
 		if (args==null || args.length==0 ) {
 			System.out.println("Specify a file");

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/BoundedReferenceTypeDelegate.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/BoundedReferenceTypeDelegate.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package org.aspectj.weaver;
 
@@ -78,7 +78,7 @@ class BoundedReferenceTypeDelegate extends AbstractReferenceTypeDelegate {
 	public AnnotationAJ[] getAnnotations() {
 		return resolvedTypeX.getAnnotations();
 	}
-	
+
 	public boolean hasAnnotations() {
 		return resolvedTypeX.hasAnnotations();
 	}

--- a/org.aspectj.matcher/src/test/java/org/aspectj/matcher/tools/ReflectionWorldPointcutExpressionTest.java
+++ b/org.aspectj.matcher/src/test/java/org/aspectj/matcher/tools/ReflectionWorldPointcutExpressionTest.java
@@ -5,7 +5,7 @@ import org.aspectj.weaver.reflect.ReflectionWorld;
 
 /**
  * Run all the pointcut parsing/matching tests against a ReflectionWorld.
- * 
+ *
  * @author Andy Clement
  */
 public class ReflectionWorldPointcutExpressionTest extends CommonPointcutExpressionTests {

--- a/tests/src/test/java/org/aspectj/systemtest/AllTests17.java
+++ b/tests/src/test/java/org/aspectj/systemtest/AllTests17.java
@@ -18,9 +18,9 @@ public class AllTests17 {
 	public static Test suite() {
 		TestSuite suite = new TestSuite("AspectJ System Test Suite - 1.7");
 		// $JUnit-BEGIN$
-		suite.addTest(AllTestsAspectJ175.suite()); 
-		suite.addTest(AllTestsAspectJ174.suite()); 
-		suite.addTest(AllTestsAspectJ173.suite()); 
+		suite.addTest(AllTestsAspectJ175.suite());
+		suite.addTest(AllTestsAspectJ174.suite());
+		suite.addTest(AllTestsAspectJ173.suite());
 		suite.addTest(AllTestsAspectJ172.suite());
 		suite.addTest(AllTestsAspectJ171.suite());
 		suite.addTest(AllTestsAspectJ170.suite());

--- a/tests/src/test/java/org/aspectj/systemtest/ajc150/GenericITDsDesign.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc150/GenericITDsDesign.java
@@ -245,7 +245,7 @@ public class GenericITDsDesign extends XMLBasedAjcTestCase {
 	// // Verify: a) sharing type vars with some target type results in the correct variable names in the serialized form
 	// public void testDesignE() {
 	// runTest("generic itds - design E");
-	//		
+	//
 	// }
 
 }

--- a/tests/src/test/java/org/aspectj/systemtest/ajc150/ltw/LTWServerTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc150/ltw/LTWServerTests.java
@@ -13,11 +13,11 @@ public class LTWServerTests extends XMLBasedAjcTestCase {
 	protected java.net.URL getSpecFile() {
 		return getClassResource("ltw.xml");
 	}
-    
+
   	public void testServerWithHelloWorld () {
   		runTest("TestServer with HelloWorld");
   	}
-    
+
   	public void testServerWithParentAndChild () {
   		runTest("TestServer with Parent and Child");
   	}

--- a/tests/src/test/java/org/aspectj/systemtest/ajc153/LTWServer153Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc153/LTWServer153Tests.java
@@ -15,7 +15,7 @@ public class LTWServer153Tests extends XMLBasedAjcTestCase {
 	protected URL getSpecFile() {
 	    return getClassResource("ajc153.xml");
 	}
-    
+
   	public void testHandleDuplicateConfiguration_pr157474 () {
   		runTest("TestServer with duplicate configuration");
   	}

--- a/weaver/src/test/java/fluffy/Aspect.java
+++ b/weaver/src/test/java/fluffy/Aspect.java
@@ -4,20 +4,20 @@ import org.aspectj.runtime.internal.AroundClosure;
 public class Aspect {
 
 	public static void ignoreMe() {}
-	
+
 	public static void before_method_call() {
-		System.out.println("before");	
+		System.out.println("before");
 	}
-	
+
 	public static void afterReturning_method_call() {
-		System.out.println("afterReturning");	
+		System.out.println("afterReturning");
 	}
 
 	public static void afterThrowing_method_execution(Throwable t) {
-		System.out.println("afterThrowing " + t);	
+		System.out.println("afterThrowing " + t);
 		t.printStackTrace();
 	}
-	
+
 	public static Object aroundFun(AroundClosure c) {
 		System.out.println("around");
 		try {

--- a/weaver/src/test/java/fluffy/Base.java
+++ b/weaver/src/test/java/fluffy/Base.java
@@ -4,15 +4,15 @@ public class Base {
 
 	public static void onlyBase() {}
 	public static void both() {}
-	
+
 	public void onlyBaseNonStatic() {}
 	public void bothNonStatic() {}
 
 	public int onlyBase;
 	public int both;
-	
+
 	public Base() {}
 	public Base(int i) {}
-	
+
 	public void m() throws CloneNotSupportedException {}
 }

--- a/weaver/src/test/java/fluffy/Derived.java
+++ b/weaver/src/test/java/fluffy/Derived.java
@@ -6,15 +6,15 @@ public class Derived extends Base {
 
 	public static void onlyDerived() throws IOException, CloneNotSupportedException {}
 	public static void both() {}
-	
+
 	public void onlyDerivedNonStatic() {}
 	public void bothNonStatic() {}
-	
+
 	public int onlyDerived;
 	public int both;
-	
+
 	public Derived() {}
-	
+
 	public void m() {}
-	
+
 }


### PR DESCRIPTION
Trailing whitespaces are useless. Most of code-styles forbids them. Most of editors always trim them on save.
I propose to clean up project from trailing whitespaces in all java files at once.