### PR TITLE
Replace more usages of StringBuffer with StringBuilder

### DIFF
--- a/ajdoc/src/main/java/org/aspectj/tools/ajdoc/HtmlDecorator.java
+++ b/ajdoc/src/main/java/org/aspectj/tools/ajdoc/HtmlDecorator.java
@@ -168,7 +168,7 @@ class HtmlDecorator {
 		System.out.println("> Decorating " + file.getCanonicalPath() + "...");
 		BufferedReader reader = new BufferedReader(new FileReader(file));
 
-		StringBuffer fileContents = new StringBuffer();
+		StringBuilder fileContents = new StringBuilder();
 		String line = reader.readLine();
 		while (line != null) {
 			fileContents.append(line + "\n");
@@ -327,7 +327,7 @@ class HtmlDecorator {
 		fos.close();
 	}
 
-	static void addAspectDocumentation(IProgramElement node, StringBuffer fileBuffer, int index) {
+	static void addAspectDocumentation(IProgramElement node, StringBuilder fileBuffer, int index) {
 		List<IProgramElement> pointcuts = new ArrayList<>();
 		List<IProgramElement> advice = new ArrayList<>();
 		List<IProgramElement> declares = new ArrayList<>();
@@ -381,7 +381,7 @@ class HtmlDecorator {
 		}
 	}
 
-	static void insertDeclarationsSummary(StringBuffer fileBuffer, List decls, String kind, int index) {
+	static void insertDeclarationsSummary(StringBuilder fileBuffer, List decls, String kind, int index) {
 		if (!declsAboveVisibilityExist(decls))
 			return;
 
@@ -479,7 +479,7 @@ class HtmlDecorator {
 		}
 	}
 
-	static void insertDeclarationsDetails(StringBuffer fileBuffer, List decls, String kind, int index) {
+	static void insertDeclarationsDetails(StringBuilder fileBuffer, List decls, String kind, int index) {
 		if (!declsAboveVisibilityExist(decls))
 			return;
 		int insertIndex = findDetailsIndex(fileBuffer, index);
@@ -535,7 +535,7 @@ class HtmlDecorator {
 	/**
 	 * TODO: don't place the summary first.
 	 */
-	static int findSummaryIndex(StringBuffer fileBuffer, int index) {
+	static int findSummaryIndex(StringBuilder fileBuffer, int index) {
 		String fbs = fileBuffer.toString();
 		String MARKER_1 = "<!-- =========== FIELD SUMMARY =========== -->";
 		String MARKER_2 = "<!-- ======== CONSTRUCTOR SUMMARY ======== -->";
@@ -550,7 +550,7 @@ class HtmlDecorator {
 		}
 	}
 
-	static int findDetailsIndex(StringBuffer fileBuffer, int index) {
+	static int findDetailsIndex(StringBuilder fileBuffer, int index) {
 		String fbs = fileBuffer.toString();
 		String MARKER_1 = "<!-- ========= CONSTRUCTOR DETAIL ======== -->";
 		String MARKER_2 = "<!-- ============ FIELD DETAIL =========== -->";
@@ -569,7 +569,7 @@ class HtmlDecorator {
 		}
 	}
 
-	static void decorateDocWithRel(IProgramElement node, StringBuffer fileContentsBuffer, int index, List targets,
+	static void decorateDocWithRel(IProgramElement node, StringBuilder fileContentsBuffer, int index, List targets,
 			HtmlRelationshipKind relKind) {
 		if (targets != null && !targets.isEmpty()) {
 			String adviceDoc = "<TABLE WIDTH=\"100%\" BGCOLOR=#FFFFFF><TR>"
@@ -656,7 +656,7 @@ class HtmlDecorator {
 		}
 	}
 
-	static void decorateMemberDocumentation(IProgramElement node, StringBuffer fileContentsBuffer, int index) {
+	static void decorateMemberDocumentation(IProgramElement node, StringBuilder fileContentsBuffer, int index) {
 		List<String> targets = StructureUtil.getTargets(node, IRelationship.Kind.ADVICE);
 		decorateDocWithRel(node, fileContentsBuffer, index, targets, HtmlRelationshipKind.ADVISED_BY);
 

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Signature.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Signature.java
@@ -183,7 +183,7 @@ public final class Signature extends Attribute {
 		return ch == 'T' || ch == 'L';
 	}
 
-	private static final void matchIdent(MyByteArrayInputStream in, StringBuffer buf) {
+	private static final void matchIdent(MyByteArrayInputStream in, StringBuilder buf) {
 		int ch;
 
 		if ((ch = in.read()) == -1)
@@ -234,7 +234,7 @@ public final class Signature extends Attribute {
 			in.unread();
 	}
 
-	private static final void matchGJIdent(MyByteArrayInputStream in, StringBuffer buf) {
+	private static final void matchGJIdent(MyByteArrayInputStream in, StringBuilder buf) {
 		int ch;
 
 		matchIdent(in, buf);
@@ -274,7 +274,7 @@ public final class Signature extends Attribute {
 
 	public static String translate(String s) {
 		// System.out.println("Sig:" + s);
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 
 		matchGJIdent(new MyByteArrayInputStream(s), buf);
 

--- a/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/GenericSignatureParsingTest.java
+++ b/bcel-builder/src/test/java/org/aspectj/apache/bcel/classfile/tests/GenericSignatureParsingTest.java
@@ -153,7 +153,7 @@ public class GenericSignatureParsingTest extends BcelTestCase {
 
 	// These routines call BCEL to determine if it can correctly translate from one form to the other.
 	private void checkClassTypeSignature(String sig, String expected) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		int p = GenericSignatureParsingTest.readClassTypeSignatureFrom(sig,0,result,false);
 		assertTrue("Only swallowed "+p+" chars of this sig "+sig+" (len="+sig.length()+")",p==sig.length());
 		assertTrue("Expected '"+expected+"' but got '"+result.toString()+"'",result.toString().equals(expected));
@@ -204,7 +204,7 @@ public class GenericSignatureParsingTest extends BcelTestCase {
 	   *
 	   * FIXME asc this should also create some kind of object you can query for information about whether its parameterized, what the bounds are, etc...
 	   */
-	  public static final int readClassTypeSignatureFrom(String signature, int posn, StringBuffer result, boolean chopit) {
+	  public static final int readClassTypeSignatureFrom(String signature, int posn, StringBuilder result, boolean chopit) {
 		    int idx = posn;
 		    try {
 		      switch (signature.charAt(idx)) {
@@ -282,7 +282,7 @@ public class GenericSignatureParsingTest extends BcelTestCase {
 
 
 	public static final String readClassTypeSignatureFrom(String signature) {
-	    StringBuffer sb = new StringBuffer();
+	    StringBuilder sb = new StringBuilder();
 		GenericSignatureParsingTest.readClassTypeSignatureFrom(signature,0,sb,false);
 		return sb.toString();
 	  }

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmElementFormatter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmElementFormatter.java
@@ -284,7 +284,7 @@ public class AsmElementFormatter {
 
 	private String handleSigForReference(TypeReference ref, TypeBinding tb, MethodScope scope) {
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			createHandleSigForReference(ref, tb, scope, sb);
 			return sb.toString();
 		} catch (Throwable t) {
@@ -299,7 +299,7 @@ public class AsmElementFormatter {
 	 * handle. Whether a type is qualified or unqualified in its source reference is actually reflected in the handle and this code
 	 * allows for that.
 	 */
-	private void createHandleSigForReference(TypeReference ref, TypeBinding tb, MethodScope scope, StringBuffer handleSig) {
+	private void createHandleSigForReference(TypeReference ref, TypeBinding tb, MethodScope scope, StringBuilder handleSig) {
 		if (ref instanceof Wildcard) {
 			Wildcard w = (Wildcard) ref;
 			if (w.bound == null) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
@@ -153,7 +153,7 @@ public class Main {
 	 * append nothing if numItems is 0, numItems + label + (numItems > 1? "s" : "") otherwise, prefixing with " " if sink has
 	 * content
 	 */
-	private static void appendNLabel(StringBuffer sink, String label, int numItems) {
+	private static void appendNLabel(StringBuilder sink, String label, int numItems) {
 		if (0 == numItems) {
 			return;
 		}
@@ -496,7 +496,7 @@ public class Main {
 		if (holder == ourHandler) {
 			lastErrors = holder.numMessages(IMessage.ERROR, false);
 			int warnings = holder.numMessages(IMessage.WARNING, false);
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			appendNLabel(sb, "fail|abort", lastFails);
 			appendNLabel(sb, "error", lastErrors);
 			appendNLabel(sb, "warning", warnings);

--- a/org.aspectj.ajdt.core/src/test/java/RunWeaveTests.java
+++ b/org.aspectj.ajdt.core/src/test/java/RunWeaveTests.java
@@ -146,7 +146,7 @@ public class RunWeaveTests {
 
 	private static void createCSV() {
 		String NL = System.getProperty("line.separator", "\n");
-		StringBuffer csv = new StringBuffer(1000);
+		StringBuilder csv = new StringBuilder(1000);
 
 		csv.append("Test Results");
 
@@ -219,10 +219,10 @@ public class RunWeaveTests {
 		return (getVMInfo() + "_" + getDateAndTime()).replace('.', '_') + ".csv";
 	}
 
-	private static StringBuffer getDateAndTime() {
+	private static StringBuilder getDateAndTime() {
 		Calendar c = Calendar.getInstance();
 
-		StringBuffer sb = new StringBuffer(15);
+		StringBuilder sb = new StringBuilder(15);
 		sb.append(c.get(Calendar.YEAR));
 		int month = (c.get(Calendar.MONTH)) + 1;
 		if(month < 10) sb.append(0);
@@ -247,8 +247,8 @@ public class RunWeaveTests {
 		return sb;
 	}
 
-	private static StringBuffer getVMInfo() {
-		StringBuffer sb = new StringBuffer(40);
+	private static StringBuilder getVMInfo() {
+		StringBuilder sb = new StringBuilder(40);
 
 		String vm = System.getProperty("java.vm.vendor");
 

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/ajdt/internal/compiler/batch/IncrementalCase.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/ajdt/internal/compiler/batch/IncrementalCase.java
@@ -104,7 +104,7 @@ public class IncrementalCase { // XXX NOT bound to junit - bridge tests?
 			throw new Error("did not get definitions");
 		}
 		MessageHandler compilerMessages = new MessageHandler();
-        StringBuffer commandLine = new StringBuffer();
+        StringBuilder commandLine = new StringBuilder();
 		for (int i = 1; result && (i < 10); i++) {
 			String fromSuffix = "." + i + "0.java";
 			// copy files, collecting as we go...
@@ -171,7 +171,7 @@ public class IncrementalCase { // XXX NOT bound to junit - bridge tests?
 		File sandboxClassesDir,
 		Definition def,
 		IMessageHolder compilerMessages,
-        StringBuffer commandLine,
+        StringBuilder commandLine,
 		IMessageHandler handler) {
         log("verifyCompile -  iteration ", iteration, handler);
 		log("verifyCompile -        def ", def, handler);

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
@@ -443,7 +443,7 @@ public abstract class AjcTestCase extends TestCase {
 		boolean infosEmpty = expected.isIgnoringInfoMessages() || missingInfos.isEmpty() && extraInfos.isEmpty();
 		if (!(missingFails.isEmpty() && missingWarnings.isEmpty() && missingErrors.isEmpty() && missingWeaves.isEmpty()
 				&& extraFails.isEmpty() && extraWarnings.isEmpty() && extraErrors.isEmpty() && extraWeaves.isEmpty() && infosEmpty)) {
-			StringBuffer failureReport = new StringBuffer(assertionFailedMessage);
+			StringBuilder failureReport = new StringBuilder(assertionFailedMessage);
 			failureReport.append("\n");
 			if (!expected.isIgnoringInfoMessages()) {
 				addMissing(failureReport, "info", missingInfos);
@@ -576,7 +576,7 @@ public abstract class AjcTestCase extends TestCase {
 			}
 		}
 		lastRunResult = null;
-		StringBuffer cp = new StringBuffer();
+		StringBuilder cp = new StringBuilder();
 		if (classpath != null) {
 			// allow replacing this special variable, rather than copying all files to allow tests of jars that don't end in .jar
 			cp.append(substituteSandbox(classpath));
@@ -587,7 +587,7 @@ public abstract class AjcTestCase extends TestCase {
 			cp.append(ajc.getSandboxDirectory().getAbsolutePath());
 			getAnyJars(ajc.getSandboxDirectory(), cp);
 		}
-		StringBuffer mp = new StringBuffer();
+		StringBuilder mp = new StringBuilder();
 		if (modulepath != null) {
 			mp.append(substituteSandbox(modulepath));
 			mp.append(File.pathSeparator);
@@ -983,7 +983,7 @@ public abstract class AjcTestCase extends TestCase {
 		}
 	}
 
-	private void addMissing(StringBuffer buff, String type, List<AjcTestCase.Message> messages) {
+	private void addMissing(StringBuilder buff, String type, List<AjcTestCase.Message> messages) {
 		if (!messages.isEmpty()) {
 			buff.append("Missing expected ");
 			buff.append(type);
@@ -996,7 +996,7 @@ public abstract class AjcTestCase extends TestCase {
 		}
 	}
 
-	private void addExtra(StringBuffer buff, String type, List messages) {
+	private void addExtra(StringBuilder buff, String type, List messages) {
 		if (!messages.isEmpty()) {
 			buff.append("Unexpected ");
 			buff.append(type);
@@ -1010,7 +1010,7 @@ public abstract class AjcTestCase extends TestCase {
 	}
 
 	// add any jars in the directory to the classpath
-	private void getAnyJars(File dir, StringBuffer buff) {
+	private void getAnyJars(File dir, StringBuilder buff) {
 		File[] files = dir.listFiles();
 		for (File file : files) {
 			if (file.getName().endsWith(".jar")) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/TypeFactory.java
@@ -113,7 +113,7 @@ public class TypeFactory {
 				return new UnresolvedType(signature, signatureErasure, UnresolvedType.NONE);
 			} else {
 				int endOfParams = locateMatchingEndAngleBracket(signature, startOfParams);
-				StringBuffer erasureSig = new StringBuffer(signature);
+				StringBuilder erasureSig = new StringBuilder(signature);
 				erasureSig.setCharAt(0, 'L');
 				while (startOfParams != -1) {
 					erasureSig.delete(startOfParams, endOfParams + 1);
@@ -210,7 +210,7 @@ public class TypeFactory {
 				return new UnresolvedType(signature);
 			} else {
 				int endOfParams = locateMatchingEndAngleBracket(signature, leftAngleBracket);
-				StringBuffer erasureSig = new StringBuffer(signature);
+				StringBuilder erasureSig = new StringBuilder(signature);
 				erasureSig.setCharAt(0, 'L');
 				while (leftAngleBracket != -1) {
 					erasureSig.delete(leftAngleBracket, endOfParams + 1);
@@ -275,7 +275,7 @@ public class TypeFactory {
 		return idx;
 	}
 
-	private static int locateFirstBracket(StringBuffer signature) {
+	private static int locateFirstBracket(StringBuilder signature) {
 		int idx = 0;
 		int max = signature.length();
 		while (idx < max) {

--- a/util/src/main/java/org/aspectj/util/GenericSignatureParser.java
+++ b/util/src/main/java/org/aspectj/util/GenericSignatureParser.java
@@ -176,7 +176,7 @@ public class GenericSignatureParser {
 	private ClassTypeSignature parseClassTypeSignature() {
 		SimpleClassTypeSignature outerType = null;
 		SimpleClassTypeSignature[] nestedTypes = new SimpleClassTypeSignature[0];
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		String identifier = eatIdentifier();
 		ret.append(identifier);
 		while (maybeEat("/")) {
@@ -215,7 +215,7 @@ public class GenericSignatureParser {
 	 * Helper method to digest nested types, slightly more complex than necessary to cope with some android related
 	 * incorrect classes (see bug 406167)
 	 */
-	private SimpleClassTypeSignature[] parseNestedTypesHelper(StringBuffer ret) {
+	private SimpleClassTypeSignature[] parseNestedTypesHelper(StringBuilder ret) {
 		boolean brokenSignature = false;
 		SimpleClassTypeSignature[] nestedTypes;
 		List<SimpleClassTypeSignature> nestedTypeList = new ArrayList<>();

--- a/util/src/main/java/org/aspectj/util/LangUtil.java
+++ b/util/src/main/java/org/aspectj/util/LangUtil.java
@@ -1510,7 +1510,7 @@ public class LangUtil {
 
 			@Override
 			public String toString() {
-				StringBuffer sb = new StringBuffer();
+				StringBuilder sb = new StringBuilder();
 				append(sb, fromProcess, "process");
 				append(sb, fromOutPipe, " stdout");
 				append(sb, fromErrPipe, " stderr");
@@ -1522,7 +1522,7 @@ public class LangUtil {
 				}
 			}
 
-			private void append(StringBuffer sb, Throwable thrown, String label) {
+			private void append(StringBuilder sb, Throwable thrown, String label) {
 				if (null != thrown) {
 					sb.append("from " + label + ": ");
 					sb.append(LangUtil.renderExceptionShort(thrown));


### PR DESCRIPTION
In #101 I did update only that StringBuffer usages that were automatically reported by IDEA.
Now I updated usages which cross private and package private method boundaries, but still are safe to migrate.