### PR TITLE
Cleanup redundant boxing.

### DIFF
--- a/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
@@ -227,7 +227,7 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 							String existingHandle = object.getHandleIdentifier();
 							int suffixPosition = existingHandle.indexOf('!');
 							if (suffixPosition != -1) {
-								count = Integer.valueOf(existingHandle.substring(suffixPosition + 1)) + 1;
+								count = Integer.parseInt(existingHandle.substring(suffixPosition + 1)) + 1;
 							} else {
 								if (count == 1) {
 									count = 2;
@@ -279,7 +279,7 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 							String existingHandle = object.getHandleIdentifier();
 							int suffixPosition = existingHandle.indexOf('!');
 							if (suffixPosition != -1) {
-								count = Integer.valueOf(existingHandle.substring(suffixPosition + 1)) + 1;
+								count = Integer.parseInt(existingHandle.substring(suffixPosition + 1)) + 1;
 							} else {
 								if (count == 1) {
 									count = 2;
@@ -314,7 +314,7 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 							int suffixPosition = existingHandle.lastIndexOf('!');
 							int lastSquareBracket = existingHandle.lastIndexOf('['); // type delimiter
 							if (suffixPosition != -1 && lastSquareBracket < suffixPosition) { // pr260384
-								count = Integer.valueOf(existingHandle.substring(suffixPosition + 1)) + 1;
+								count = Integer.parseInt(existingHandle.substring(suffixPosition + 1)) + 1;
 							} else {
 								if (count == 1) {
 									count = 2;
@@ -334,7 +334,7 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 							int suffixPosition = existingHandle.lastIndexOf('!');
 							int lastSquareBracket = existingHandle.lastIndexOf('['); // type delimiter
 							if (suffixPosition != -1 && lastSquareBracket < suffixPosition) { // pr260384
-								count = Integer.valueOf(existingHandle.substring(suffixPosition + 1)) + 1;
+								count = Integer.parseInt(existingHandle.substring(suffixPosition + 1)) + 1;
 							} else {
 								if (count == 1) {
 									count = 2;
@@ -383,7 +383,7 @@ public class JDTLikeHandleProvider implements IElementHandleProvider {
 					String existingHandle = object.getHandleIdentifier();
 					int suffixPosition = existingHandle.indexOf('!');
 					if (suffixPosition != -1) {
-						count = Integer.valueOf(existingHandle.substring(suffixPosition + 1)) + 1;
+						count = Integer.parseInt(existingHandle.substring(suffixPosition + 1)) + 1;
 					} else {
 						if (count == 1) {
 							count = 2;

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/ajdt/internal/compiler/batch/IncrementalCase.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/ajdt/internal/compiler/batch/IncrementalCase.java
@@ -311,7 +311,7 @@ public class IncrementalCase { // XXX NOT bound to junit - bridge tests?
 			if (-1 != loc)
 				s = s.substring(loc + 1);
 			try {
-				exp[i] = Integer.valueOf(s);
+				exp[i] = Integer.parseInt(s);
 				sb.append(exp[i] + ((i < (exp.length - 1)) ? ", " : ""));
 			} catch (NumberFormatException e) {
 				info(handler, "bad " + label + ":" + expected[i]);

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
@@ -1041,7 +1041,7 @@ public abstract class AjcTestCase extends TestCase {
 	private static boolean getBoolean(String name, boolean def) {
 		String defaultValue = String.valueOf(def);
 		String value = System.getProperty(name, defaultValue);
-		return Boolean.valueOf(value);
+		return Boolean.parseBoolean(value);
 	}
 
 	/*

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/TraceFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/TraceFactory.java
@@ -30,7 +30,7 @@ public abstract class TraceFactory {
     protected static boolean getBoolean(String name, boolean def) {
 		String defaultValue = String.valueOf(def);
 		String value = System.getProperty(name,defaultValue);
-		return Boolean.valueOf(value);
+		return Boolean.parseBoolean(value);
 	}
 
 	static {

--- a/testing/src/test/java/org/aspectj/testing/harness/bridge/FlatSuiteReader.java
+++ b/testing/src/test/java/org/aspectj/testing/harness/bridge/FlatSuiteReader.java
@@ -267,7 +267,7 @@ public class FlatSuiteReader implements SFileReader.Maker {
             description.setLength(0);
             description.append((prefix + " " + suffix).trim());
             try {
-                result.setBugId(Integer.valueOf(pr));
+                result.setBugId(Integer.parseInt(pr));
             } catch (NumberFormatException e) {
                 throw new Error("unable to convert " + pr + " for " + result
                     + " at " + lineReader);

--- a/testing/src/test/java/org/aspectj/testing/harness/bridge/ParseTestCase.java
+++ b/testing/src/test/java/org/aspectj/testing/harness/bridge/ParseTestCase.java
@@ -105,7 +105,7 @@ public class ParseTestCase extends TestCase {
         AjcTest.Spec test = new AjcTest.Spec();
         test.setDescription(title);
         test.setTestDirOffset(dir);
-        test.setBugId(Integer.valueOf(pr));
+        test.setBugId(Integer.parseInt(pr));
         test.setSourceLocation(sourceLocation);
 		//AjcTest test = new AjcTest(title, dir, pr, sourceLocation);
 
@@ -174,7 +174,7 @@ public class ParseTestCase extends TestCase {
 			file = new File("XXX");  //XXX
 		}
 
-		int line = Integer.valueOf(getAttributeString(child, "line"));
+		int line = Integer.parseInt(getAttributeString(child, "line"));
 
 		ISourceLocation sourceLocation = new SourceLocation(file, line, line, 0);
 

--- a/testing/src/test/java/org/aspectj/testing/xml/SoftMessage.java
+++ b/testing/src/test/java/org/aspectj/testing/xml/SoftMessage.java
@@ -300,7 +300,7 @@ public class SoftMessage implements IMessage {
 		if (null != sourceLocation) {
 			throw new IllegalStateException("cannot set line after creating source location");
 		}
-		this.line = Integer.valueOf(line);
+		this.line = Integer.parseInt(line);
 		SourceLocation.validLine(this.line);
 	}
 

--- a/testing/src/test/java/org/aspectj/testing/xml/SoftSourceLocation.java
+++ b/testing/src/test/java/org/aspectj/testing/xml/SoftSourceLocation.java
@@ -109,7 +109,7 @@ public class SoftSourceLocation implements ISourceLocation  {
     }
 
     private int convert(String in) {
-        return Integer.valueOf(in);
+        return Integer.parseInt(in);
     }
 
 	public String getLocationContext() {

--- a/util/src/main/java/org/aspectj/util/LangUtil.java
+++ b/util/src/main/java/org/aspectj/util/LangUtil.java
@@ -353,7 +353,7 @@ public class LangUtil {
 			try {
 				String value = System.getProperty(propertyName);
 				if (null != value) {
-					return Boolean.valueOf(value);
+					return Boolean.parseBoolean(value);
 				}
 			} catch (Throwable t) {
 				// default below


### PR DESCRIPTION
Methods `Integer.parseInt`/`Boolean.parseBoolean` should be preferred over `Integer.valueOf`/`Boolean.valueOf` if final result is assigned to primitive variable.
They are generally faster and generate less garbage.