### PR TITLE
Update org.aspectj.matcher code to use generics.

### DIFF
--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NewConstructorTypeMunger.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NewConstructorTypeMunger.java
@@ -89,9 +89,9 @@ public class NewConstructorTypeMunger extends ResolvedTypeMunger {
 		ResolvedMember sig = ResolvedMemberImpl.readResolvedMember(s, context);
 		ResolvedMember syntheticCtor = ResolvedMemberImpl.readResolvedMember(s, context);
 		ResolvedMember explicitCtor = ResolvedMemberImpl.readResolvedMember(s, context);
-		Set superMethodsCalled = readSuperMethodsCalled(s);
+		Set<ResolvedMember> superMethodsCalled = readSuperMethodsCalled(s);
 		sloc = readSourceLocation(s);
-		List typeVarAliases = readInTypeAliases(s);
+		List<String> typeVarAliases = readInTypeAliases(s);
 		ResolvedTypeMunger munger = new NewConstructorTypeMunger(sig, syntheticCtor, explicitCtor, superMethodsCalled,
 				typeVarAliases);
 		if (sloc != null) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NewFieldTypeMunger.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/NewFieldTypeMunger.java
@@ -57,9 +57,9 @@ public class NewFieldTypeMunger extends ResolvedTypeMunger {
 	public static ResolvedTypeMunger readField(VersionedDataInputStream s, ISourceContext context) throws IOException {
 		ISourceLocation sloc = null;
 		ResolvedMember fieldSignature = ResolvedMemberImpl.readResolvedMember(s, context);
-		Set superMethodsCalled = readSuperMethodsCalled(s);
+		Set<ResolvedMember> superMethodsCalled = readSuperMethodsCalled(s);
 		sloc = readSourceLocation(s);
-		List aliases = readInTypeAliases(s);
+		List<String> aliases = readInTypeAliases(s);
 		NewFieldTypeMunger munger = new NewFieldTypeMunger(fieldSignature, superMethodsCalled, aliases);
 		if (sloc != null) {
 			munger.setSourceLocation(sloc);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedPointcutDefinition.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedPointcutDefinition.java
@@ -101,7 +101,7 @@ public class ResolvedPointcutDefinition extends ResolvedMemberImpl {
 		if (isParameterized && (typeVariables.length != typeParameters.length)) {
 			throw new IllegalStateException("Wrong number of type parameters supplied");
 		}
-		Map typeMap = new HashMap();
+		Map<String, UnresolvedType> typeMap = new HashMap<>();
 		boolean typeParametersSupplied = typeParameters != null && typeParameters.length > 0;
 		if (typeVariables != null) {
 			// If no 'replacements' were supplied in the typeParameters array then collapse

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Shadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Shadow.java
@@ -549,7 +549,7 @@ public abstract class Shadow {
 
 	private void sortMungers() {
 
-		List sorted = PartialOrder.sort(mungers);
+		List<ShadowMunger> sorted = PartialOrder.sort(mungers);
 
 		// Bunch of code to work out whether to report xlints for advice that isn't ordered at this Joinpoint
 		possiblyReportUnorderedAdvice(sorted);
@@ -565,7 +565,7 @@ public abstract class Shadow {
 	}
 
 	// not quite optimal... but the xlint is ignore by default
-	private void possiblyReportUnorderedAdvice(List sorted) {
+	private void possiblyReportUnorderedAdvice(List<ShadowMunger> sorted) {
 		if (sorted != null && getIWorld().getLint().unorderedAdviceAtShadow.isEnabled() && mungers.size() > 1) {
 
 			// Stores a set of strings of the form 'aspect1:aspect2' which indicates there is no

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/WeakClassLoaderReference.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/WeakClassLoaderReference.java
@@ -36,10 +36,10 @@ public class WeakClassLoaderReference{
 
 	protected final int hashcode;
 
-	private final WeakReference loaderRef;
+	private final WeakReference<ClassLoader> loaderRef;
 
 	public WeakClassLoaderReference(ClassLoader loader) {
-		loaderRef = new WeakReference(loader);
+		loaderRef = new WeakReference<>(loader);
 		if(loader == null){
 			// Bug: 363962
 			// Check that ClassLoader is not null, for instance when loaded from BootStrapClassLoader

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/internal/tools/PointcutExpressionImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/internal/tools/PointcutExpressionImpl.java
@@ -411,8 +411,8 @@ public class PointcutExpressionImpl implements PointcutExpression {
 
 	public static class Handler implements Member {
 
-		private Class decClass;
-		private Class exType;
+		private Class<?> decClass;
+		private Class<?> exType;
 
 		public Handler(Class decClass, Class exType) {
 			this.decClass = decClass;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/internal/tools/StandardPointcutExpressionImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/internal/tools/StandardPointcutExpressionImpl.java
@@ -354,8 +354,8 @@ public class StandardPointcutExpressionImpl implements StandardPointcutExpressio
 
 	public static class Handler implements Member {
 
-		private Class decClass;
-		private Class exType;
+		private Class<?> decClass;
+		private Class<?> exType;
 
 		public Handler(Class decClass, Class exType) {
 			this.decClass = decClass;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPointcut.java
@@ -139,7 +139,7 @@ public class AnnotationPointcut extends NameBindingPointcut {
 			if (rMember.isAnnotatedElsewhere()) {
 				if (kind == Shadow.FieldGet || kind == Shadow.FieldSet) {
 					// FIXME asc should include supers with getInterTypeMungersIncludingSupers ?
-					List mungers = rMember.getDeclaringType().resolve(shadow.getIWorld()).getInterTypeMungers();
+					List<ConcreteTypeMunger> mungers = rMember.getDeclaringType().resolve(shadow.getIWorld()).getInterTypeMungers();
 					for (Object munger : mungers) {
 						ConcreteTypeMunger typeMunger = (ConcreteTypeMunger) munger;
 						if (typeMunger.getMunger() instanceof NewFieldTypeMunger) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePattern.java
@@ -61,7 +61,7 @@ public class HasMemberTypePattern extends TypePattern {
 	private boolean hasField(ResolvedType type) {
 		// TODO what about ITDs
 		World world = type.getWorld();
-		for (Iterator iter = type.getFields(); iter.hasNext();) {
+		for (Iterator<ResolvedMember> iter = type.getFields(); iter.hasNext();) {
 			Member field = (Member) iter.next();
 			if (field.getName().startsWith(declareAtPrefix)) {
 				continue;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
@@ -354,7 +354,7 @@ public class IfPointcut extends Pointcut {
 			ResolvedPointcutDefinition def = bindings.peekEnclosingDefinition();
 			if (def != null) {
 				ResolvedType aspect = inAspect.getWorld().resolve(def.getDeclaringType());
-				for (Iterator memberIter = aspect.getMethods(true, true); memberIter.hasNext();) {
+				for (Iterator<ResolvedMember> memberIter = aspect.getMethods(true, true); memberIter.hasNext();) {
 					ResolvedMember method = (ResolvedMember) memberIter.next();
 					if (def.getName().equals(method.getName())
 							&& def.getParameterTypes().length == method.getParameterTypes().length) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegateFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegateFactory.java
@@ -34,7 +34,7 @@ public class ReflectionBasedReferenceTypeDelegateFactory {
 	public static ReflectionBasedReferenceTypeDelegate createDelegate(ReferenceType forReferenceType, World inWorld,
 			ClassLoader usingClassLoader) {
 		try {
-			Class c = Class.forName(forReferenceType.getName(), false, usingClassLoader);
+			Class<?> c = Class.forName(forReferenceType.getName(), false, usingClassLoader);
 			ReflectionBasedReferenceTypeDelegate rbrtd = create15Delegate(forReferenceType, c, usingClassLoader, inWorld);
 			if (rbrtd != null) {
 				return rbrtd; // can be null if we didn't find the class the delegate logic loads
@@ -57,7 +57,7 @@ public class ReflectionBasedReferenceTypeDelegateFactory {
 	public static ReflectionBasedReferenceTypeDelegate create14Delegate(ReferenceType forReferenceType, World inWorld,
 			ClassLoader usingClassLoader) {
 		try {
-			Class c = Class.forName(forReferenceType.getName(), false, usingClassLoader);
+			Class<?> c = Class.forName(forReferenceType.getName(), false, usingClassLoader);
 			return new ReflectionBasedReferenceTypeDelegate(c, usingClassLoader, inWorld, forReferenceType);
 		} catch (ClassNotFoundException cnfEx) {
 			return null;
@@ -68,7 +68,7 @@ public class ReflectionBasedReferenceTypeDelegateFactory {
 	private static ReflectionBasedReferenceTypeDelegate create15Delegate(ReferenceType forReferenceType, Class forClass,
 			ClassLoader usingClassLoader, World inWorld) {
 		try {
-			Class delegateClass = Class.forName("org.aspectj.weaver.reflect.Java15ReflectionBasedReferenceTypeDelegate");
+			Class<?> delegateClass = Class.forName("org.aspectj.weaver.reflect.Java15ReflectionBasedReferenceTypeDelegate");
 			ReflectionBasedReferenceTypeDelegate ret = (ReflectionBasedReferenceTypeDelegate) delegateClass.getDeclaredConstructor().newInstance();
 			ret.initialize(forReferenceType, forClass, usingClassLoader, inWorld);
 			return ret;
@@ -92,8 +92,8 @@ public class ReflectionBasedReferenceTypeDelegateFactory {
 
 	private static GenericSignatureInformationProvider createGenericSignatureProvider(World inWorld) {
 		try {
-			Class providerClass = Class.forName("org.aspectj.weaver.reflect.Java15GenericSignatureInformationProvider");
-			Constructor cons = providerClass.getConstructor(new Class[] { World.class });
+			Class<?> providerClass = Class.forName("org.aspectj.weaver.reflect.Java15GenericSignatureInformationProvider");
+			Constructor<?> cons = providerClass.getConstructor(new Class[] { World.class });
 			GenericSignatureInformationProvider ret = (GenericSignatureInformationProvider) cons
 					.newInstance(new Object[] { inWorld });
 			return ret;
@@ -204,7 +204,7 @@ public class ReflectionBasedReferenceTypeDelegateFactory {
 		}
 	}
 
-	private static ResolvedType toResolvedType(Class aClass, IReflectionWorld aWorld) {
+	private static ResolvedType toResolvedType(Class<?> aClass, IReflectionWorld aWorld) {
 		return aWorld.resolve(aClass);
 	}
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionShadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionShadow.java
@@ -42,10 +42,10 @@ public class ReflectionShadow extends Shadow {
 	private Var[] argsVars = null;
 	private Var atThisVar = null;
 	private Var atTargetVar = null;
-	private Map atArgsVars = new HashMap();
-	private Map withinAnnotationVar = new HashMap();
-	private Map withinCodeAnnotationVar = new HashMap();
-	private Map annotationVar = new HashMap();
+	private Map<ResolvedType, Var[]> atArgsVars = new HashMap<>();
+	private Map<ResolvedType, Var> withinAnnotationVar = new HashMap<>();
+	private Map<ResolvedType, Var> withinCodeAnnotationVar = new HashMap<>();
+	private Map<ResolvedType, Var> annotationVar = new HashMap<>();
 	private AnnotationFinder annotationFinder;
 
 	public static Shadow makeExecutionShadow(World inWorld, java.lang.reflect.Member forMethod, MatchingContext withContext) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/StandardShadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/StandardShadow.java
@@ -44,10 +44,10 @@ public class StandardShadow extends Shadow {
 	private Var[] argsVars = null;
 	private Var atThisVar = null;
 	private Var atTargetVar = null;
-	private Map atArgsVars = new HashMap();
-	private Map withinAnnotationVar = new HashMap();
-	private Map withinCodeAnnotationVar = new HashMap();
-	private Map annotationVar = new HashMap();
+	private Map<ResolvedType, Var[]> atArgsVars = new HashMap<>();
+	private Map<ResolvedType, Var> withinAnnotationVar = new HashMap<>();
+	private Map<ResolvedType, Var> withinCodeAnnotationVar = new HashMap<>();
+	private Map<ResolvedType, Var> annotationVar = new HashMap<>();
 	private AnnotationFinder annotationFinder;
 
 	public static Shadow makeExecutionShadow(World inWorld, java.lang.reflect.Member forMethod, MatchingContext withContext) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/DefaultMatchingContext.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/DefaultMatchingContext.java
@@ -20,7 +20,7 @@ import java.util.Map;
  */
 public class DefaultMatchingContext implements MatchingContext {
 
-	private Map contextMap = new HashMap();
+	private Map<String, Object> contextMap = new HashMap<>();
 
 	/* (non-Javadoc)
 	 * @see org.aspectj.weaver.tools.MatchingContext#hasContextParameter(java.lang.String)

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutParser.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutParser.java
@@ -146,7 +146,7 @@ public class StandardPointcutParser {
 	 * @param supportedPointcutKinds a set of PointcutPrimitives this parser should support
 	 * @throws UnsupportedOperationException if the set contains if, cflow, or cflow below
 	 */
-	private StandardPointcutParser(Set/* <PointcutPrimitives> */supportedPointcutKinds, World world) {
+	private StandardPointcutParser(Set<PointcutPrimitive> supportedPointcutKinds, World world) {
 		supportedPrimitives = supportedPointcutKinds;
 		for (Object supportedPointcutKind : supportedPointcutKinds) {
 			PointcutPrimitive element = (PointcutPrimitive) supportedPointcutKind;
@@ -306,7 +306,7 @@ public class StandardPointcutParser {
 		return current;
 	}
 
-	private IScope buildResolutionScope(Class inScope, PointcutParameter[] formalParameters) {
+	private IScope buildResolutionScope(Class<?> inScope, PointcutParameter[] formalParameters) {
 		if (formalParameters == null) {
 			formalParameters = new PointcutParameter[0];
 		}
@@ -342,7 +342,7 @@ public class StandardPointcutParser {
 		}
 	}
 
-	private UnresolvedType toUnresolvedType(Class clazz) {
+	private UnresolvedType toUnresolvedType(Class<?> clazz) {
 		if (clazz.isArray()) {
 			return UnresolvedType.forSignature(clazz.getName().replace('.', '/'));
 		} else {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/TraceFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/TraceFactory.java
@@ -44,7 +44,7 @@ public abstract class TraceFactory {
 				instance = new DefaultTraceFactory();
 			}
 			else {
-	    		Class factoryClass = Class.forName(factoryName);
+	    		Class<?> factoryClass = Class.forName(factoryName);
 	    		instance = (TraceFactory)factoryClass.getDeclaredConstructor().newInstance();
 			}
 		}
@@ -57,7 +57,7 @@ public abstract class TraceFactory {
 		 */
     	if (instance == null) try {
 			{
-	    		Class factoryClass = Class.forName("org.aspectj.weaver.tools.Jdk14TraceFactory");
+	    		Class<?> factoryClass = Class.forName("org.aspectj.weaver.tools.Jdk14TraceFactory");
 	    		instance = (TraceFactory)factoryClass.getDeclaredConstructor().newInstance();
 			}
     	}


### PR DESCRIPTION
Generics make code more type-safe and allow removing type-casts (in the future).
I updated only one module to make sure that such contributions are welcomed.
I intentionally didn't remove redundant casts under this PR, to minimize changes. I plan to do it in another PR, after this PR is merged.
Also I didn't touch public/protected methods and fields. They can be subject of compatibility.