### PR TITLE
Cleanup redundant type casts, due to too weak variable type declaration

### DIFF
--- a/ajde/src/main/java/org/aspectj/ajde/internal/LstBuildConfigManager.java
+++ b/ajde/src/main/java/org/aspectj/ajde/internal/LstBuildConfigManager.java
@@ -276,8 +276,8 @@ public class LstBuildConfigManager implements BuildConfigManager {
 	}
 
 	private void notifyConfigChanged() {
-		for (Object element : listeners) {
-			((BuildConfigListener) element).currConfigChanged(currConfigFilePath);
+		for (BuildConfigListener element : listeners) {
+			element.currConfigChanged(currConfigFilePath);
 		}
 	}
 

--- a/ajde/src/main/java/org/aspectj/ajde/ui/BuildConfigModel.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/BuildConfigModel.java
@@ -112,8 +112,8 @@ public class BuildConfigModel {
 		}
 
 		if (node != null && node.getChildren() != null) {
-			for (Object element : node.getChildren()) {
-				BuildConfigNode foundNode = findNodeForSourceLineHelper((BuildConfigNode) element, sourceFilePath, lineNumber);
+			for (BuildConfigNode element : node.getChildren()) {
+				BuildConfigNode foundNode = findNodeForSourceLineHelper(element, sourceFilePath, lineNumber);
 				if (foundNode != null)
 					return foundNode;
 			}

--- a/ajde/src/main/java/org/aspectj/ajde/ui/internal/TreeStructureViewBuilder.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/internal/TreeStructureViewBuilder.java
@@ -125,8 +125,7 @@ public class TreeStructureViewBuilder {
 			}
 		}
 		if (node.getChildren() != null) {
-			for (Object element : node.getChildren()) {
-				IProgramElement IProgramElement = (IProgramElement)element;
+			for (IProgramElement IProgramElement : node.getChildren()) {
 				if (acceptNode(IProgramElement, properties)) {
 					children.add(createViewNode(IProgramElement, properties));
 				}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/EmacsStructureModelManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/EmacsStructureModelManager.java
@@ -95,11 +95,10 @@ public class EmacsStructureModelManager {
 
 		private void printDecls(IProgramElement node) {
 			print("(");
-			for (Object nodeObject : node.getChildren()) {
+			for (IProgramElement child : node.getChildren()) {
 				// this ignores relations on the compile unit
 				// throw new RuntimeException("unimplemented");
 				// if (nodeObject instanceof IProgramElement) {
-				IProgramElement child = (IProgramElement) nodeObject;
 				printDecl(child, true);
 				// }
 				// else if (nodeObject instanceof LinkNode) {
@@ -179,13 +178,10 @@ public class EmacsStructureModelManager {
 				if (it3.hasNext()) {
 					while (it3.hasNext()) {
 						// this ignores relations on the compile unit
-						Object nodeObject = it3.next();
-						if (nodeObject instanceof IProgramElement) {
-							IProgramElement currNode = (IProgramElement) nodeObject;
-							if (// !currNode.isStmntKind() &&
-							!currNode.getKind().equals("<undefined>")) {
-								printDecl(currNode, true);
-							}
+						IProgramElement currNode = it3.next();
+						if (// !currNode.isStmntKind() &&
+						!currNode.getKind().equals("<undefined>")) {
+							printDecl(currNode, true);
 						}
 					}
 				}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTConverter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjASTConverter.java
@@ -658,10 +658,10 @@ public class AjASTConverter extends ASTConverter {
 		} else if (declare instanceof DeclareParents) {
 			DeclareParents dp = (DeclareParents) declare;
 			declareDeclaration = new org.aspectj.org.eclipse.jdt.core.dom.DeclareParentsDeclaration(this.ast, dp.isExtends());
-			org.aspectj.org.eclipse.jdt.core.dom.PatternNode pNode = convert(dp.getChild());
+			AbstractTypePattern pNode = convert(dp.getChild());
 			if (pNode instanceof AbstractTypePattern) {
 				((DeclareParentsDeclaration) declareDeclaration)
-						.setChildTypePattern((AbstractTypePattern) pNode);
+						.setChildTypePattern(pNode);
 			}
 			TypePattern[] weaverTypePatterns = dp.getParents().getTypePatterns();
 			List typePatterns = ((DeclareParentsDeclaration) declareDeclaration).parentTypePatterns();
@@ -680,10 +680,10 @@ public class AjASTConverter extends ASTConverter {
 			declareDeclaration = new DeclareSoftDeclaration(this.ast);
 			DeclareSoft ds = (DeclareSoft) declare;
 			((DeclareSoftDeclaration) declareDeclaration).setPointcut(convert(ds.getPointcut()));
-			org.aspectj.org.eclipse.jdt.core.dom.PatternNode pNode = convert(ds.getException());
+			AbstractTypePattern pNode = convert(ds.getException());
 			if (pNode instanceof AbstractTypePattern) {
 				((DeclareSoftDeclaration) declareDeclaration)
-						.setTypePattern((AbstractTypePattern) pNode);
+						.setTypePattern(pNode);
 			}
 		}
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembers.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembers.java
@@ -343,25 +343,15 @@ public class CrosscuttingMembers {
 		Set<Object> theseTypeMungers = new HashSet<>();
 		Set<Object> otherTypeMungers = new HashSet<>();
 		if (!careAboutShadowMungers) {
-			for (Object o : typeMungers) {
-				if (o instanceof ConcreteTypeMunger) {
-					ConcreteTypeMunger typeMunger = (ConcreteTypeMunger) o;
-					if (!typeMunger.existsToSupportShadowMunging()) {
-						theseTypeMungers.add(typeMunger);
-					}
-				} else {
-					theseTypeMungers.add(o);
+			for (ConcreteTypeMunger typeMunger : typeMungers) {
+				if (!typeMunger.existsToSupportShadowMunging()) {
+					theseTypeMungers.add(typeMunger);
 				}
 			}
 
-			for (Object o : other.typeMungers) {
-				if (o instanceof ConcreteTypeMunger) {
-					ConcreteTypeMunger typeMunger = (ConcreteTypeMunger) o;
-					if (!typeMunger.existsToSupportShadowMunging()) {
-						otherTypeMungers.add(typeMunger);
-					}
-				} else {
-					otherTypeMungers.add(o);
+			for (ConcreteTypeMunger typeMunger : other.typeMungers) {
+				if (!typeMunger.existsToSupportShadowMunging()) {
+					otherTypeMungers.add(typeMunger);
 				}
 			}
 		} else {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPointcut.java
@@ -140,8 +140,7 @@ public class AnnotationPointcut extends NameBindingPointcut {
 				if (kind == Shadow.FieldGet || kind == Shadow.FieldSet) {
 					// FIXME asc should include supers with getInterTypeMungersIncludingSupers ?
 					List<ConcreteTypeMunger> mungers = rMember.getDeclaringType().resolve(shadow.getIWorld()).getInterTypeMungers();
-					for (Object munger : mungers) {
-						ConcreteTypeMunger typeMunger = (ConcreteTypeMunger) munger;
+					for (ConcreteTypeMunger typeMunger : mungers) {
 						if (typeMunger.getMunger() instanceof NewFieldTypeMunger) {
 							ResolvedMember fakerm = typeMunger.getSignature();
 							if (fakerm.equals(member)) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutParser.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/tools/StandardPointcutParser.java
@@ -148,8 +148,7 @@ public class StandardPointcutParser {
 	 */
 	private StandardPointcutParser(Set<PointcutPrimitive> supportedPointcutKinds, World world) {
 		supportedPrimitives = supportedPointcutKinds;
-		for (Object supportedPointcutKind : supportedPointcutKinds) {
-			PointcutPrimitive element = (PointcutPrimitive) supportedPointcutKind;
+		for (PointcutPrimitive element : supportedPointcutKinds) {
 			if ((element == PointcutPrimitive.IF) || (element == PointcutPrimitive.CFLOW)
 					|| (element == PointcutPrimitive.CFLOW_BELOW)) {
 				throw new UnsupportedOperationException("Cannot handle if, cflow, and cflowbelow primitives");

--- a/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadCounterImpl11.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadCounterImpl11.java
@@ -48,8 +48,7 @@ public class ThreadCounterImpl11 implements ThreadCounter {
 					Thread t = (Thread)e.nextElement();
 					if (!t.isAlive()) dead_stacks.add(t);
 				}
-				for (Object dead_stack : dead_stacks) {
-					Thread t = (Thread) dead_stack;
+				for (Thread t : dead_stacks) {
 					counters.remove(t);
 				}
 				change_count = 0;

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajc2.java
@@ -414,8 +414,8 @@ public class Ajc2 extends Javac {
         List<File> newIncludes = new ArrayList<>();
         List<String> newArguments = new ArrayList<>();
         if (argfiles != null) {
-			for (Object o : argfiles) {
-				File argfile = ((Argfile) o).getFile();
+			for (Argfile o : argfiles) {
+				File argfile = o.getFile();
 				expandArgfile(argfile, newIncludes, newArguments);
 			}
         }
@@ -442,8 +442,8 @@ public class Ajc2 extends Javac {
         }
 
         // Add the new included files
-		for (Object newInclude : newIncludes) {
-			newFiles.add((File) newInclude);
+		for (File newInclude : newIncludes) {
+			newFiles.add(newInclude);
 		}
 
         // This is the same behavior found in Javac

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -1570,8 +1570,7 @@ public class AjcTask extends MatchingTask {
 			}
 		}
 		if (0 < adapterFiles.size()) {
-            for (Object adapterFile : adapterFiles) {
-                File file = (File) adapterFile;
+            for (File file : adapterFiles) {
                 if (file.canRead() && FileUtil.hasSourceSuffix(file)) {
                     list.add(file.getAbsolutePath());
                 }

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelShadow.java
@@ -1510,8 +1510,7 @@ public class BcelShadow extends Shadow {
 		if (foundMember == null) {
 			// check the ITD'd dooberries
 			List<ConcreteTypeMunger> mungers = relevantType.resolve(world).getInterTypeMungers();
-			for (Object munger : mungers) {
-				ConcreteTypeMunger typeMunger = (ConcreteTypeMunger) munger;
+			for (ConcreteTypeMunger typeMunger : mungers) {
 				if (typeMunger.getMunger() instanceof NewMethodTypeMunger
 						|| typeMunger.getMunger() instanceof NewConstructorTypeMunger) {
 					ResolvedMember fakerm = typeMunger.getSignature();

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWeaver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWeaver.java
@@ -1257,8 +1257,7 @@ public class BcelWeaver {
 			List<ShadowMunger> l = world.getCrosscuttingMembersSet().getShadowMungers();
 			Set<AdviceLocation> alreadyWarnedLocations = new HashSet<>();
 
-			for (Object o : l) {
-				ShadowMunger element = (ShadowMunger) o;
+			for (ShadowMunger element : l) {
 				// This will stop us incorrectly reporting deow checkers:
 				if (element instanceof BcelAdvice) {
 					BcelAdvice ba = (BcelAdvice) element;

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
@@ -165,9 +165,8 @@ public final class LazyClassGen {
 	}
 
 	void addInlinedSourceFileInfo(String fullpath, int highestLineNumber) {
-		Object o = inlinedFiles.get(fullpath);
-		if (o != null) {
-			InlinedSourceFileInfo info = (InlinedSourceFileInfo) o;
+		InlinedSourceFileInfo info = inlinedFiles.get(fullpath);
+		if (info != null) {
 			if (info.highestLineNumber < highestLineNumber) {
 				info.highestLineNumber = highestLineNumber;
 			}

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/SimpleAOPParser.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/SimpleAOPParser.java
@@ -254,8 +254,7 @@ public class SimpleAOPParser {
 			throws Exception {
 		sap.startElement(xml.getName(), xml.getAttributes());
 		Iterable<LightXMLParser> childrens = xml.getChildrens();
-		for (Object children : childrens) {
-			LightXMLParser child = (LightXMLParser) children;
+		for (LightXMLParser child : childrens) {
 			traverse(sap, child);
 		}
 		sap.endElement(xml.getName());

--- a/weaver/src/main/java/org/aspectj/weaver/reflect/Java15ReflectionBasedReferenceTypeDelegate.java
+++ b/weaver/src/main/java/org/aspectj/weaver/reflect/Java15ReflectionBasedReferenceTypeDelegate.java
@@ -269,8 +269,7 @@ public class Java15ReflectionBasedReferenceTypeDelegate extends ReflectionBasedR
 				parser = new InternalUseOnlyPointcutParser(classLoaderReference.getClassLoader());
 			}
 			Set<PointcutDesignatorHandler> additionalPointcutHandlers = world.getRegisteredPointcutHandlers();
-			for (Object additionalPointcutHandler : additionalPointcutHandlers) {
-				PointcutDesignatorHandler handler = (PointcutDesignatorHandler) additionalPointcutHandler;
+			for (PointcutDesignatorHandler handler : additionalPointcutHandlers) {
 				parser.registerPointcutDesignatorHandler(handler);
 			}
 

--- a/weaver/src/main/java/org/aspectj/weaver/tools/WeavingAdaptor.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/WeavingAdaptor.java
@@ -568,8 +568,7 @@ public class WeavingAdaptor implements IMessageContext {
 
 	private void registerAspectLibraries(List<String> aspectPath) {
 		// System.err.println("? WeavingAdaptor.registerAspectLibraries(" + aspectPath + ")");
-		for (Object o : aspectPath) {
-			String libName = (String) o;
+		for (String libName : aspectPath) {
 			addAspectLibrary(libName);
 		}
 


### PR DESCRIPTION
There are several redundant casts, caused by fact, that related declared variable has too weak type.
They are detected by IntelliJ IDEA inspection 'Too weak variable type leads to unnecessary cast'.