### PR TITLE
Update 'runtime' code to use generics

### DIFF
--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/AjTypeImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/AjTypeImpl.java
@@ -120,7 +120,7 @@ public class AjTypeImpl<T> implements AjType<T> {
 	 */
 	public AjType<? super T> getSupertype() {
 		Class<? super T> superclass = clazz.getSuperclass();
-		return superclass==null ? null : (AjType<? super T>) new AjTypeImpl(superclass);
+		return superclass==null ? null : (AjType<? super T>) new AjTypeImpl<>(superclass);
 	}
 
 	/* (non-Javadoc)
@@ -149,15 +149,15 @@ public class AjTypeImpl<T> implements AjType<T> {
 	 */
 	public AjType<?> getEnclosingType() {
 		Class<?> enc = clazz.getEnclosingClass();
-		return enc != null ? new AjTypeImpl(enc) : null;
+		return enc != null ? new AjTypeImpl<>(enc) : null;
 	}
 
 	/* (non-Javadoc)
 	 * @see org.aspectj.lang.reflect.AjType#getDeclaringType()
 	 */
 	public AjType<?> getDeclaringType() {
-		Class dec = clazz.getDeclaringClass();
-		return dec != null ? new AjTypeImpl(dec) : null;
+		Class<?> dec = clazz.getDeclaringClass();
+		return dec != null ? new AjTypeImpl<>(dec) : null;
 	}
 
 	public PerClause getPerClause() {
@@ -463,7 +463,7 @@ public class AjTypeImpl<T> implements AjType<T> {
 	/* (non-Javadoc)
 	 * @see org.aspectj.lang.reflect.AjType#getDeclaredAdvice(org.aspectj.lang.reflect.AdviceType)
 	 */
-	private Advice[] getDeclaredAdvice(Set ofAdviceTypes) {
+	private Advice[] getDeclaredAdvice(Set<AdviceKind> ofAdviceTypes) {
 		if (declaredAdvice == null) initDeclaredAdvice();
 		List<Advice> adviceList = new ArrayList<>();
 		for (Advice a : declaredAdvice) {
@@ -488,7 +488,7 @@ public class AjTypeImpl<T> implements AjType<T> {
 	/* (non-Javadoc)
 	 * @see org.aspectj.lang.reflect.AjType#getDeclaredAdvice(org.aspectj.lang.reflect.AdviceType)
 	 */
-	private Advice[] getAdvice(Set ofAdviceTypes) {
+	private Advice[] getAdvice(Set<AdviceKind> ofAdviceTypes) {
 		if (advice == null) initAdvice();
 		List<Advice> adviceList = new ArrayList<>();
 		for (Advice a : advice) {
@@ -1071,7 +1071,7 @@ public class AjTypeImpl<T> implements AjType<T> {
 	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof AjTypeImpl)) return false;
-		AjTypeImpl other = (AjTypeImpl) obj;
+		AjTypeImpl<?> other = (AjTypeImpl<?>) obj;
 		return other.clazz.equals(clazz);
 	}
 

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareErrorOrWarningImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/DeclareErrorOrWarningImpl.java
@@ -24,7 +24,7 @@ public class DeclareErrorOrWarningImpl implements DeclareErrorOrWarning {
 	private PointcutExpression pc;
 	private String msg;
 	private boolean isError;
-	private AjType declaringType;
+	private AjType<?> declaringType;
 
 	public DeclareErrorOrWarningImpl(String pointcut, String message, boolean isError, AjType decType) {
 		this.pc = new PointcutExpressionImpl(pointcut);

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/PointcutImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/PointcutImpl.java
@@ -28,7 +28,7 @@ public class PointcutImpl implements Pointcut {
 	private final String name;
 	private final PointcutExpression pc;
 	private final Method baseMethod;
-	private final AjType declaringType;
+	private final AjType<?> declaringType;
 	private String[] parameterNames = new String[0];
 
 	protected PointcutImpl(String name, String pc, Method method, AjType declaringType, String pNames) {

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/StringToType.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/StringToType.java
@@ -48,7 +48,7 @@ public class StringToType {
 		} catch (ClassNotFoundException e) {
 			// could be a type variable
 			TypeVariable[] tVars = classScope.getTypeParameters();
-			for (TypeVariable tVar : tVars) {
+			for (TypeVariable<?> tVar : tVars) {
 				if (tVar.getName().equals(typeName)) {
 					return tVar;
 				}
@@ -57,11 +57,11 @@ public class StringToType {
 		}
 	}
 
-	private static Type makeParameterizedType(String typeName, Class classScope)
+	private static Type makeParameterizedType(String typeName, Class<?> classScope)
 	throws ClassNotFoundException {
 		int paramStart = typeName.indexOf('<');
 		String baseName = typeName.substring(0, paramStart);
-		final Class baseClass = Class.forName(baseName,false,classScope.getClassLoader());
+		final Class<?> baseClass = Class.forName(baseName,false,classScope.getClassLoader());
 		int paramEnd = typeName.lastIndexOf('>');
 		String params = typeName.substring(paramStart+1,paramEnd);
 		final Type[] typeParams = commaSeparatedListToTypeArray(params,classScope);

--- a/runtime/src/main/java/org/aspectj/lang/Aspects.java
+++ b/runtime/src/main/java/org/aspectj/lang/Aspects.java
@@ -157,22 +157,22 @@ public class Aspects {
 
     // -- hasAspect
 
-    private static Method getSingletonOrThreadHasAspect(Class aspectClass) throws NoSuchMethodException {
+    private static Method getSingletonOrThreadHasAspect(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(HASASPECT, EMPTY_CLASS_ARRAY);
         return checkHasAspect(method, aspectClass);
     }
 
-    private static Method getPerObjectHasAspect(Class aspectClass) throws NoSuchMethodException {
+    private static Method getPerObjectHasAspect(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(HASASPECT, PEROBJECT_CLASS_ARRAY);
         return checkHasAspect(method, aspectClass);
     }
 
-    private static Method getPerTypeWithinHasAspect(Class aspectClass) throws NoSuchMethodException {
+    private static Method getPerTypeWithinHasAspect(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(HASASPECT, PERTYPEWITHIN_CLASS_ARRAY);
         return checkHasAspect(method, aspectClass);
     }
 
-    private static Method checkHasAspect(Method method, Class aspectClass) throws NoSuchMethodException {
+    private static Method checkHasAspect(Method method, Class<?> aspectClass) throws NoSuchMethodException {
         method.setAccessible(true);
         if (!method.isAccessible()
             || !Modifier.isPublic(method.getModifiers())

--- a/runtime/src/main/java/org/aspectj/lang/Aspects14.java
+++ b/runtime/src/main/java/org/aspectj/lang/Aspects14.java
@@ -133,22 +133,22 @@ public class Aspects14 {
 
     // -- aspectOf
 
-    private static Method getSingletonOrThreadAspectOf(Class aspectClass) throws NoSuchMethodException {
+    private static Method getSingletonOrThreadAspectOf(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(ASPECTOF, EMPTY_CLASS_ARRAY);
         return checkAspectOf(method, aspectClass);
     }
 
-    private static Method getPerObjectAspectOf(Class aspectClass) throws NoSuchMethodException {
+    private static Method getPerObjectAspectOf(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(ASPECTOF, PEROBJECT_CLASS_ARRAY);
         return checkAspectOf(method, aspectClass);
     }
 
-    private static Method getPerTypeWithinAspectOf(Class aspectClass) throws NoSuchMethodException {
+    private static Method getPerTypeWithinAspectOf(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(ASPECTOF, PERTYPEWITHIN_CLASS_ARRAY);
         return checkAspectOf(method, aspectClass);
     }
 
-    private static Method checkAspectOf(Method method, Class aspectClass) throws NoSuchMethodException {
+    private static Method checkAspectOf(Method method, Class<?> aspectClass) throws NoSuchMethodException {
         method.setAccessible(true);
         if (!method.isAccessible()
             || !Modifier.isPublic(method.getModifiers())
@@ -160,22 +160,22 @@ public class Aspects14 {
 
     // -- hasAspect
 
-    private static Method getSingletonOrThreadHasAspect(Class aspectClass) throws NoSuchMethodException {
+    private static Method getSingletonOrThreadHasAspect(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(HASASPECT, EMPTY_CLASS_ARRAY);
         return checkHasAspect(method, aspectClass);
     }
 
-    private static Method getPerObjectHasAspect(Class aspectClass) throws NoSuchMethodException {
+    private static Method getPerObjectHasAspect(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(HASASPECT, PEROBJECT_CLASS_ARRAY);
         return checkHasAspect(method, aspectClass);
     }
 
-    private static Method getPerTypeWithinHasAspect(Class aspectClass) throws NoSuchMethodException {
+    private static Method getPerTypeWithinHasAspect(Class<?> aspectClass) throws NoSuchMethodException {
         Method method = aspectClass.getDeclaredMethod(HASASPECT, PERTYPEWITHIN_CLASS_ARRAY);
         return checkHasAspect(method, aspectClass);
     }
 
-    private static Method checkHasAspect(Method method, Class aspectClass) throws NoSuchMethodException {
+    private static Method checkHasAspect(Method method, Class<?> aspectClass) throws NoSuchMethodException {
         method.setAccessible(true);
         if (!method.isAccessible()
             || !Modifier.isPublic(method.getModifiers())

--- a/runtime/src/main/java/org/aspectj/runtime/internal/CFlowStack.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/CFlowStack.java
@@ -81,7 +81,7 @@ public class CFlowStack {
     }
 
     public void pop() {
-        Stack s = getThreadStack();
+        Stack<?> s = getThreadStack();
         s.pop();
         if (s.isEmpty()) {
         	stackProxy.removeThreadStack();
@@ -89,7 +89,7 @@ public class CFlowStack {
     }
 
     public Object peek() {
-        Stack stack = getThreadStack();
+        Stack<?> stack = getThreadStack();
         if (stack.isEmpty()) throw new org.aspectj.lang.NoAspectBoundException();
         return (Object)stack.peek();
     }
@@ -106,13 +106,13 @@ public class CFlowStack {
     }
 
     public CFlow peekCFlow() {
-        Stack stack = getThreadStack();
+        Stack<?> stack = getThreadStack();
         if (stack.isEmpty()) return null;
         return (CFlow)stack.peek();
     }
 
     public CFlow peekTopCFlow() {
-        Stack stack = getThreadStack();
+        Stack<?> stack = getThreadStack();
         if (stack.isEmpty()) return null;
         return (CFlow)stack.elementAt(0);
     }

--- a/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadCounterImpl11.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadCounterImpl11.java
@@ -19,7 +19,7 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 
 public class ThreadCounterImpl11 implements ThreadCounter {
-	private Hashtable counters = new Hashtable();
+	private Hashtable<Thread, Counter> counters = new Hashtable<>();
 	private Thread cached_thread;
 	private Counter cached_counter;
 
@@ -43,8 +43,8 @@ public class ThreadCounterImpl11 implements ThreadCounter {
 			// Collect more often if there are many threads, but not *too* often
 			int size = Math.max(1, counters.size()); // should be >1 b/c always live threads, but...
 			if (change_count > Math.max(MIN_COLLECT_AT, COLLECT_AT/size)) {
-				List dead_stacks = new ArrayList();
-				for (Enumeration e = counters.keys(); e.hasMoreElements(); ) {
+				List<Thread> dead_stacks = new ArrayList<>();
+				for (Enumeration<Thread> e = counters.keys(); e.hasMoreElements(); ) {
 					Thread t = (Thread)e.nextElement();
 					if (!t.isAlive()) dead_stacks.add(t);
 				}

--- a/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackFactoryImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackFactoryImpl.java
@@ -16,8 +16,8 @@ import java.util.Stack;
 
 public class ThreadStackFactoryImpl implements ThreadStackFactory {
 
-	private static class ThreadStackImpl extends ThreadLocal implements ThreadStack {
-		public Object initialValue() {
+	private static class ThreadStackImpl extends ThreadLocal<Stack> implements ThreadStack {
+		public Stack initialValue() {
 		  return new Stack();
 		}
 		public Stack getThreadStack() {
@@ -32,9 +32,9 @@ public class ThreadStackFactoryImpl implements ThreadStackFactory {
 		return new ThreadStackImpl();
 	}
 
-	private static class ThreadCounterImpl extends ThreadLocal implements ThreadCounter {
+	private static class ThreadCounterImpl extends ThreadLocal<ThreadCounterImpl.Counter> implements ThreadCounter {
 
-		public Object initialValue() {
+		public Counter initialValue() {
 		  return new Counter();
 		}
 		public Counter getThreadCounter() {

--- a/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackImpl11.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackImpl11.java
@@ -18,7 +18,7 @@ import java.util.Hashtable;
 import java.util.Stack;
 
 public class ThreadStackImpl11 implements ThreadStack {
-	private Hashtable stacks = new Hashtable();
+	private Hashtable<Thread, Stack> stacks = new Hashtable<>();
 	private Thread cached_thread;
 	private Stack cached_stack;
 	private int change_count = 0;
@@ -28,21 +28,21 @@ public class ThreadStackImpl11 implements ThreadStack {
 	public synchronized Stack getThreadStack() {
 		if (Thread.currentThread() != cached_thread) {
 			cached_thread = Thread.currentThread();
-			cached_stack = (Stack)stacks.get(cached_thread);
+			cached_stack = (Stack<?>)stacks.get(cached_thread);
 			if (cached_stack == null) {
-				cached_stack = new Stack();
+				cached_stack = new Stack<>();
 				stacks.put(cached_thread, cached_stack);
 			}
 			change_count++;
 			// Collect more often if there are many threads, but not *too* often
 			int size = Math.max(1, stacks.size()); // should be >1 b/c always live threads, but...
 			if (change_count > Math.max(MIN_COLLECT_AT, COLLECT_AT/size)) {
-				Stack dead_stacks = new Stack();
-				for (Enumeration e = stacks.keys(); e.hasMoreElements(); ) {
+				Stack<Thread> dead_stacks = new Stack<>();
+				for (Enumeration<Thread> e = stacks.keys(); e.hasMoreElements(); ) {
 					Thread t = (Thread)e.nextElement();
 					if (!t.isAlive()) dead_stacks.push(t);
 				}
-				for (Enumeration e = dead_stacks.elements(); e.hasMoreElements(); ) {
+				for (Enumeration<Thread> e = dead_stacks.elements(); e.hasMoreElements(); ) {
 					Thread t = (Thread)e.nextElement();
 					stacks.remove(t);
 				}

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/AdviceSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/AdviceSignatureImpl.java
@@ -20,12 +20,12 @@ import java.util.StringTokenizer;
 import org.aspectj.lang.reflect.AdviceSignature;
 
 class AdviceSignatureImpl extends CodeSignatureImpl implements AdviceSignature {
-    Class returnType;
+    Class<?> returnType;
 	private Method adviceMethod = null;
 
-    AdviceSignatureImpl(int modifiers, String name, Class declaringType,
+    AdviceSignatureImpl(int modifiers, String name, Class<?> declaringType,
         Class[] parameterTypes, String[] parameterNames, Class[] exceptionTypes,
-        Class returnType)
+        Class<?> returnType)
     {
         super(modifiers, name, declaringType, parameterTypes, parameterNames,
             exceptionTypes);

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/CatchClauseSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/CatchClauseSignatureImpl.java
@@ -17,11 +17,11 @@ package org.aspectj.runtime.reflect;
 import org.aspectj.lang.reflect.CatchClauseSignature;
 
 class CatchClauseSignatureImpl extends SignatureImpl implements CatchClauseSignature {
-    Class parameterType;
+    Class<?> parameterType;
     String parameterName;
 
-    CatchClauseSignatureImpl(Class declaringType,
-        Class parameterType, String parameterName)
+    CatchClauseSignatureImpl(Class<?> declaringType,
+        Class<?> parameterType, String parameterName)
     {
         super(0, "catch", declaringType);
         this.parameterType = parameterType;

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/CodeSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/CodeSignatureImpl.java
@@ -21,7 +21,7 @@ abstract class CodeSignatureImpl extends MemberSignatureImpl implements CodeSign
     String[] parameterNames;
     Class[] exceptionTypes;
 
-    CodeSignatureImpl(int modifiers, String name, Class declaringType,
+    CodeSignatureImpl(int modifiers, String name, Class<?> declaringType,
         Class[] parameterTypes, String[] parameterNames, Class[] exceptionTypes)
     {
         super(modifiers, name, declaringType);

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/ConstructorSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/ConstructorSignatureImpl.java
@@ -19,9 +19,9 @@ import java.lang.reflect.Constructor;
 import org.aspectj.lang.reflect.ConstructorSignature;
 
 class ConstructorSignatureImpl extends CodeSignatureImpl implements ConstructorSignature {
-	private Constructor constructor;
+    private Constructor<?> constructor;
 
-    ConstructorSignatureImpl(int modifiers, Class declaringType,
+    ConstructorSignatureImpl(int modifiers, Class<?> declaringType,
         Class[] parameterTypes, String[] parameterNames, Class[] exceptionTypes)
     {
         super(modifiers, "<init>", declaringType, parameterTypes, parameterNames, exceptionTypes);

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/Factory.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/Factory.java
@@ -35,7 +35,7 @@ import org.aspectj.lang.reflect.SourceLocation;
 import org.aspectj.lang.reflect.UnlockSignature;
 
 public final class Factory {
-	Class lexicalClass;
+	Class<?> lexicalClass;
 	ClassLoader lookupClassLoader;
 	String filename;
 	int count;
@@ -43,7 +43,7 @@ public final class Factory {
 	private static final Class[] NO_TYPES = new Class[0];
 	private static final String[] NO_STRINGS = new String[0];
 
-	static Hashtable prims = new Hashtable();
+	static Hashtable<String, Class<?>> prims = new Hashtable<>();
 	static {
 		prims.put("void", Void.TYPE);
 		prims.put("boolean", Boolean.TYPE);
@@ -56,10 +56,10 @@ public final class Factory {
 		prims.put("double", Double.TYPE);
 	}
 
-	static Class makeClass(String s, ClassLoader loader) {
+	static Class<?> makeClass(String s, ClassLoader loader) {
 		if (s.equals("*"))
 			return null;
-		Class ret = (Class)prims.get(s);
+		Class<?> ret = (Class)prims.get(s);
 		if (ret != null)
 			return ret;
 		try {
@@ -246,7 +246,7 @@ public final class Factory {
 					.getReturnType());
 			kind = JoinPoint.METHOD_EXECUTION;
 		} else if (member instanceof Constructor) {
-			Constructor cons = (Constructor) member;
+			Constructor<?> cons = (Constructor<?>) member;
 			sig = new ConstructorSignatureImpl(cons.getModifiers(), cons.getDeclaringClass(), cons.getParameterTypes(),
 					new String[cons.getParameterTypes().length], cons.getExceptionTypes());
 			kind = JoinPoint.CONSTRUCTOR_EXECUTION;
@@ -282,7 +282,7 @@ public final class Factory {
 
 	public MethodSignature makeMethodSig(String modifiers, String methodName, String declaringType, String paramTypes,
 			String paramNames, String exceptionTypes, String returnType) {
-		Class declaringTypeClass = makeClass(declaringType, lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass(declaringType, lookupClassLoader);
 		return makeMethodSig(modifiers, methodName, declaringTypeClass, paramTypes, paramNames, exceptionTypes, returnType);
 	}
 
@@ -308,7 +308,7 @@ public final class Factory {
 		for (int i = 0; i < numParams; i++)
 			exceptionTypeClasses[i] = makeClass(st.nextToken(), lookupClassLoader);
 
-		Class returnTypeClass = makeClass(returnType, lookupClassLoader);
+		Class<?> returnTypeClass = makeClass(returnType, lookupClassLoader);
 
 		MethodSignatureImpl ret = new MethodSignatureImpl(modifiersAsInt, methodName, declaringTypeClass, paramTypeClasses,
 				paramNamesArray, exceptionTypeClasses, returnTypeClass);
@@ -334,7 +334,7 @@ public final class Factory {
 			String exceptionTypes) {
 		int modifiersAsInt = Integer.parseInt(modifiers, 16);
 
-		Class declaringTypeClass = makeClass(declaringType, lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass(declaringType, lookupClassLoader);
 
 		StringTokenizer st = new StringTokenizer(paramTypes, ":");
 		int numParams = st.countTokens();
@@ -376,8 +376,8 @@ public final class Factory {
 
 	public FieldSignature makeFieldSig(String modifiers, String name, String declaringType, String fieldType) {
 		int modifiersAsInt = Integer.parseInt(modifiers, 16);
-		Class declaringTypeClass = makeClass(declaringType, lookupClassLoader);
-		Class fieldTypeClass = makeClass(fieldType, lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass(declaringType, lookupClassLoader);
+		Class<?> fieldTypeClass = makeClass(fieldType, lookupClassLoader);
 
 		FieldSignatureImpl ret = new FieldSignatureImpl(modifiersAsInt, name, declaringTypeClass, fieldTypeClass);
 		ret.setLookupClassLoader(lookupClassLoader);
@@ -400,7 +400,7 @@ public final class Factory {
 			String exceptionTypes, String returnType) {
 		int modifiersAsInt = Integer.parseInt(modifiers, 16);
 
-		Class declaringTypeClass = makeClass(declaringType, lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass(declaringType, lookupClassLoader);
 
 		StringTokenizer st = new StringTokenizer(paramTypes, ":");
 		int numParams = st.countTokens();
@@ -421,7 +421,7 @@ public final class Factory {
 			exceptionTypeClasses[i] = makeClass(st.nextToken(), lookupClassLoader);
 		;
 
-		Class returnTypeClass = makeClass(returnType, lookupClassLoader);
+		Class<?> returnTypeClass = makeClass(returnType, lookupClassLoader);
 
 		AdviceSignatureImpl ret = new AdviceSignatureImpl(modifiersAsInt, name, declaringTypeClass, paramTypeClasses,
 				paramNamesArray, exceptionTypeClasses, returnTypeClass);
@@ -445,7 +445,7 @@ public final class Factory {
 
 	public InitializerSignature makeInitializerSig(String modifiers, String declaringType) {
 		int modifiersAsInt = Integer.parseInt(modifiers, 16);
-		Class declaringTypeClass = makeClass(declaringType, lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass(declaringType, lookupClassLoader);
 
 		InitializerSignatureImpl ret = new InitializerSignatureImpl(modifiersAsInt, declaringTypeClass);
 		ret.setLookupClassLoader(lookupClassLoader);
@@ -465,10 +465,10 @@ public final class Factory {
 	}
 
 	public CatchClauseSignature makeCatchClauseSig(String declaringType, String parameterType, String parameterName) {
-		Class declaringTypeClass = makeClass(declaringType, lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass(declaringType, lookupClassLoader);
 
 		StringTokenizer st = new StringTokenizer(parameterType, ":");
-		Class parameterTypeClass = makeClass(st.nextToken(), lookupClassLoader);
+		Class<?> parameterTypeClass = makeClass(st.nextToken(), lookupClassLoader);
 
 		st = new StringTokenizer(parameterName, ":");
 		String parameterNameForReturn = st.nextToken();
@@ -491,7 +491,7 @@ public final class Factory {
 	}
 
 	public LockSignature makeLockSig() {
-		Class declaringTypeClass = makeClass("Ljava/lang/Object;", lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass("Ljava/lang/Object;", lookupClassLoader);
 		LockSignatureImpl ret = new LockSignatureImpl(declaringTypeClass);
 		ret.setLookupClassLoader(lookupClassLoader);
 		return ret;
@@ -510,7 +510,7 @@ public final class Factory {
 	}
 
 	public UnlockSignature makeUnlockSig() {
-		Class declaringTypeClass = makeClass("Ljava/lang/Object;", lookupClassLoader);
+		Class<?> declaringTypeClass = makeClass("Ljava/lang/Object;", lookupClassLoader);
 		UnlockSignatureImpl ret = new UnlockSignatureImpl(declaringTypeClass);
 		ret.setLookupClassLoader(lookupClassLoader);
 		return ret;

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/FieldSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/FieldSignatureImpl.java
@@ -19,11 +19,11 @@ import java.lang.reflect.Field;
 import org.aspectj.lang.reflect.FieldSignature;
 
 public class FieldSignatureImpl extends MemberSignatureImpl implements FieldSignature {
-    Class fieldType;
+    Class<?> fieldType;
 	private Field field;
 
-    FieldSignatureImpl(int modifiers, String name, Class declaringType,
-        Class fieldType)
+    FieldSignatureImpl(int modifiers, String name, Class<?> declaringType,
+        Class<?> fieldType)
     {
         super(modifiers, name, declaringType);
         this.fieldType = fieldType;

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/InitializerSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/InitializerSignatureImpl.java
@@ -20,9 +20,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
 class InitializerSignatureImpl extends CodeSignatureImpl implements InitializerSignature {
-	private Constructor constructor;
+    private Constructor<?> constructor;
 
-    InitializerSignatureImpl(int modifiers, Class declaringType) {
+    InitializerSignatureImpl(int modifiers, Class<?> declaringType) {
         super(modifiers, Modifier.isStatic(modifiers) ? "<clinit>" : "<init>", declaringType, EMPTY_CLASS_ARRAY,
               EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY);
     }

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/LockSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/LockSignatureImpl.java
@@ -17,9 +17,9 @@ import java.lang.reflect.Modifier;
 import org.aspectj.lang.reflect.LockSignature;
 
 class LockSignatureImpl extends SignatureImpl implements LockSignature {
-    private Class parameterType;
+    private Class<?> parameterType;
 
-    LockSignatureImpl(Class c) {
+    LockSignatureImpl(Class<?> c) {
         super(Modifier.STATIC, "lock", c);
         parameterType = c;
     }
@@ -33,7 +33,7 @@ class LockSignatureImpl extends SignatureImpl implements LockSignature {
         return "lock("+sm.makeTypeName(parameterType)+")";
     }
 
-    public Class getParameterType() {
+    public Class<?> getParameterType() {
         if (parameterType == null) parameterType = extractType(3);
         return parameterType;
     }

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/MemberSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/MemberSignatureImpl.java
@@ -18,7 +18,7 @@ import org.aspectj.lang.reflect.MemberSignature;
 
 abstract class MemberSignatureImpl extends SignatureImpl implements MemberSignature {
 
-    MemberSignatureImpl(int modifiers, String name, Class declaringType) {
+    MemberSignatureImpl(int modifiers, String name, Class<?> declaringType) {
         super(modifiers, name, declaringType);
     }
 

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/MethodSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/MethodSignatureImpl.java
@@ -21,10 +21,10 @@ import org.aspectj.lang.reflect.MethodSignature;
 
 class MethodSignatureImpl extends CodeSignatureImpl implements MethodSignature {
 	private Method method;
-	Class returnType;
+	Class<?> returnType;
 
-	MethodSignatureImpl(int modifiers, String name, Class declaringType, Class[] parameterTypes, String[] parameterNames,
-			Class[] exceptionTypes, Class returnType) {
+	MethodSignatureImpl(int modifiers, String name, Class<?> declaringType, Class[] parameterTypes, String[] parameterNames,
+			Class[] exceptionTypes, Class<?> returnType) {
 		super(modifiers, name, declaringType, parameterTypes, parameterNames, exceptionTypes);
 		this.returnType = returnType;
 	}
@@ -62,12 +62,12 @@ class MethodSignatureImpl extends CodeSignatureImpl implements MethodSignature {
 	 */
 	public Method getMethod() {
 		if (method == null) {
-			Class dtype = getDeclaringType();
+			Class<?> dtype = getDeclaringType();
 			try {
 				method = dtype.getDeclaredMethod(getName(), getParameterTypes());
 			} catch (NoSuchMethodException nsmEx) {
 				// pr154427 - search
-				Set searched = new HashSet();
+				Set<Class<?>> searched = new HashSet<>();
 				searched.add(dtype); // avoids another getDeclaredMethod() on dtype
 				method = search(dtype, getName(), getParameterTypes(), searched);
 			}
@@ -84,7 +84,7 @@ class MethodSignatureImpl extends CodeSignatureImpl implements MethodSignature {
 	 * @param searched a set of types already searched to avoid looking at anything twice
 	 * @return the method if found, or null if not found
 	 */
-	private Method search(Class type, String name, Class[] params, Set searched) {
+	private Method search(Class<?> type, String name, Class[] params, Set<Class<?>> searched) {
 		if (type == null) {
 			return null;
 		}
@@ -102,7 +102,7 @@ class MethodSignatureImpl extends CodeSignatureImpl implements MethodSignature {
 		}
 		Class[] superinterfaces = type.getInterfaces();
 		if (superinterfaces != null) {
-			for (Class superinterface : superinterfaces) {
+			for (Class<?> superinterface : superinterfaces) {
 				m = search(superinterface, name, params, searched);
 				if (m != null) {
 					return m;

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/SignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/SignatureImpl.java
@@ -25,10 +25,10 @@ abstract class SignatureImpl implements Signature {
     int modifiers = -1;
     String name;
     String declaringTypeName;
-    Class declaringType;
+    Class<?> declaringType;
     Cache stringCache;
 
-    SignatureImpl(int modifiers, String name, Class declaringType) {
+    SignatureImpl(int modifiers, String name, Class<?> declaringType) {
         this.modifiers = modifiers;
         this.name = name;
         this.declaringType = declaringType;
@@ -82,7 +82,7 @@ abstract class SignatureImpl implements Signature {
     	return declaringTypeName;
     }
 
-    String fullTypeName(Class type) {
+    String fullTypeName(Class<?> type) {
         if (type == null) return "ANONYMOUS";
         if (type.isArray()) return fullTypeName(type.getComponentType()) + "[]";
         return type.getName().replace('$', '.');
@@ -94,7 +94,7 @@ abstract class SignatureImpl implements Signature {
         return name.substring(dot+1);
     }
 
-    String shortTypeName(Class type) {
+    String shortTypeName(Class<?> type) {
         if (type == null) return "ANONYMOUS";
         if (type.isArray()) return shortTypeName(type.getComponentType()) + "[]";
         return stripPackageName(type.getName()).replace('$', '.');
@@ -157,7 +157,7 @@ abstract class SignatureImpl implements Signature {
         return Integer.parseInt(s, 16);
     }
 
-    Class extractType(int n) {
+    Class<?> extractType(int n) {
         String s = extractString(n);
         return Factory.makeClass(s,getLookupClassLoader());
     }
@@ -207,7 +207,7 @@ abstract class SignatureImpl implements Signature {
 
 	// separate implementation so we don't need SoftReference to hold the field...
 	private static final class CacheImpl implements Cache {
-		private java.lang.ref.SoftReference toStringCacheRef;
+		private java.lang.ref.SoftReference<String[]> toStringCacheRef;
 
 		public CacheImpl() {
 			makeCache();
@@ -235,7 +235,7 @@ abstract class SignatureImpl implements Signature {
 
 		private String[] makeCache() {
 			String[] array = new String[3];
-			toStringCacheRef = new java.lang.ref.SoftReference(array);
+			toStringCacheRef = new java.lang.ref.SoftReference<>(array);
 			return array;
 		}
 

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/SourceLocationImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/SourceLocationImpl.java
@@ -17,11 +17,11 @@ package org.aspectj.runtime.reflect;
 import org.aspectj.lang.reflect.SourceLocation;
 
 class SourceLocationImpl implements SourceLocation {
-    Class withinType;
+    Class<?> withinType;
     String fileName;
     int line;
 
-    SourceLocationImpl(Class withinType, String fileName, int line) {
+    SourceLocationImpl(Class<?> withinType, String fileName, int line) {
         this.withinType = withinType;
         this.fileName = fileName;
         this.line = line;

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/StringMaker.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/StringMaker.java
@@ -87,10 +87,10 @@ class StringMaker {
         return name.substring(dot+1);
     }
 
-    String makeTypeName(Class type, String typeName, boolean shortName) {
+    String makeTypeName(Class<?> type, String typeName, boolean shortName) {
         if (type == null) return "ANONYMOUS";
         if (type.isArray()) {
-        	Class componentType = type.getComponentType();
+        	Class<?> componentType = type.getComponentType();
         	return makeTypeName(componentType, componentType.getName(), shortName) + "[]";
         }
         if (shortName) {
@@ -100,11 +100,11 @@ class StringMaker {
         }
     }
 
-    public String makeTypeName(Class type) {
+    public String makeTypeName(Class<?> type) {
         return makeTypeName(type, type.getName(),shortTypeNames);
     }
 
-    public String makePrimaryTypeName(Class type, String typeName) {
+    public String makePrimaryTypeName(Class<?> type, String typeName) {
         return makeTypeName(type, typeName, shortPrimaryTypeNames);
     }
 

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/UnlockSignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/UnlockSignatureImpl.java
@@ -17,9 +17,9 @@ import java.lang.reflect.Modifier;
 import org.aspectj.lang.reflect.UnlockSignature;
 
 class UnlockSignatureImpl extends SignatureImpl implements UnlockSignature {
-    private Class parameterType;
+    private Class<?> parameterType;
 
-    UnlockSignatureImpl(Class c) {
+    UnlockSignatureImpl(Class<?> c) {
         super(Modifier.STATIC, "unlock", c);
         parameterType = c;
     }


### PR DESCRIPTION
Continuation of https://github.com/eclipse/org.aspectj/pull/104
Generics make code more type-safe and allow removing type-casts (in the future).
I intentionally didn't remove redundant casts under this PR, to minimize changes. I plan to do it in another PR, after this PR is merged.
Also I didn't touch public/protected methods and fields. They can be subject of compatibility.