### PR TITLE
Release 1.9.8

### DIFF
--- a/ajbrowser/pom.xml
+++ b/ajbrowser/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajbrowser</artifactId>

--- a/ajbrowser/pom.xml
+++ b/ajbrowser/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>ajbrowser</artifactId>

--- a/ajde.core/pom.xml
+++ b/ajde.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>ajde.core</artifactId>

--- a/ajde.core/pom.xml
+++ b/ajde.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajde.core</artifactId>

--- a/ajde/pom.xml
+++ b/ajde/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajde</artifactId>

--- a/ajde/pom.xml
+++ b/ajde/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>ajde</artifactId>

--- a/ajdoc/pom.xml
+++ b/ajdoc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>ajdoc</artifactId>

--- a/ajdoc/pom.xml
+++ b/ajdoc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>ajdoc</artifactId>

--- a/asm/pom.xml
+++ b/asm/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>asm</artifactId>

--- a/asm/pom.xml
+++ b/asm/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>asm</artifactId>

--- a/aspectjmatcher/pom.xml
+++ b/aspectjmatcher/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjmatcher</artifactId>

--- a/aspectjmatcher/pom.xml
+++ b/aspectjmatcher/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>aspectjmatcher</artifactId>

--- a/aspectjrt/pom.xml
+++ b/aspectjrt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjrt</artifactId>

--- a/aspectjrt/pom.xml
+++ b/aspectjrt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>aspectjrt</artifactId>

--- a/aspectjtools/pom.xml
+++ b/aspectjtools/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjtools</artifactId>

--- a/aspectjtools/pom.xml
+++ b/aspectjtools/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>aspectjtools</artifactId>

--- a/aspectjweaver/pom.xml
+++ b/aspectjweaver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>aspectjweaver</artifactId>

--- a/aspectjweaver/pom.xml
+++ b/aspectjweaver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aspectjweaver</artifactId>

--- a/bcel-builder/pom.xml
+++ b/bcel-builder/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>bcel-builder</artifactId>

--- a/bcel-builder/pom.xml
+++ b/bcel-builder/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bcel-builder</artifactId>

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bridge</artifactId>

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>bridge</artifactId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>build</artifactId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>build</artifactId>

--- a/docs/developer/IDE.md
+++ b/docs/developer/IDE.md
@@ -32,8 +32,8 @@ projects using AspectJ Maven Plugin.
 #### AspectJ Development Tools (AJDT)
 
 Use an update sites corresponding to your Eclipse version (minimal version listed):
-* Eclipse 2021-09 (4.21): https://aspectj.dev/eclipse/ajdt/421
-* Eclipse 2021-03 (4.19): https://aspectj.dev/eclipse/ajdt/419
+* Eclipse 2021-09 (4.21): https://download.eclipse.org/tools/ajdt/421/dev/update
+* Eclipse 2021-03 (4.19): https://download.eclipse.org/tools/ajdt/419/dev/update
 * Eclipse 2018-12 (4.10): https://download.eclipse.org/tools/ajdt/410/dev/update
 * For older versions, please refer to https://www.eclipse.org/ajdt/downloads (page was not updated in a long time,
   and I have no write access).

--- a/docs/dist/doc/README-198.html
+++ b/docs/dist/doc/README-198.html
@@ -110,9 +110,10 @@
       craft a condy class with ASM</a>.
   </li>
   <li>
-    Fix <a href="https://github.com/eclipse/org.aspectj/issues/115">issue #115</a>: In annotation-style pointcuts,
-    <tt>if(false)</tt> and <tt>if(true)</tt> now work as expected and do not require a boolean return value and body for
-    the <tt>@Pointcut</tt> method.
+    Improvements for <tt>if()</tt> pointcuts in annotation syntax, see issues
+    <a href="https://github.com/eclipse/org.aspectj/issues/115">#115</a>,
+    <a href="https://github.com/eclipse/org.aspectj/issues/120">#120</a>,
+    <a href="https://github.com/eclipse/org.aspectj/issues/122">#122</a>.
   </li>
   <li>
     Thanks to Andrey Turbanov for several clean code contributions and to Dmitry Mikhaylov for fixing a potential
@@ -148,7 +149,7 @@
 <hr>
 
 <p>
-  <b>Available:</b> 1.9.8 available DD-MMM-2022
+  <b>Available:</b> 1.9.8 available 11-Feb-2022
 </p>
 
 </body>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>installer</artifactId>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>installer</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>lib</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>lib</artifactId>

--- a/loadtime/pom.xml
+++ b/loadtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>loadtime</artifactId>

--- a/loadtime/pom.xml
+++ b/loadtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>loadtime</artifactId>

--- a/org.aspectj.ajdt.core/pom.xml
+++ b/org.aspectj.ajdt.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.aspectj.ajdt.core</artifactId>

--- a/org.aspectj.ajdt.core/pom.xml
+++ b/org.aspectj.ajdt.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>org.aspectj.ajdt.core</artifactId>

--- a/org.aspectj.matcher/pom.xml
+++ b/org.aspectj.matcher/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.aspectj.matcher</artifactId>

--- a/org.aspectj.matcher/pom.xml
+++ b/org.aspectj.matcher/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>org.aspectj.matcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.aspectj</groupId>
 	<artifactId>aspectj-parent</artifactId>
-	<version>1.9.8-SNAPSHOT</version>
+	<version>1.9.8</version>
 	<packaging>pom</packaging>
 
 	<name>AspectJ Parent Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.aspectj</groupId>
 	<artifactId>aspectj-parent</artifactId>
-	<version>1.9.8</version>
+	<version>1.9.9-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>AspectJ Parent Project</name>

--- a/run-all-junit-tests/pom.xml
+++ b/run-all-junit-tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>run-all-junit-tests</artifactId>

--- a/run-all-junit-tests/pom.xml
+++ b/run-all-junit-tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>run-all-junit-tests</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>runtime</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>runtime</artifactId>

--- a/taskdefs/pom.xml
+++ b/taskdefs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>taskdefs</artifactId>

--- a/taskdefs/pom.xml
+++ b/taskdefs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>taskdefs</artifactId>

--- a/testing-client/pom.xml
+++ b/testing-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing-client</artifactId>

--- a/testing-client/pom.xml
+++ b/testing-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>testing-client</artifactId>

--- a/testing-drivers/pom.xml
+++ b/testing-drivers/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing-drivers</artifactId>

--- a/testing-drivers/pom.xml
+++ b/testing-drivers/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>testing-drivers</artifactId>

--- a/testing-util/pom.xml
+++ b/testing-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>testing-util</artifactId>

--- a/testing-util/pom.xml
+++ b/testing-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing-util</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8-SNAPSHOT</version>
+		<version>1.9.8</version>
 	</parent>
 
 	<artifactId>tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.aspectj</groupId>
 		<artifactId>aspectj-parent</artifactId>
-		<version>1.9.8</version>
+		<version>1.9.9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tests</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>util</artifactId>

--- a/weaver/pom.xml
+++ b/weaver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>weaver</artifactId>

--- a/weaver/pom.xml
+++ b/weaver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.aspectj</groupId>
     <artifactId>aspectj-parent</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
   </parent>
 
   <artifactId>weaver</artifactId>


### PR DESCRIPTION
This PR has evolved into a release PR, because in the same branch I just added the commits which led to release 1.9.8. After merging this, we will have a 1.9.9-SNAPSHOT development version.

Besides, I am not sure you tagged my previous releases. @aclement, maybe you want to add and push the tags which are not in the upstream repo yet:

```none
$ git tag --list 'V1_9_[678]*' --format "%(objectname) %(refname:short)"

3d7bc042885bb01697fbd5004fe36cf6c274cfea V1_9_6
a22efad2542a2252c8803d0083b80855826b97a7 V1_9_7
08c6b70963e778bf2d12f063b833a2f544b9d37c V1_9_7_M2
9721f936bd8c7b8e95c100d7b2d0261950f8a80c V1_9_7_M3
c8da9556e21be5b919c3f74d868202d7e564e17c V1_9_8
4b2be42d2e9d1c979803f6e2d9a0a1673bc285d6 V1_9_8_M1
7eeb27c73003bff73ccf4829310097a540926f98 V1_9_8_RC1
5d4f2c2a6b5df574360e5c5fac6ce6a5cbea833f V1_9_8_RC2
d2588d086ff61d65cd90a376732ae1b9b4d646dd V1_9_8_RC3

$ git tag --list 'V1_9_[678]*' | xargs -n 1 git log --oneline -1

3d7bc0428 (tag: V1_9_6) AspectJ 1.9.6 final bits
a22efad25 (tag: V1_9_7) 1.9.7 release
08c6b7096 (tag: V1_9_7_M2) Set version to 1.9.7.M2
9721f936b (tag: V1_9_7_M3) Set version to 1.9.7.M3
c8da9556e (tag: V1_9_8) Set version to 1.9.8
4b2be42d2 (tag: V1_9_8_M1) Set version to 1.9.8.M1
7eeb27c73 (tag: V1_9_8_RC1) Release version to 1.9.8.RC1
5d4f2c2a6 (tag: V1_9_8_RC2) Set version to 1.9.8.RC2
d2588d086 (tag: V1_9_8_RC3) Set version to 1.9.8.RC3
```

---

***Old subject and PR description:***

### IDE.md points to AJDT Eclipse update sites

Because the Jenkins builds for Eclipse now exist and deploy to the correct update sites, we no longer need the AspectJ.dev ones.