### PR TITLE
Reduce empty array allocations

### DIFF
--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/FieldOrMethod.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/FieldOrMethod.java
@@ -177,7 +177,7 @@ public abstract class FieldOrMethod extends Modifiers implements Node {
 			if (accumulatedAnnotations.size() == 0) {
 				annotations = AnnotationGen.NO_ANNOTATIONS;
 			} else {
-				annotations = accumulatedAnnotations.toArray(new AnnotationGen[] {});
+				annotations = accumulatedAnnotations.toArray(AnnotationGen.NO_ANNOTATIONS);
 			}
 		}
 		return annotations;

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
@@ -88,10 +88,7 @@ import org.aspectj.apache.bcel.util.SyntheticRepository;
 public class JavaClass extends Modifiers implements Cloneable, Node {
 
 	private static final String[] NoInterfaceNames = new String[0];
-	private static final Field[] NoFields = new Field[0];
-	private static final Method[] NoMethod = new Method[0];
 	private static final int[] NoInterfaceIndices = new int[0];
-	private static final Attribute[] NoAttributes = new Attribute[0];
 
 	private String fileName;
 	private String packageName;
@@ -141,9 +138,9 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 		this.modifiers = access_flags;
 		this.cpool = cpool;
 		this.interfaces = interfaces;
-		this.fields = (fields == null ? NoFields : fields);
-		this.methods = (methods == null ? NoMethod : methods);
-		this.attributes = (attributes == null ? NoAttributes : attributes);
+		this.fields = (fields == null ? Field.NoFields : fields);
+		this.methods = (methods == null ? Method.NoMethods : methods);
+		this.attributes = (attributes == null ? Attribute.NoAttributes : attributes);
 		annotationsOutOfDate = true;
 
 		// Get source file name if available
@@ -294,7 +291,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 					accumulatedAnnotations.addAll(runtimeAnnotations.getAnnotations());
 				}
 			}
-			annotations = accumulatedAnnotations.toArray(new AnnotationGen[] {});
+			annotations = accumulatedAnnotations.toArray(AnnotationGen.NO_ANNOTATIONS);
 			annotationsOutOfDate = false;
 		}
 		return annotations;

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Method.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Method.java
@@ -228,8 +228,8 @@ public final class Method extends FieldOrMethod {
 			AnnotationGen[] invisibleOnes = null;
 			for (int i = 0; i < parameterCount; i++) {
 				int count = 0;
-				visibleOnes = new AnnotationGen[0];
-				invisibleOnes = new AnnotationGen[0];
+				visibleOnes = AnnotationGen.NO_ANNOTATIONS;
+				invisibleOnes = AnnotationGen.NO_ANNOTATIONS;
 				if (parameterAnnotationsVis != null) {
 					visibleOnes = parameterAnnotationsVis.getAnnotationsOnParameter(i);
 					count += visibleOnes.length;

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Utility.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/Utility.java
@@ -709,7 +709,7 @@ public abstract class Utility {
 				newAttributes.add(new RuntimeInvisParamAnnos(riaIndex, riaData.length, riaData, cp));
 			}
 
-			return newAttributes.toArray(new Attribute[] {});
+			return newAttributes.toArray(Attribute.NoAttributes);
 		} catch (IOException e) {
 			System.err.println("IOException whilst processing parameter annotations");
 			e.printStackTrace();

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ClassGen.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/ClassGen.java
@@ -195,7 +195,7 @@ public class ClassGen extends Modifiers implements Cloneable {
 		ConstantPool cp = this.cpool.getFinalConstantPool();
 
 		return new JavaClass(classnameIndex, superclassnameIndex, filename, major, minor, modifiers, cp, interfaces, fields,
-				methods, attributes.toArray(new Attribute[0]));// OPTIMIZE avoid toArray()?
+				methods, attributes.toArray(Attribute.NoAttributes));// OPTIMIZE avoid toArray()?
 	}
 
 	public void addInterface(String name) {

--- a/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
+++ b/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
@@ -357,7 +357,7 @@ public class MessageUtil {
 	 */
 	public static IMessage[] getMessagesExcept(IMessageHolder holder, final IMessage.Kind kind, final boolean orGreater) {
 		if ((null == holder) || (null == kind)) {
-			return new IMessage[0];
+			return IMessage.RA_IMessage;
 		}
 
 		IMessageHandler selector = new IMessageHandler() {

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ConcreteAspectCodeGen.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ConcreteAspectCodeGen.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.aspectj.weaver.loadtime;
 
+import static org.aspectj.apache.bcel.generic.Type.NO_ARGS;
+
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,7 +77,6 @@ import org.aspectj.weaver.patterns.TypePattern;
 public class ConcreteAspectCodeGen {
 
 	private final static String[] EMPTY_STRINGS = new String[0];
-	private final static Type[] EMPTY_TYPES = new Type[0];
 
 	/**
 	 * Concrete aspect definition we build for
@@ -427,17 +428,17 @@ public class ConcreteAspectCodeGen {
 		}
 
 		// default constructor
-		LazyMethodGen init = new LazyMethodGen(Modifier.PUBLIC, Type.VOID, "<init>", EMPTY_TYPES, EMPTY_STRINGS, cg);
+		LazyMethodGen init = new LazyMethodGen(Modifier.PUBLIC, Type.VOID, "<init>", NO_ARGS, EMPTY_STRINGS, cg);
 		InstructionList cbody = init.getBody();
 		cbody.append(InstructionConstants.ALOAD_0);
 
-		cbody.append(cg.getFactory().createInvoke(parentName, "<init>", Type.VOID, EMPTY_TYPES, Constants.INVOKESPECIAL));
+		cbody.append(cg.getFactory().createInvoke(parentName, "<init>", Type.VOID, NO_ARGS, Constants.INVOKESPECIAL));
 		cbody.append(InstructionConstants.RETURN);
 		cg.addMethodGen(init);
 
 		for (Definition.Pointcut abstractPc : concreteAspect.pointcuts) {
 			// TODO AV - respect visibility instead of opening up as public?
-			LazyMethodGen mg = new LazyMethodGen(Modifier.PUBLIC, Type.VOID, abstractPc.name, EMPTY_TYPES, EMPTY_STRINGS, cg);
+			LazyMethodGen mg = new LazyMethodGen(Modifier.PUBLIC, Type.VOID, abstractPc.name, NO_ARGS, EMPTY_STRINGS, cg);
 			SimpleElementValue svg = new SimpleElementValue(ElementValue.STRING, cg.getConstantPool(), abstractPc.expression);
 			List<NameValuePair> elems = new ArrayList<>();
 			elems.add(new NameValuePair("value", svg, cg.getConstantPool()));
@@ -547,7 +548,7 @@ public class ConcreteAspectCodeGen {
 
 		String nameComponent = da.declareAnnotationKind.name().toLowerCase();
 		String declareName = new StringBuilder("ajc$declare_at_").append(nameComponent).append("_").append(decCounter).toString();
-		LazyMethodGen declareMethod = new LazyMethodGen(Modifier.PUBLIC, Type.VOID, declareName, Type.NO_ARGS, EMPTY_STRINGS, cg);
+		LazyMethodGen declareMethod = new LazyMethodGen(Modifier.PUBLIC, Type.VOID, declareName, NO_ARGS, EMPTY_STRINGS, cg);
 		InstructionList declareMethodBody = declareMethod.getBody();
 		declareMethodBody.append(InstructionFactory.RETURN);
 		declareMethod.addAnnotation(constructedAnnotation);
@@ -909,7 +910,7 @@ public class ConcreteAspectCodeGen {
 		}
 
 		// Time to construct the method itself:
-		LazyMethodGen advice = new LazyMethodGen(Modifier.PUBLIC, returnType, adviceName, paramTypes.toArray(new Type[0]), EMPTY_STRINGS, cg);
+		LazyMethodGen advice = new LazyMethodGen(Modifier.PUBLIC, returnType, adviceName, paramTypes.toArray(NO_ARGS), EMPTY_STRINGS, cg);
 
 		InstructionList adviceBody = advice.getBody();
 

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AdviceDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AdviceDeclaration.java
@@ -141,9 +141,9 @@ public class AdviceDeclaration extends AjMethodDeclaration {
 
 			// XXX set these correctly
 			formalsUnchangedToProceed = new boolean[baseArgumentCount];
-			proceedCallSignatures = new ResolvedMember[0];
+			proceedCallSignatures = ResolvedMember.NONE;
 			proceedInInners = false;
-			declaredExceptions = new UnresolvedType[0];
+			declaredExceptions = UnresolvedType.NONE;
 
 			for (Proceed call : proceedCalls) {
 				if (call.inInner) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AspectDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AspectDeclaration.java
@@ -1129,7 +1129,7 @@ public class AspectDeclaration extends TypeDeclaration {
 	}
 
 	private PerClause resolvePerClause() {
-		EclipseScope iscope = new EclipseScope(new FormalBinding[0], scope);
+		EclipseScope iscope = new EclipseScope(FormalBinding.NONE, scope);
 		perClause.resolve(iscope);
 		return perClause;
 	}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/DeclareDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/DeclareDeclaration.java
@@ -147,7 +147,7 @@ public class DeclareDeclaration extends AjMethodDeclaration {
 			return null;
 		}
 
-		EclipseScope scope = new EclipseScope(new FormalBinding[0], classScope);
+		EclipseScope scope = new EclipseScope(FormalBinding.NONE, classScope);
 
 		declareDecl.resolve(scope);
 		return declareDecl;

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ValidateAtAspectJAnnotationsVisitor.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ValidateAtAspectJAnnotationsVisitor.java
@@ -280,7 +280,7 @@ public class ValidateAtAspectJAnnotationsVisitor extends ASTVisitor {
 			if (perClause != null && !perClause.equals("")) {
 				ISourceContext context = new EclipseSourceContext(unit.compilationResult, pcLoc[0]);
 				Pointcut pc = new PatternParser(perClause, context).maybeParsePerClause();
-				FormalBinding[] bindings = new FormalBinding[0];
+				FormalBinding[] bindings = FormalBinding.NONE;
 				if (pc != null)
 					pc.resolve(new EclipseScope(bindings, typeDecl.scope));
 			}
@@ -430,9 +430,9 @@ public class ValidateAtAspectJAnnotationsVisitor extends ASTVisitor {
 
 	private FormalBinding[] buildFormalAdviceBindingsFrom(MethodDeclaration mDecl) {
 		if (mDecl.arguments == null)
-			return new FormalBinding[0];
+			return FormalBinding.NONE;
 		if (mDecl.binding == null)
-			return new FormalBinding[0];
+			return FormalBinding.NONE;
 		EclipseFactory factory = EclipseFactory.fromScopeLookupEnvironment(mDecl.scope);
 		String extraArgName = maybeGetExtraArgName();
 		if (extraArgName == null)

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseFactory.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseFactory.java
@@ -291,7 +291,7 @@ public class EclipseFactory {
 			// act of resolution here may cause recursion problems since the parameters may
 			// be type variables that we haven't fixed up yet.
 			if (arguments == null) {
-				arguments = new UnresolvedType[0];
+				arguments = UnresolvedType.NONE;
 				// for pr384398
 				if (!hasAnyArguments(ptb)) {
 					return UnresolvedType.forRawTypeName(getName(binding));

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseSourceType.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseSourceType.java
@@ -349,9 +349,9 @@ public class EclipseSourceType extends AbstractReferenceTypeDelegate {
 			declaredFields.add(factory.makeResolvedMember(f));
 		}
 
-		this.declaredPointcuts = declaredPointcuts.toArray(new ResolvedPointcutDefinition[0]);
-		this.declaredMethods = declaredMethods.toArray(new ResolvedMember[0]);
-		this.declaredFields = declaredFields.toArray(new ResolvedMember[0]);
+		this.declaredPointcuts = declaredPointcuts.toArray(ResolvedPointcutDefinition.NO_POINTCUTS);
+		this.declaredMethods = declaredMethods.toArray(ResolvedMember.NONE);
+		this.declaredFields = declaredFields.toArray(ResolvedMember.NONE);
 	}
 
 	private final static char[] valuesCharArray = "values".toCharArray();
@@ -395,10 +395,10 @@ public class EclipseSourceType extends AbstractReferenceTypeDelegate {
 
 	private FormalBinding[] buildFormalAdviceBindingsFrom(AbstractMethodDeclaration mDecl) {
 		if (mDecl.arguments == null) {
-			return new FormalBinding[0];
+			return FormalBinding.NONE;
 		}
 		if (mDecl.binding == null) {
-			return new FormalBinding[0];
+			return FormalBinding.NONE;
 		}
 		EclipseFactory factory = EclipseFactory.fromScopeLookupEnvironment(mDecl.scope);
 		String extraArgName = "";// maybeGetExtraArgName();
@@ -1198,7 +1198,7 @@ public class EclipseSourceType extends AbstractReferenceTypeDelegate {
 	@Override
 	public TypeVariable[] getTypeVariables() {
 		if (declaration.typeParameters == null) {
-			return new TypeVariable[0];
+			return TypeVariable.NONE;
 		}
 		TypeVariable[] typeVariables = new TypeVariable[declaration.typeParameters.length];
 		for (int i = 0; i < typeVariables.length; i++) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Advice.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Advice.java
@@ -104,7 +104,7 @@ public abstract class Advice extends ShadowMunger {
 		if (signature != null) {
 			bindingParameterTypes = signature.getParameterTypes();
 		} else {
-			bindingParameterTypes = new UnresolvedType[0];
+			bindingParameterTypes = UnresolvedType.NONE;
 		}
 	}
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjcMemberMaker.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AjcMemberMaker.java
@@ -140,7 +140,7 @@ public class AjcMemberMaker {
 		// public static a.X ajc$createAspectInstance(java.lang.String)
 		ResolvedMemberImpl rm = new ResolvedMemberImpl(Member.METHOD, declaringType, PUBLIC_STATIC, declaringType, // return value
 				NameMangler.PERTYPEWITHIN_CREATEASPECTINSTANCE_METHOD,
-				new UnresolvedType[] { UnresolvedType.forSignature("Ljava/lang/String;") }, new UnresolvedType[] {});
+				new UnresolvedType[] { UnresolvedType.forSignature("Ljava/lang/String;") }, UnresolvedType.NONE);
 		return rm;
 	}
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MemberImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MemberImpl.java
@@ -211,7 +211,7 @@ public class MemberImpl implements Member {
 					l.add(UnresolvedType.forSignature(sig.substring(start, i)));
 				}
 			}
-			UnresolvedType[] paramTypes = l.toArray(new UnresolvedType[0]);
+			UnresolvedType[] paramTypes = l.toArray(UnresolvedType.NONE);
 			UnresolvedType returnType = UnresolvedType.forSignature(sig.substring(i + 1, sig.length()));
 			return new Object[] { returnType, paramTypes };
 		} else {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MissingResolvedTypeWithKnownSignature.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/MissingResolvedTypeWithKnownSignature.java
@@ -25,8 +25,6 @@ import org.aspectj.bridge.context.CompilationAndWeavingContext;
  */
 public class MissingResolvedTypeWithKnownSignature extends ResolvedType {
 
-	private static ResolvedMember[] NO_MEMBERS = new ResolvedMember[0];
-	private static ResolvedType[] NO_TYPES = new ResolvedType[0];
 	private boolean issuedCantFindTypeError = false;
 	private boolean issuedJoinPointWarning = false;
 	private boolean issuedMissingInterfaceWarning = false;
@@ -61,7 +59,7 @@ public class MissingResolvedTypeWithKnownSignature extends ResolvedType {
 	@Override
 	public ResolvedMember[] getDeclaredFields() {
 		raiseCantFindType(WeaverMessages.CANT_FIND_TYPE_FIELDS);
-		return NO_MEMBERS;
+		return ResolvedMember.NONE;
 	}
 
 	/*
@@ -72,7 +70,7 @@ public class MissingResolvedTypeWithKnownSignature extends ResolvedType {
 	@Override
 	public ResolvedMember[] getDeclaredMethods() {
 		raiseCantFindType(WeaverMessages.CANT_FIND_TYPE_METHODS);
-		return NO_MEMBERS;
+		return ResolvedMember.NONE;
 	}
 
 	@Override
@@ -84,13 +82,13 @@ public class MissingResolvedTypeWithKnownSignature extends ResolvedType {
 	@Override
 	public ResolvedType[] getDeclaredInterfaces() {
 		raiseCantFindType(WeaverMessages.CANT_FIND_TYPE_INTERFACES);
-		return NO_TYPES;
+		return ResolvedType.EMPTY_RESOLVED_TYPE_ARRAY;
 	}
 
 	@Override
 	public ResolvedMember[] getDeclaredPointcuts() {
 		raiseCantFindType(WeaverMessages.CANT_FIND_TYPE_POINTCUTS);
-		return NO_MEMBERS;
+		return ResolvedMember.NONE;
 	}
 
 	@Override

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
@@ -1085,7 +1085,7 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 				l.add(m);
 			}
 		}
-		return l.toArray(new ResolvedMember[0]);
+		return l.toArray(ResolvedMember.NONE);
 	}
 
 	public abstract ISourceContext getSourceContext();

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPatternList.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPatternList.java
@@ -30,13 +30,13 @@ public class AnnotationPatternList extends PatternNode {
 	private AnnotationTypePattern[] typePatterns;
 	int ellipsisCount = 0;
 
-	public static final AnnotationPatternList EMPTY = new AnnotationPatternList(new AnnotationTypePattern[] {});
+	public static final AnnotationPatternList EMPTY = new AnnotationPatternList(AnnotationTypePattern.NONE);
 
 	public static final AnnotationPatternList ANY = new AnnotationPatternList(
 			new AnnotationTypePattern[] { AnnotationTypePattern.ELLIPSIS });
 
 	public AnnotationPatternList() {
-		typePatterns = new AnnotationTypePattern[0];
+		typePatterns = AnnotationTypePattern.NONE;
 		ellipsisCount = 0;
 	}
 
@@ -50,7 +50,7 @@ public class AnnotationPatternList extends PatternNode {
 	}
 
 	public AnnotationPatternList(List<AnnotationTypePattern> l) {
-		this((AnnotationTypePattern[]) l.toArray(new AnnotationTypePattern[0]));
+		this((AnnotationTypePattern[]) l.toArray(AnnotationTypePattern.NONE));
 	}
 
 	protected AnnotationTypePattern[] getAnnotationPatterns() {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
@@ -308,7 +308,7 @@ public class IfPointcut extends Pointcut {
 				}
 			}
 
-			ret = Test.makeAnd(ret, Test.makeCall(testMethod, (Expr[]) args.toArray(new Expr[0])));
+			ret = Test.makeAnd(ret, Test.makeCall(testMethod, (Expr[]) args.toArray(Expr.NONE)));
 
 			// Remember...
 			ifLastMatchedShadowId = shadow.shadowId;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegate.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegate.java
@@ -212,7 +212,7 @@ public class ReflectionBasedReferenceTypeDelegate implements ReferenceTypeDelega
 	 */
 	public ResolvedType[] getAnnotationTypes() {
 		// no annotations in Java 1.4
-		return new ResolvedType[0];
+		return ResolvedType.EMPTY_RESOLVED_TYPE_ARRAY;
 	}
 
 	/*
@@ -281,7 +281,7 @@ public class ReflectionBasedReferenceTypeDelegate implements ReferenceTypeDelega
 	 * @see org.aspectj.weaver.ReferenceTypeDelegate#getDeclaredPointcuts()
 	 */
 	public ResolvedMember[] getDeclaredPointcuts() {
-		return new ResolvedMember[0];
+		return ResolvedMember.NONE;
 	}
 
 	/*
@@ -291,7 +291,7 @@ public class ReflectionBasedReferenceTypeDelegate implements ReferenceTypeDelega
 	 */
 	public TypeVariable[] getTypeVariables() {
 		// no type variables in Java 1.4
-		return new TypeVariable[0];
+		return TypeVariable.NONE;
 	}
 
 	/*

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegateFactory.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionBasedReferenceTypeDelegateFactory.java
@@ -160,8 +160,8 @@ public class ReflectionBasedReferenceTypeDelegateFactory {
 
 	public static ResolvedMember createStaticInitMember(Class forType, World inWorld) {
 		return new ResolvedMemberImpl(org.aspectj.weaver.Member.STATIC_INITIALIZATION, toResolvedType(forType,
-				(IReflectionWorld) inWorld), Modifier.STATIC, UnresolvedType.VOID, "<clinit>", new UnresolvedType[0],
-				new UnresolvedType[0]);
+				(IReflectionWorld) inWorld), Modifier.STATIC, UnresolvedType.VOID, "<clinit>", UnresolvedType.NONE,
+				UnresolvedType.NONE);
 	}
 
 	public static ResolvedMember createResolvedConstructor(Constructor aConstructor, World inWorld) {
@@ -181,7 +181,7 @@ public class ReflectionBasedReferenceTypeDelegateFactory {
 	public static ResolvedMember createResolvedField(Field aField, World inWorld) {
 		ReflectionBasedResolvedMemberImpl ret = new ReflectionBasedResolvedMemberImpl(org.aspectj.weaver.Member.FIELD,
 				toResolvedType(aField.getDeclaringClass(), (IReflectionWorld) inWorld), aField.getModifiers(), toResolvedType(
-						aField.getType(), (IReflectionWorld) inWorld), aField.getName(), new UnresolvedType[0], aField);
+						aField.getType(), (IReflectionWorld) inWorld), aField.getName(), UnresolvedType.NONE, aField);
 		if (inWorld instanceof IReflectionWorld) {
 			ret.setAnnotationFinder(((IReflectionWorld) inWorld).getAnnotationFinder());
 		}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/StandardShadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/StandardShadow.java
@@ -111,7 +111,7 @@ public class StandardShadow extends Shadow {
 		Kind kind = Shadow.StaticInitialization;
 		if (clinit == -1) {
 			Member clinitMember = new ResolvedMemberImpl(org.aspectj.weaver.Member.STATIC_INITIALIZATION, forType, Modifier.STATIC,
-					UnresolvedType.VOID, "<clinit>", new UnresolvedType[0], new UnresolvedType[0]);
+					UnresolvedType.VOID, "<clinit>", UnresolvedType.NONE, UnresolvedType.NONE);
 			return new StandardShadow(inWorld, kind, clinitMember, null, forType, null, withContext);
 		} else {
 			return new StandardShadow(inWorld, kind, members[clinit], null, forType, null, withContext);

--- a/util/src/main/java/org/aspectj/util/GenericSignature.java
+++ b/util/src/main/java/org/aspectj/util/GenericSignature.java
@@ -38,7 +38,7 @@ public class GenericSignature {
 	}
 
 	public static class MethodTypeSignature {
-		public FormalTypeParameter[] formalTypeParameters = new FormalTypeParameter[0];
+		public FormalTypeParameter[] formalTypeParameters = FormalTypeParameter.NONE;
 		public TypeSignature[] parameters = new TypeSignature[0];
 		public TypeSignature returnType;
 		public FieldTypeSignature[] throwsSignatures = new FieldTypeSignature[0];

--- a/util/src/main/java/org/aspectj/util/GenericSignatureParser.java
+++ b/util/src/main/java/org/aspectj/util/GenericSignatureParser.java
@@ -71,7 +71,7 @@ public class GenericSignatureParser {
 		this.inputString = sig;
 		tokenStream = tokenize(sig);
 		tokenIndex = 0;
-		FormalTypeParameter[] formals = new FormalTypeParameter[0];
+		FormalTypeParameter[] formals = FormalTypeParameter.NONE;
 		TypeSignature returnType = null;
 		// FormalTypeParameters-opt
 		if (maybeEat("<")) {

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/AtAjAttributes.java
@@ -558,7 +558,7 @@ public class AtAjAttributes {
 				// struct.ajAttributes.add(new AjAttribute.WeaverVersionInfo());
 				AjAttribute.Aspect aspectAttribute = new AjAttribute.Aspect(perClause);
 				struct.ajAttributes.add(aspectAttribute);
-				FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+				FormalBinding[] bindings = FormalBinding.NONE;
 				final IScope binding;
 				binding = new BindingScope(struct.enclosingType, struct.context, bindings);
 
@@ -717,7 +717,7 @@ public class AtAjAttributes {
 				}
 				if (fieldType.isInterface()) {
 					TypePattern parent = parseTypePattern(fieldType.getName(), struct);
-					FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+					FormalBinding[] bindings = FormalBinding.NONE;
 					IScope binding = new BindingScope(struct.enclosingType, struct.context, bindings);
 					// first add the declare implements like
 					List<TypePattern> parents = new ArrayList<>(1);
@@ -970,7 +970,7 @@ public class AtAjAttributes {
 		}
 
 		// Create the declare parents that will add the interfaces to matching targets
-		FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+		FormalBinding[] bindings = FormalBinding.NONE;
 		IScope binding = new BindingScope(struct.enclosingType, struct.context, bindings);
 		// how do we mark this as a decp due to decmixin?
 		DeclareParents dp = new DeclareParentsMixin(targetTypePattern, newParents);
@@ -990,7 +990,7 @@ public class AtAjAttributes {
 			// TODO check for overlapping interfaces. Eg. A implements I, I extends J - if they specify interfaces={I,J} we dont
 			// want to do any methods twice
 			ResolvedMember[] methods = typeForDelegation.getMethodsWithoutIterator(true, false, false).toArray(
-					new ResolvedMember[0]);
+                    ResolvedMember.NONE);
 			for (ResolvedMember resolvedMember : methods) {
 				ResolvedMember method = resolvedMember;
 				if (method.isAbstract()) {
@@ -1033,7 +1033,7 @@ public class AtAjAttributes {
 				if (argumentNames != null) {
 					struct.unparsedArgumentNames = argumentNames;
 				}
-				FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+				FormalBinding[] bindings = FormalBinding.NONE;
 				try {
 					bindings = extractBindings(struct);
 				} catch (UnreadableDebugInfoException unreadableDebugInfoException) {
@@ -1082,7 +1082,7 @@ public class AtAjAttributes {
 			NameValuePair afterAdvice = getAnnotationElement(after, VALUE);
 			if (afterAdvice != null) {
 				// this/target/args binding
-				FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+				FormalBinding[] bindings = FormalBinding.NONE;
 				String argumentNames = getArgNamesValue(after);
 				if (argumentNames != null) {
 					struct.unparsedArgumentNames = argumentNames;
@@ -1172,7 +1172,7 @@ public class AtAjAttributes {
 			// this/target/args binding
 			// exclude the return binding from the pointcut binding since it is
 			// an extraArg binding
-			FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+			FormalBinding[] bindings = FormalBinding.NONE;
 			try {
 				bindings = (returned == null ? extractBindings(struct) : extractBindings(struct, returned));
 			} catch (UnreadableDebugInfoException unreadableDebugInfoException) {
@@ -1262,7 +1262,7 @@ public class AtAjAttributes {
 			// this/target/args binding
 			// exclude the throwned binding from the pointcut binding since it
 			// is an extraArg binding
-			FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+			FormalBinding[] bindings = FormalBinding.NONE;
 			try {
 				bindings = (thrownFormal == null ? extractBindings(struct) : extractBindings(struct, thrownFormal));
 			} catch (UnreadableDebugInfoException unreadableDebugInfoException) {
@@ -1317,7 +1317,7 @@ public class AtAjAttributes {
 				if (argumentNames != null) {
 					struct.unparsedArgumentNames = argumentNames;
 				}
-				FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+				FormalBinding[] bindings = FormalBinding.NONE;
 				try {
 					bindings = extractBindings(struct);
 				} catch (UnreadableDebugInfoException unreadableDebugInfoException) {
@@ -1579,7 +1579,7 @@ public class AtAjAttributes {
 			}
 		}
 
-		return bindings.toArray(new FormalBinding[] {});
+		return bindings.toArray(FormalBinding.NONE);
 	}
 
 	// FIXME alex deal with exclude index

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelCflowCounterFieldAdder.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelCflowCounterFieldAdder.java
@@ -56,7 +56,7 @@ public class BcelCflowCounterFieldAdder extends BcelTypeMunger {
 
 		setup.append(fact.createNew(new ObjectType(NameMangler.CFLOW_COUNTER_TYPE)));
 		setup.append(InstructionFactory.createDup(1));
-		setup.append(fact.createInvoke(NameMangler.CFLOW_COUNTER_TYPE, "<init>", Type.VOID, new Type[0], Constants.INVOKESPECIAL));
+		setup.append(fact.createInvoke(NameMangler.CFLOW_COUNTER_TYPE, "<init>", Type.VOID, Type.NO_ARGS, Constants.INVOKESPECIAL));
 
 		setup.append(Utility.createSet(fact, cflowCounterField));
 		clinit.getBody().insert(setup);

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
@@ -1946,7 +1946,7 @@ class BcelClassWeaver implements IClassWeaver {
 				catchBlockForLiteralLoadingFail.append(InstructionFactory.createDup_1(1));
 				catchBlockForLiteralLoadingFail.append(InstructionFactory.SWAP);
 				catchBlockForLiteralLoadingFail.append(fact.createInvoke("java.lang.Throwable", "getMessage",
-						Type.getType(String.class), new Type[] {}, Constants.INVOKEVIRTUAL));
+						Type.getType(String.class), Type.NO_ARGS, Constants.INVOKEVIRTUAL));
 				catchBlockForLiteralLoadingFail.append(fact.createInvoke("java.lang.NoClassDefFoundError", "<init>", Type.VOID,
 						new Type[] { Type.getType(String.class) }, Constants.INVOKESPECIAL));
 				catchBlockForLiteralLoadingFail.append(InstructionFactory.ATHROW);

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelField.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelField.java
@@ -273,7 +273,7 @@ final class BcelField extends ResolvedMemberImpl {
 			GenericSignature.ClassSignature genericTypeSig = bcelObjectType.getGenericClassTypeSignature();
 
 			GenericSignature.FormalTypeParameter[] parentFormals = bcelObjectType.getAllFormals();
-			GenericSignature.FormalTypeParameter[] typeVars = ((genericTypeSig == null) ? new GenericSignature.FormalTypeParameter[0]
+			GenericSignature.FormalTypeParameter[] typeVars = ((genericTypeSig == null) ? GenericSignature.FormalTypeParameter.NONE
 					: genericTypeSig.formalTypeParameters);
 			GenericSignature.FormalTypeParameter[] formals = new GenericSignature.FormalTypeParameter[parentFormals.length
 					+ typeVars.length];

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelMethod.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelMethod.java
@@ -423,15 +423,13 @@ class BcelMethod extends ResolvedMemberImpl {
 		bitflags |= HAS_ANNOTATIONS;
 	}
 
-	public static final AnnotationAJ[] NO_PARAMETER_ANNOTATIONS = new AnnotationAJ[] {};
-
 	public void addParameterAnnotation(int param, AnnotationAJ anno) {
 		ensureParameterAnnotationsRetrieved();
 		if (parameterAnnotations == NO_PARAMETER_ANNOTATIONXS) {
 			// First time we've added any, so lets set up the array
 			parameterAnnotations = new AnnotationAJ[getArity()][];
 			for (int i = 0; i < getArity(); i++) {
-				parameterAnnotations[i] = NO_PARAMETER_ANNOTATIONS;
+				parameterAnnotations[i] = AnnotationAJ.EMPTY_ARRAY;
 			}
 		}
 		int existingCount = parameterAnnotations[param].length;

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelObjectType.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelObjectType.java
@@ -398,7 +398,7 @@ public class BcelObjectType extends AbstractReferenceTypeDelegate {
 		if (pointcuts.size() == 0) {
 			this.pointcuts = ResolvedPointcutDefinition.NO_POINTCUTS;
 		} else {
-			this.pointcuts = pointcuts.toArray(new ResolvedPointcutDefinition[0]);
+			this.pointcuts = pointcuts.toArray(ResolvedPointcutDefinition.NO_POINTCUTS);
 		}
 
 		resolveAnnotationDeclares(l);
@@ -459,7 +459,7 @@ public class BcelObjectType extends AbstractReferenceTypeDelegate {
 	 * until *after* the pointcuts have been resolved.
 	 */
 	private void resolveAnnotationDeclares(List<AjAttribute> attributeList) {
-		FormalBinding[] bindings = new org.aspectj.weaver.patterns.FormalBinding[0];
+		FormalBinding[] bindings = FormalBinding.NONE;
 		IScope bindingScope = new BindingScope(getResolvedTypeX(), getResolvedTypeX().getSourceContext(), bindings);
 		for (AjAttribute a : attributeList) {
 			if (a instanceof AjAttribute.DeclareAttribute) {
@@ -836,7 +836,7 @@ public class BcelObjectType extends AbstractReferenceTypeDelegate {
 	public GenericSignature.FormalTypeParameter[] getAllFormals() {
 		ensureGenericSignatureUnpacked();
 		if (formalsForResolution == null) {
-			return new GenericSignature.FormalTypeParameter[0];
+			return FormalTypeParameter.NONE;
 		} else {
 			return formalsForResolution;
 		}

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
@@ -2047,7 +2047,7 @@ public class BcelShadow extends Shadow {
 
 			if (isPer) {
 				entrySuccessInstructions.append(fact.createInvoke(munger.getConcreteAspect().getName(),
-						NameMangler.PERCFLOW_PUSH_METHOD, Type.VOID, new Type[] {}, Constants.INVOKESTATIC));
+						NameMangler.PERCFLOW_PUSH_METHOD, Type.VOID, Type.NO_ARGS, Constants.INVOKESTATIC));
 			} else {
 				BcelVar[] cflowStateVars = munger.getExposedStateAsBcelVars(false);
 
@@ -2059,7 +2059,7 @@ public class BcelShadow extends Shadow {
 					entrySuccessInstructions.append(Utility.createGet(fact, cflowField));
 					// arrayVar.appendLoad(entrySuccessInstructions, fact);
 					entrySuccessInstructions.append(fact.createInvoke(NameMangler.CFLOW_COUNTER_TYPE, "inc", Type.VOID,
-							new Type[] {}, Constants.INVOKEVIRTUAL));
+							Type.NO_ARGS, Constants.INVOKEVIRTUAL));
 				} else {
 					BcelVar arrayVar = genTempVar(UnresolvedType.OBJECTARRAY);
 
@@ -2097,10 +2097,10 @@ public class BcelShadow extends Shadow {
 				exitInstructions.append(Utility.createGet(fact, cflowField));
 				if (munger.getKind() != AdviceKind.PerCflowEntry && munger.getKind() != AdviceKind.PerCflowBelowEntry
 						&& munger.getExposedStateAsBcelVars(false).length == 0) {
-					exitInstructions.append(fact.createInvoke(NameMangler.CFLOW_COUNTER_TYPE, "dec", Type.VOID, new Type[] {},
+					exitInstructions.append(fact.createInvoke(NameMangler.CFLOW_COUNTER_TYPE, "dec", Type.VOID, Type.NO_ARGS,
 							Constants.INVOKEVIRTUAL));
 				} else {
-					exitInstructions.append(fact.createInvoke(NameMangler.CFLOW_STACK_TYPE, "pop", Type.VOID, new Type[] {},
+					exitInstructions.append(fact.createInvoke(NameMangler.CFLOW_STACK_TYPE, "pop", Type.VOID, Type.NO_ARGS,
 							Constants.INVOKEVIRTUAL));
 				}
 				return exitInstructions;

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
@@ -783,7 +783,7 @@ public class BcelTypeMunger extends ConcreteTypeMunger {
 
 			Type fieldType = BcelWorld.makeBcelType(aspectType);
 			LazyMethodGen mg = new LazyMethodGen(Modifier.PUBLIC, fieldType, NameMangler.perObjectInterfaceGet(aspectType),
-					new Type[0], new String[0], gen);
+					Type.NO_ARGS, new String[0], gen);
 			InstructionList il = new InstructionList();
 			InstructionFactory fact = gen.getFactory();
 			il.append(InstructionConstants.ALOAD_0);
@@ -832,7 +832,7 @@ public class BcelTypeMunger extends ConcreteTypeMunger {
 		// "public com_blah_SecurityAspect ajc$com_blah_SecurityAspect$localAspectOf()"
 		Type fieldType = BcelWorld.makeBcelType(aspectType);
 		LazyMethodGen mg = new LazyMethodGen(Modifier.PUBLIC | Modifier.STATIC, fieldType,
-				NameMangler.perTypeWithinLocalAspectOf(aspectType), new Type[0], new String[0], gen);
+				NameMangler.perTypeWithinLocalAspectOf(aspectType), Type.NO_ARGS, new String[0], gen);
 		InstructionList il = new InstructionList();
 		// PTWIMPL ?? Should check if it is null and throw
 		// NoAspectBoundException

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
@@ -990,7 +990,7 @@ public final class LazyClassGen {
 				return gen;
 			}
 		}
-		LazyMethodGen clinit = new LazyMethodGen(Modifier.STATIC, Type.VOID, "<clinit>", new Type[0], NO_STRINGS, this);
+		LazyMethodGen clinit = new LazyMethodGen(Modifier.STATIC, Type.VOID, "<clinit>", Type.NO_ARGS, NO_STRINGS, this);
 		clinit.getBody().insert(InstructionConstants.RETURN);
 		methodGens.add(clinit);
 		return clinit;

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/LazyMethodGen.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/LazyMethodGen.java
@@ -78,8 +78,6 @@ import org.aspectj.weaver.tools.Traceable;
  */
 public final class LazyMethodGen implements Traceable {
 
-	private static final AnnotationAJ[] NO_ANNOTATIONAJ = new AnnotationAJ[] {};
-
 	private int modifiers;
 	private Type returnType;
 	private final String name;
@@ -305,7 +303,7 @@ public final class LazyMethodGen implements Traceable {
 						newParameterAnnotations[i] = new AnnotationAJ[1];
 						newParameterAnnotations[i][0] = anno;
 					} else {
-						newParameterAnnotations[i] = NO_ANNOTATIONAJ;
+						newParameterAnnotations[i] = AnnotationAJ.EMPTY_ARRAY;
 					}
 				}
 			} else {
@@ -336,7 +334,7 @@ public final class LazyMethodGen implements Traceable {
 	public AnnotationAJ[] getAnnotations() {
 		initialize();
 		if (memberView == null && newAnnotations!=null && newAnnotations.size()!=0) {
-			return newAnnotations.toArray(new AnnotationAJ[0]);
+			return newAnnotations.toArray(AnnotationAJ.EMPTY_ARRAY);
 		}
 		return null;
 	}
@@ -618,7 +616,7 @@ public final class LazyMethodGen implements Traceable {
 		if (enclosingClass != null && enclosingClass.getType() != null) {
 			context = enclosingClass.getType().getSourceContext();
 		}
-		List<AjAttribute> as = Utility.readAjAttributes(getClassName(), attributes.toArray(new Attribute[] {}), context, null, weaverVersion,
+		List<AjAttribute> as = Utility.readAjAttributes(getClassName(), attributes.toArray(Attribute.NoAttributes), context, null, weaverVersion,
 				new BcelConstantPoolReader(this.enclosingClass.getConstantPool()));
 		if (!as.isEmpty()) {
 			out.println("    " + as.get(0)); // XXX assuming exactly one

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/TypeAnnotationAccessVar.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/TypeAnnotationAccessVar.java
@@ -59,7 +59,7 @@ public class TypeAnnotationAccessVar extends BcelVar {
 		Type jlClass = BcelWorld.makeBcelType(UnresolvedType.JL_CLASS);
 		Type jlaAnnotation = BcelWorld.makeBcelType(UnresolvedType.ANNOTATION);
 		il.append(target.createLoad(fact));
-		il.append(fact.createInvoke("java/lang/Object", "getClass", jlClass, new Type[] {}, Constants.INVOKEVIRTUAL));
+		il.append(fact.createInvoke("java/lang/Object", "getClass", jlClass, Type.NO_ARGS, Constants.INVOKEVIRTUAL));
 		il.append(fact.createConstant(new ObjectType(toType.getName())));
 		il.append(fact.createInvoke("java/lang/Class", "getAnnotation", jlaAnnotation, new Type[] { jlClass },
 				Constants.INVOKEVIRTUAL));

--- a/weaver/src/main/java/org/aspectj/weaver/reflect/Java15AnnotationFinder.java
+++ b/weaver/src/main/java/org/aspectj/weaver/reflect/Java15AnnotationFinder.java
@@ -20,6 +20,7 @@ import org.aspectj.apache.bcel.classfile.Attribute;
 import org.aspectj.apache.bcel.classfile.JavaClass;
 import org.aspectj.apache.bcel.classfile.LocalVariable;
 import org.aspectj.apache.bcel.classfile.LocalVariableTable;
+import org.aspectj.apache.bcel.classfile.annotation.AnnotationGen;
 import org.aspectj.apache.bcel.util.ClassLoaderRepository;
 import org.aspectj.apache.bcel.util.NonCachingClassLoaderRepository;
 import org.aspectj.apache.bcel.util.Repository;
@@ -124,7 +125,7 @@ public class Java15AnnotationFinder implements AnnotationFinder, ArgNameFinder {
 		// memory.
 		try {
 			JavaClass jc = bcelRepository.loadClass(onMember.getDeclaringClass());
-			org.aspectj.apache.bcel.classfile.annotation.AnnotationGen[] anns = new org.aspectj.apache.bcel.classfile.annotation.AnnotationGen[0];
+			org.aspectj.apache.bcel.classfile.annotation.AnnotationGen[] anns = AnnotationGen.NO_ANNOTATIONS;
 			if (onMember instanceof Method) {
 				org.aspectj.apache.bcel.classfile.Method bcelMethod = jc.getMethod((Method) onMember);
 				if (bcelMethod == null) {
@@ -147,7 +148,7 @@ public class Java15AnnotationFinder implements AnnotationFinder, ArgNameFinder {
 			bcelRepository.clear();
 			// OPTIMIZE make constant 0 size array for sharing
 			if (anns == null)
-				anns = new org.aspectj.apache.bcel.classfile.annotation.AnnotationGen[0];
+				anns = AnnotationGen.NO_ANNOTATIONS;
 			// convert to our Annotation type
 			for (org.aspectj.apache.bcel.classfile.annotation.AnnotationGen ann : anns) {
 				if (ann.getTypeSignature().equals(ofType.getSignature())) {

--- a/weaver/src/main/java/org/aspectj/weaver/reflect/Java15ReflectionBasedReferenceTypeDelegate.java
+++ b/weaver/src/main/java/org/aspectj/weaver/reflect/Java15ReflectionBasedReferenceTypeDelegate.java
@@ -250,7 +250,7 @@ public class Java15ReflectionBasedReferenceTypeDelegate extends ReflectionBasedR
 	private ResolvedMember createGenericFieldMember(Field forField) {
 		ReflectionBasedResolvedMemberImpl ret = new ReflectionBasedResolvedMemberImpl(org.aspectj.weaver.Member.FIELD,
 				getGenericResolvedType(), forField.getModifiers(), typeConverter.fromType(forField.getType()), forField.getName(),
-				new UnresolvedType[0], forField);
+				UnresolvedType.NONE, forField);
 		ret.setAnnotationFinder(this.annotationFinder);
 		ret.setGenericSignatureInformationProvider(new Java15GenericSignatureInformationProvider(this.getWorld()));
 		return ret;

--- a/weaver/src/main/java/org/aspectj/weaver/reflect/JavaLangTypeToResolvedTypeConverter.java
+++ b/weaver/src/main/java/org/aspectj/weaver/reflect/JavaLangTypeToResolvedTypeConverter.java
@@ -94,7 +94,7 @@ public class JavaLangTypeToResolvedTypeConverter {
 			Type[] bounds = tv.getBounds();
 			ResolvedType[] resBounds = fromTypes(bounds);
 			ResolvedType upperBound = resBounds[0];
-			ResolvedType[] additionalBounds = new ResolvedType[0];
+			ResolvedType[] additionalBounds = ResolvedType.EMPTY_RESOLVED_TYPE_ARRAY;
 			if (resBounds.length > 1) {
 				additionalBounds = new ResolvedType[resBounds.length - 1];
 				System.arraycopy(resBounds, 1, additionalBounds, 0, additionalBounds.length);


### PR DESCRIPTION
There is common practice to re-use Immutable empty arrays, which declared as static final fields.
AspectJ contains many such fields for empty arrays, but not all code use them. Fortunately for us, IntelliJ IDEA is able to find such places automatically and allows to replace them with static field reference.
It simplifies code and reduce garbage.