### PR TITLE
Fix JDK-version-dependent test JVM arguments in POM

### DIFF
--- a/docs/developer/BUILD.md
+++ b/docs/developer/BUILD.md
@@ -110,11 +110,15 @@ Other existing profiles, which developers are less likely to actively use becaus
     profile is inactive by default, because in the context of a Maven build it would cause all tests to be run twice
     (during module build and again when running the big suite), hence the profile name.
 
-  * `jdk-8-to-15` - Activated automatically on JDKs 8-15, setting property `jvm.arg.addOpens` to an empty value, because
-    it is only needed on JDK 16+, see next bullet point.
+  * `jdk-8-to-15` - Activated automatically on JDKs 8-15, setting properties `jvm.arg.addOpens` and
+    `jvm.arg.allowSecurityManager` to empty values, because they are only needed on JDK 16+ or 18+, respectively. See
+    next bullet point.
 
   * `jdk-16-to-xx` - Activated automatically on JDKs 16+, setting property `jvm.arg.addOpens` to value
     `--add-opens java.base/java.lang=ALL-UNNAMED`, which is needed in order to run LTW tests.
+
+  * `jdk-18-to-xx` - Activated automatically on JDKs 18+, setting property `jvm.arg.allowSecurityManager` to value
+    `-Djava.security.manager=allow`, which is needed by some tests in order to override `System.exit`.
 
 ### Build properties
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
 			</activation>
 			<properties>
 				<jvm.arg.addOpens/>
+				<jvm.arg.allowSecurityManager/>
 			</properties>
 		</profile>
 		<profile>
@@ -205,6 +206,7 @@
 			</activation>
 			<properties>
 				<jvm.arg.addOpens>--add-opens java.base/java.lang=ALL-UNNAMED</jvm.arg.addOpens>
+				<jvm.arg.allowSecurityManager/>
 			</properties>
 		</profile>
 		<profile>
@@ -218,7 +220,7 @@
 					As of Java 18, the new API for blocking System.exit is not available yet, see
 					https://bugs.openjdk.java.net/browse/JDK-8199704.
 				-->
-				<jvm.arg.addOpens>-Djava.security.manager=allow</jvm.arg.addOpens>
+				<jvm.arg.allowSecurityManager>-Djava.security.manager=allow</jvm.arg.allowSecurityManager>
 			</properties>
 		</profile>
 		<profile>
@@ -268,7 +270,10 @@
 					<version>2.22.2</version>
 					<configuration>
 						<!--<testFailureIgnore>true</testFailureIgnore>-->
-						<argLine>${jvm.arg.addOpens}</argLine>
+						<argLine>
+							${jvm.arg.addOpens}
+							${jvm.arg.allowSecurityManager}
+						</argLine>
 						<excludes>
 							<exclude>**/*ModuleTests.java</exclude>
 						</excludes>

--- a/run-all-junit-tests/pom.xml
+++ b/run-all-junit-tests/pom.xml
@@ -198,7 +198,10 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<configuration>
 							<testFailureIgnore>true</testFailureIgnore>
-							<argLine>${jvm.arg.addOpens}</argLine>
+							<argLine>
+								${jvm.arg.addOpens}
+								${jvm.arg.allowSecurityManager}
+							</argLine>
 						</configuration>
 						<executions>
 							<execution>
@@ -253,4 +256,3 @@
 	</build>
 
 </project>
-

--- a/testing-drivers/pom.xml
+++ b/testing-drivers/pom.xml
@@ -55,7 +55,10 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <testFailureIgnore>false</testFailureIgnore>
-          <argLine>${jvm.arg.addOpens}</argLine>
+          <argLine>
+            ${jvm.arg.addOpens}
+            ${jvm.arg.allowSecurityManager}
+          </argLine>
           <excludes>
             <exclude>**/*AjcTestSpecAsTest*</exclude>
           </excludes>

--- a/testing/src/test/java/org/aspectj/testing/RunSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/RunSpec.java
@@ -22,7 +22,7 @@ import java.util.StringTokenizer;
 import org.aspectj.tools.ajc.AjcTestCase;
 import org.aspectj.util.FileUtil;
 
-import static org.aspectj.util.LangUtil.is9VMOrGreater;
+import static org.aspectj.util.LangUtil.is16VMOrGreater;
 
 /**
  * @author Adrian Colyer
@@ -75,7 +75,7 @@ public class RunSpec implements ITestStep {
 			// The reason for setting this parameter for Java 9+ instead of 16+ is that it helps to avoid the JVM printing
 			// unwanted illegal access warnings during weaving in 'useFullLTW' mode, either making existing tests fail or
 			// having to assert on the warning messages.
-			vmargs += is9VMOrGreater() ? " --add-opens java.base/java.lang=ALL-UNNAMED" : "";
+			vmargs += is16VMOrGreater() ? " --add-opens java.base/java.lang=ALL-UNNAMED" : "";
 
 			AjcTestCase.RunResult rr = inTestCase.run(getClassToRun(), getModuleToRun(), args, vmargs, getClasspath(), getModulepath(), useLtw, "true".equalsIgnoreCase(usefullltw));
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -122,7 +122,10 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration combine.self="override">
 						<testFailureIgnore>false</testFailureIgnore>
-						<argLine>${jvm.arg.addOpens}</argLine>
+						<argLine>
+							${jvm.arg.addOpens}
+							${jvm.arg.allowSecurityManager}
+						</argLine>
 						<includes>
 							<include>**/TestsModuleTests*</include>
 						</includes>

--- a/tests/src/test/java/org/aspectj/systemtest/ajc150/ataspectj/AtAjLTWTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc150/ataspectj/AtAjLTWTests.java
@@ -121,12 +121,11 @@ public class AtAjLTWTests extends XMLBasedAjcTestCase {
 	public void testLTWDumpClosure() {
 		runTest("LTW DumpTest closure");
 
-		// Test runs with 'usefullltw="true"' -> dump files are created in the sandbox directory
-		File f = new File(ajc.getSandboxDirectory() + "/_ajdump/ataspectj/DumpTestTheDump$AjcClosure1.class");
+		File f = new File("_ajdump/ataspectj/DumpTestTheDump$AjcClosure1.class");
 		assertTrue("Missing dump file " + f.getAbsolutePath(), f.exists());
 
-		// tidy up... (should not be necessary in sandbox directory, but does not hurt)
-		f = new File(ajc.getSandboxDirectory() + "/_ajdump");
+		// tidy up...
+		f = new File("_ajdump");
 		FileUtil.deleteContents(f);
 		f.delete();
 	}

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc150/ajc150.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc150/ajc150.xml
@@ -6174,7 +6174,7 @@
            <line text="RecoveryNotSelf.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
        </stdout>
      </run>
-     <run class="services.account.StockQuoteServiceTest" ltw="aop-notself.xml" usefullltw="true">
+     <run class="services.account.StockQuoteServiceTest" ltw="aop-notself.xml">
        <stdout>
            <line text="RecoveryNotSelf.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
        </stdout>
@@ -6184,7 +6184,7 @@
    <ajc-test dir="bugs150/pr119657" title="IllegalAccessError with around advice on interface method call using -XterminateAfterCompilation and LTW">
      <compile files="services/account/StockQuoteServiceTest.java, services/accountdata/StockAccount.java, services/stockquote/StockQuoteService.java, services/stockquote/StockQuoteServiceImpl.java, services/account/AccountReport.java" options="-1.5"/>
      <compile files="accounts/recovery/Recovery.aj" options="-1.5 -XterminateAfterCompilation"/>
-     <run class="services.account.StockQuoteServiceTest" ltw="aop.xml" usefullltw="true">
+     <run class="services.account.StockQuoteServiceTest" ltw="aop.xml">
        <stdout>
            <line text="Recovery.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
        </stdout>
@@ -6194,7 +6194,7 @@
    <ajc-test dir="bugs150/pr119657" title="IllegalAccessError with around advice on interface method call using LTW">
      <compile files="services/account/StockQuoteServiceTest.java, services/accountdata/StockAccount.java, services/stockquote/StockQuoteService.java, services/stockquote/StockQuoteServiceImpl.java, services/account/AccountReport.java" options="-1.5"/>
      <compile files="accounts/recovery/Recovery.aj" options="-1.5"/>
-     <run class="services.account.StockQuoteServiceTest" ltw="aop.xml" usefullltw="true">
+     <run class="services.account.StockQuoteServiceTest" ltw="aop.xml">
        <stdout>
            <line text="Recovery.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
        </stdout>
@@ -6204,7 +6204,7 @@
    <ajc-test dir="bugs150/pr119657" title="IllegalAccessError with around advice on interface method call not self using LTW">
      <compile files="services/account/StockQuoteServiceTest.java, services/accountdata/StockAccount.java, services/stockquote/StockQuoteService.java, services/stockquote/StockQuoteServiceImpl.java, services/account/AccountReport.java" options="-1.5"/>
      <compile files="accounts/recovery/RecoveryNotSelf.aj" options="-1.4"/>
-     <run class="services.account.StockQuoteServiceTest" ltw="aop-notself.xml" usefullltw="true">
+     <run class="services.account.StockQuoteServiceTest" ltw="aop-notself.xml">
        <stdout>
            <line text="RecoveryNotSelf.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
        </stdout>
@@ -6214,7 +6214,7 @@
    <ajc-test dir="bugs150/pr119657" title="IllegalAccessError with around advice on interface method call self and not self using LTW">
      <compile files="services/account/StockQuoteServiceTest.java, services/accountdata/StockAccount.java, services/stockquote/StockQuoteService.java, services/stockquote/StockQuoteServiceImpl.java, services/account/AccountReport.java" options="-1.5"/>
      <compile files="accounts/recovery/Recovery.aj, accounts/recovery/RecoveryNotSelf.aj" options="-1.5"/>
-     <run class="services.account.StockQuoteServiceTest" ltw="aop-selfandnotself.xml" usefullltw="true">
+     <run class="services.account.StockQuoteServiceTest" ltw="aop-selfandnotself.xml">
        <stdout>
            <line text="Recovery.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
            <line text="RecoveryNotSelf.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
@@ -6225,7 +6225,7 @@
    <ajc-test dir="bugs150/pr119657" title="IllegalAccessError with around advice on interface method call using LTW and -XnoInline">
      <compile files="services/account/StockQuoteServiceTest.java, services/accountdata/StockAccount.java, services/stockquote/StockQuoteService.java, services/stockquote/StockQuoteServiceImpl.java, services/account/AccountReport.java" options="-1.5"/>
      <compile files="accounts/recovery/Recovery.aj" options="-1.5"/>
-     <run class="services.account.StockQuoteServiceTest" ltw="aop-noinline.xml" usefullltw="true">
+     <run class="services.account.StockQuoteServiceTest" ltw="aop-noinline.xml">
        <stdout>
            <line text="Recovery.around() call(float services.stockquote.StockQuoteService.getQuote(String))"/>
        </stdout>
@@ -6235,7 +6235,7 @@
    <ajc-test dir="bugs150/pr121385" title="override protected pointcut in aop.xml concrete aspect">
      <compile files="Hello.java" options="-1.5"/>
      <compile files="World.aj, ConcreteWorld.aj" options="-1.4"/>
-     <run class="Hello" ltw="aop.xml" usefullltw="true">
+     <run class="Hello" ltw="aop.xml">
        <stdout>
            <line text="around start!"/>
            <line text="Hello"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc150/ataspectj/ltw.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc150/ataspectj/ltw.xml
@@ -95,7 +95,7 @@
                 options="-1.5"/>
         <run class="ataspectj.DumpTest" ltw="ataspectj/aop-dump.xml"/>
     </ajc-test>
-
+    
     <ajc-test dir="java5/ataspectj" title="LTW DumpTest before and after">
         <compile
                 files="ataspectj/EmptyAspect.aj"
@@ -123,7 +123,7 @@
         <compile
                 files="ataspectj/DumpTest.java,ataspectj/DumpTestTheDump.java,ataspectj/TestAroundAspect.aj"
                 options="-1.5"/>
-        <run class="ataspectj.DumpTest" ltw="ataspectj/aop-dumpclosure.xml" usefullltw="true"/>
+        <run class="ataspectj.DumpTest" ltw="ataspectj/aop-dumpclosure.xml"/>
     </ajc-test>
 
     <ajc-test dir="java5/ataspectj" title="LTW DumpTest proxy">
@@ -163,7 +163,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>
+        </compile>	
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-silent.xml">
         	<stdout>
  				<line text="execution(Main.target())"/>
@@ -182,7 +182,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>
+        </compile>	
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-verbose.xml">
         	<stdout>
  				<line text="execution(Main.target())"/>
@@ -207,7 +207,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>
+        </compile>	
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-verboseandshow.xml">
         	<stdout>
  				<line text="execution(Main.target())"/>
@@ -233,7 +233,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>
+        </compile>	
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-messagehandler.xml">
         	<stdout>
 				<line text="MessageHolder.MessageHolder()"/>
@@ -290,7 +290,7 @@
             files="ataspectj/ConcreteAtAspectTest.java,ataspectj/TestHelper.java"
             options="-1.5 -XterminateAfterCompilation"
             />
-        <run class="ataspectj.ConcreteAtAspectTest" ltw="ataspectj/aop-concreteataspect.xml" usefullltw="true"/>
+        <run class="ataspectj.ConcreteAtAspectTest" ltw="ataspectj/aop-concreteataspect.xml"/>
     </ajc-test>
 
     <ajc-test dir="java5/ataspectj" title="ConcreteAspect">
@@ -298,7 +298,7 @@
             files="ataspectj/ConcreteAspectTest.aj,ataspectj/TestHelper.java"
             options="-1.5 -Xdev:NoAtAspectJProcessing -XterminateAfterCompilation"
             />
-        <run class="ataspectj.ConcreteAspectTest" ltw="ataspectj/aop-concreteaspect.xml" usefullltw="true"/>
+        <run class="ataspectj.ConcreteAspectTest" ltw="ataspectj/aop-concreteaspect.xml"/>
     </ajc-test>
 
     <ajc-test dir="java5/ataspectj" title="ConcretePrecedenceAspect">
@@ -306,7 +306,7 @@
             files="ataspectj/ConcretePrecedenceAspectTest.java,ataspectj/TestHelper.java"
             options="-1.5 -Xdev:NoAtAspectJProcessing -XterminateAfterCompilation"
             />
-        <run class="ataspectj.ConcretePrecedenceAspectTest" ltw="ataspectj/aop-concreteprecedenceaspect.xml" usefullltw="true"/>
+        <run class="ataspectj.ConcretePrecedenceAspectTest" ltw="ataspectj/aop-concreteprecedenceaspect.xml"/>
     </ajc-test>
 
     <ajc-test dir="java5/ataspectj" title="AspectOfWhenAspectNotInInclude">

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc150/ltw/ltw.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc150/ltw/ltw.xml
@@ -215,7 +215,7 @@
 	<compile files="AbstractSuperAspect.aj" outjar="aspect.jar"
 		options="-1.4">
 	</compile>
-	<run class="Main" ltw="aop-defineaspect.xml" usefullltw="true">
+	<run class="Main" ltw="aop-defineaspect.xml">
 		<stdout>
 			<line text="Main.main" />
 			<line text="Main.test1" />

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc150/ltw/ltw.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc150/ltw/ltw.xml
@@ -221,7 +221,7 @@
 			<line text="Main.test1" />
 			<line text="Main.test2" />
 		</stdout>
-		<stderr ordered="no">
+		<stderr>
 			<line text="info AspectJ Weaver Version" />
 			<line text="info register classloader" />
 			<line text="info using" />
@@ -229,33 +229,6 @@
 			<line text="debug weaving 'ConcreteAspect'" />
 			<line text="debug generating class 'ConcreteAspect'" />
 			<line text="debug weaving 'Main'" />
-
-			<!-- In full LTW mode with weaver option '-debug' in aop.xml, the weaver prints this -->
-			<line text="debug cannot weave 'org.aspectj.lang.Signature'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.Factory'" />
-			<line text="debug cannot weave 'org.aspectj.lang.JoinPoint$StaticPart'" />
-			<line text="debug cannot weave 'org.aspectj.lang.JoinPoint$EnclosingStaticPart'" />
-			<line text="debug cannot weave 'org.aspectj.lang.JoinPoint'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.MethodSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.CodeSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.MemberSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.ConstructorSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.FieldSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.AdviceSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.CatchClauseSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.LockSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.UnlockSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.InitializerSignature'" />
-			<line text="debug cannot weave 'org.aspectj.lang.reflect.SourceLocation'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.MethodSignatureImpl'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.CodeSignatureImpl'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.MemberSignatureImpl'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.SignatureImpl'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.SignatureImpl$Cache'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.JoinPointImpl$StaticPartImpl'" />
-			<line text="debug cannot weave 'org.aspectj.runtime.reflect.SourceLocationImpl'" />
-			<line text="debug cannot weave 'org.aspectj.lang.NoAspectBoundException'" />
-
 			<line text="AbstractSuperAspect.before_test1" />
 		</stderr>
 	</run>
@@ -271,7 +244,7 @@
 			text="this affected type is not exposed to the weaver: TestITDMethod" />
 	</compile>
 	<run class="TestITDMethod" options="test"
-		ltw="aop-abstractaspect.xml" usefullltw="true">
+		ltw="aop-abstractaspect.xml">
 		<stdout>
 			<line text="TestITDMethod.main" />
 		</stdout>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc151/ajc151.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc151/ajc151.xml
@@ -4,7 +4,7 @@
 <suite>
 
     <!-- atDecp begin -->
-
+   
     <!-- something simple -->
     <ajc-test dir="bugs151/atDecp/case1" title="atDecp - simple">
       <compile files="MainClass.java" options="-1.5 -showWeaveInfo">
@@ -20,7 +20,7 @@
          </stderr>
       </run>
     </ajc-test>
-
+    
     <!-- applying parent based on annotation -->
     <ajc-test dir="bugs151/atDecp/case2" title="atDecp - annotation">
       <compile files="MainClass.java" options="-1.5 -showWeaveInfo">
@@ -36,7 +36,7 @@
          </stderr>
       </run>
     </ajc-test>
-
+    
     <!-- when interface is binary -->
     <ajc-test dir="bugs151/atDecp/case3" title="atDecp - binary interface">
       <compile files="Mood.java,Moody.java" outjar="moody.jar" options="-1.5"/>
@@ -53,7 +53,7 @@
          </stderr>
       </run>
     </ajc-test>
-
+    
     <!-- when interface is binary and implementation is not an inner  -->
     <ajc-test dir="bugs151/atDecp/case4" title="atDecp - binary interface - 2">
       <compile files="Mood.java,Moody.java" outjar="moody.jar" options="-1.5"/>
@@ -70,7 +70,7 @@
          </stderr>
       </run>
     </ajc-test>
-
+    
     <!-- atDecp end -->
 
 
@@ -99,7 +99,7 @@
        </stderr>
      </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr98901" title="annotations and itds - 2">
      <compile files="Failing2.java" options="-1.5"/>
      <run class="Failing2">
@@ -120,23 +120,23 @@
      <compile files="InputAnnotation.java" outjar="foo.jar" options="-1.5"/>
      <compile files="AffectedType.java" classpath="foo.jar" options="-1.5"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr132926" pr="132926" title="crashing on annotation type resolving with asm - 3">
      <compile files="InputAnnotation2.java" outjar="foo.jar" options="-1.5"/>
      <compile files="AffectedType.java" classpath="foo.jar" options="-1.5">
      	<message kind="error" line="9" text="AffectedType is not a valid target for annotation InputAnnotation, this annotation can only be applied to these element types {METHOD}"/>
      </compile>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr133307" title="circular generics">
       <compile files="Broken.aj" options="-1.5"/>
-    </ajc-test>
-
+    </ajc-test>  
+    
     <ajc-test dir="bugs151/pr123553" title="generic advice parameters">
         <compile files="A.java" options="-1.5"/>
         <run class="A"/>
-    </ajc-test>
-
+    </ajc-test>  
+    
     <ajc-test dir="bugs151/pr133298" title="doubly annotating a method with declare">
       <compile files="DecA.java" options="-1.5"/>
       <run class="DecA">
@@ -153,7 +153,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr133298" title="doubly annotating a method with declare - 2">
       <compile files="DecA2.java" options="-1.5"/>
       <run class="DecA2">
@@ -167,19 +167,19 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
      <ajc-test dir="bugs151/pr129566" title="arrayindexoutofbounds">
         <compile files="SkipList.java" options="-1.5"/>
-    </ajc-test>
-
+    </ajc-test>  
+    
     <ajc-test dir="bugs151" title="member types in generic types">
         <compile files="pr122458.aj" options="-1.5 -emacssym"/>
-    </ajc-test>
-
+    </ajc-test>  
+    
     <ajc-test dir="bugs151/pr127299" title="missing import gives funny message">
         <compile files="ModelErrorConversion.aj" options="-1.5"/>
     </ajc-test>
-
+      
     <ajc-test dir="bugs151/pr122742" title="@AJ VerifyError with @AfterThrowing and thisJoinPoint argument">
     	<compile files="AfterThrowingTest.java" options="-1.5"/>
     	<run class="AfterThrowingTest">
@@ -191,32 +191,32 @@
     	<run class="AfterReturningTest">
     	</run>
     </ajc-test>
-
+   
     <ajc-test dir="bugs151/pr120527" title="incorrect unused interface message">
         <compile files="Bugs.aj" options="-warn:unusedPrivate"/>
-    </ajc-test>
-
+    </ajc-test>  
+    
     <ajc-test dir="bugs151/pr123901" title="inlinevisitor NPE">
         <compile files="A.java,B.java" options="-1.5">
           <message kind="error" line="5" text="A cannot be resolved or is not a field"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151" title="member types in generic types - 2">
         <compile files="pr122458_2.aj" options="-1.5 -emacssym"/>
         <run class="pr122458_2"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr123695" title="Internal nullptr exception with complex declare annotation">
         <compile files="InjectName.java,Main.java,MarkMyMethods.java,MarkMyMethodsAspect.java,NameAspect.java,Named.java,Read.java,Write.java" options="-1.5"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr124105" title="hasMember problems with packages">
         <compile files="com/test/IOption.java,com/test/IXOption.java,com/test/IYOption.java,com/test/IZOption.java,com/test/MyBrokenXOption.java,com/test/MyXOption.java,com/test/OptionAspect.aj,com/test/OptionType.java" options="-1.5 -XhasMember">
           <message kind="error" line="4" text="IOption implementations must provide a constructor which accepts an OptionType"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr124803" title="generics and different numbers of type variables">
         <compile files="Test.java,TestAspect.java" options="-1.5 -showWeaveInfo">
           <message kind="weave" text="Join point 'method-execution(void Test.foo(java.lang.Number))' in Type 'Test' (Test.java:12) advised by after advice from 'TestAspect' (TestAspect.java:4)"/>
@@ -227,7 +227,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr124803" title="generics and different numbers of type variables - classes">
         <compile files="Test2.java,TestAspect2.java" options="-1.5 -showWeaveInfo">
           <message kind="weave" text="Join point 'method-execution(void Test2.foo(java.lang.Number))' in Type 'Test2' (Test2.java:12) advised by after advice from 'TestAspect2' (TestAspect2.java:4)"/>
@@ -239,7 +239,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr124808" title="parameterized collection fields matched via pointcut">
         <compile files="Test.java,TestAspect.java" options="-1.5"/>
         <run class="Test">
@@ -248,12 +248,12 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151" title="calling inherited generic method from around advice">
         <compile files="pr124999.aj" options="-1.5"/>
         <run class="pr124999"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr124654" title="generic aspects and annotations">
         <compile files="GenericAnnotation.java,TestSubAspect.java" options="-1.5"/>
         <run class="TestSubAspect">
@@ -264,7 +264,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151" title="incorrectly referencing pointcuts">
         <compile files="pr122452.aj" options="-1.5">
           <message kind="warning" line="2" text="no match for this type name: Point [Xlint:invalidAbsoluteTypeName]"/>
@@ -272,18 +272,18 @@
           <message kind="error" line="4" text="Syntax error on token &quot;*&quot;, &quot;(&quot; expected"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151" title="incorrectly referencing pointcuts - 2">
         <compile files="pr122452_2.aj" options="-1.5">
           <message kind="error" line="2" text="Syntax error on token &quot;*&quot;, &quot;(&quot; expected"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr125080" title="mixing numbers of type parameters">
         <compile files="Test.java" options="-1.5"/>
         <run class="ConcreteAspect"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr125080" title="mixing numbers of type parameters - 2">
         <compile files="Test2.java" options="-1.5"/>
         <run class="ConcreteAspect"/>
@@ -292,11 +292,11 @@
     <ajc-test dir="bugs151/pr125295" title="new IProgramElement methods">
         <compile files="pkg/C.java,pkg/A.aj" options="-emacssym"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr125475" title="define empty pointcut using an annotation">
         <compile files="TestEmptyPointcutAtAspect.java" options="-1.5"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr125475" title="define empty pointcut using an annotation - 2">
         <compile files="TestEmptyPointcutAtAspect2.java" options="-1.5 -showWeaveInfo">
           <message kind="warning" line="10" text="advice defined in TestEmptyPointcutAtAspect2 has not been applied [Xlint:adviceDidNotMatch]"/>
@@ -307,17 +307,17 @@
         <compile files="Test.java TestAspect.aj"/>
         <run class="Test" ltw="aop.xml"/>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr128744" title="broken ltw">
         <compile files="Hello.java World.java" options="-1.5" />
-        <run class="Hello" ltw="aop.xml" usefullltw="true">
+        <run class="Hello" ltw="aop.xml">
         	<stdout>
                 <line text="Hello"/>
                 <line text="World"/>
             </stdout>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151/pr125699" title="inherit advice with this() and thisJoinPoint">
         <compile files="Tracing.aj, TestTracing.aj, AtTestTracing.java" options="-1.5">
           <message kind="warning" line="13" text="advice defined in Tracing has not been applied [Xlint:adviceDidNotMatch]"/>
@@ -345,7 +345,7 @@
 
     <ajc-test dir="bugs151" title="E extends Enum(E) again">
         <compile files="Pr126316.aj" options="-1.5"/>
-    </ajc-test>
+    </ajc-test> 
 
     <ajc-test dir="bugs151" title="@AJ without JoinPoint import">
         <compile files="pr121616.java" options="-1.5">
@@ -379,7 +379,7 @@
             </stdout>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="bugs151" title="Pointcut interfaces">
         <compile files="pr130869.aj" options="-1.5">
           <message kind="warning" line="30" text="no directly runnable classes"/>
@@ -390,10 +390,10 @@
         <compile files="pr131933.aj" options="-1.5">
           <message kind="error" line="5" text="can't bind type name 'MyList'"/>
         </compile>
-    </ajc-test>
+    </ajc-test> 
 
     <!-- New features down here... when they arent big enough to have their own test file -->
-
+    
     <ajc-test dir="features151/ptw" title="exposing withintype">
         <compile files="ExposedType.java" options="-1.5"/>
         <run class="ExposedType">
@@ -403,8 +403,8 @@
             <line text="here I am execution(void ExposedTypeThree.foo()): for class ExposedTypeThree"/>
           </stderr>
         </run>
-    </ajc-test>
-
+    </ajc-test>  
+    
     <ajc-test dir="features151/swallowedExceptions" title="swallowed exceptions">
         <compile files="SwallowedException.java" options="-Xlint:warning">
             <message kind="warning" line="11" text="Exception swallowed in catch block"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc152/ajc152.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc152/ajc152.xml
@@ -451,7 +451,7 @@
     <ajc-test dir="bugs152/pr125480" title="aop.xml aspect inheriting abstract method">
         <compile files="HelloWorld.java"/>
         <compile files="AbstractMethods.aj, ConcreteMethods.aj" options="-1.5"/>
-        <run class="HelloWorld" ltw="aop-tracing.xml" usefullltw="true">
+        <run class="HelloWorld" ltw="aop-tracing.xml">
           <stdout>
             <line text="advice running"/>
             <line text="Hello World!"/>
@@ -462,7 +462,7 @@
     <ajc-test dir="bugs152/pr125480/case2" title="aop.xml aspect inheriting abstract method - code style">
         <compile files="HelloWorld.java"/>
         <compile files="AbstractMethods.aj, ConcreteMethods.aj" options="-1.5"/>
-        <run class="HelloWorld" ltw="aop-tracing.xml" usefullltw="true">
+        <run class="HelloWorld" ltw="aop-tracing.xml">
           <stdout>
             <line text="advice running"/>
             <line text="Hello World!"/>
@@ -600,7 +600,7 @@
     <ajc-test dir="bugs152/pr142165" title="broken concretization">
       <compile files="C.java" options="-1.5"/>
       <compile files="A.java" options="-1.5"/>
-      <run class="C" ltw="aop.xml" usefullltw="true">
+      <run class="C" ltw="aop.xml">
         <stderr>
           <line text="warning at Type 'AA' (no debug info available)::0 no match for this type name: SomeType [Xlint:invalidAbsoluteTypeName]"/>
           <line text="foo running"/>
@@ -611,7 +611,7 @@
     <ajc-test dir="bugs152/pr142165" title="broken concretization - 2">
       <compile files="C.java" options="-1.5"/>
       <compile files="A.java" options="-1.5"/>
-      <run class="C" ltw="aop2.xml" usefullltw="true">
+      <run class="C" ltw="aop2.xml">
         <stderr>
            <line text="foo running"/>
         </stderr>
@@ -621,7 +621,7 @@
     <ajc-test dir="bugs152/pr142165" title="broken concretization - 3">
       <compile files="C.java" options="-1.5"/>
       <compile files="A.java" options="-1.5"/>
-      <run class="C" ltw="aop3.xml" usefullltw="true">
+      <run class="C" ltw="aop3.xml">
         <stderr>
            <line text="advice"/>
            <line text="foo running"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc152/synchronization.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc152/synchronization.xml
@@ -2,7 +2,7 @@
 
 <!-- AspectJ v1.5.1 Tests -->
 <suite>
-
+    
     <ajc-test dir="features152/synchronization" title="basic">
         <compile files="Basic.java" options="-1.5 -showWeaveInfo -Xjoinpoints:synchronization">
         </compile>
@@ -15,7 +15,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="basic - within">
         <compile files="Basic2.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -36,7 +36,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="basic - within plus args">
         <compile files="Basic3.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -57,7 +57,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="basic - within plus this">
         <compile files="Basic4.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -78,7 +78,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="basic - within plus target">
         <compile files="Basic5.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -110,19 +110,19 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="parsing - lock">
         <compile files="Parsing1.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="5" text="advice defined in Parsing1 has not been applied [Xlint:adviceDidNotMatch]"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="parsing - unlock">
         <compile files="Parsing2.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="5" text="advice defined in Parsing2 has not been applied [Xlint:adviceDidNotMatch]"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="parsing - error - lock">
         <compile files="Parsing1.java" options="-1.5">
           <message kind="warning" line="5" text="advice defined in Parsing1 has not been applied [Xlint:adviceDidNotMatch]"/>
@@ -130,7 +130,7 @@
           <message kind="warning" line="5" text="lock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="parsing - error - unlock">
         <compile files="Parsing2.java" options="-1.5">
           <message kind="warning" line="5" text="advice defined in Parsing2 has not been applied [Xlint:adviceDidNotMatch]"/>
@@ -138,7 +138,7 @@
           <message kind="warning" line="5" text="unlock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="parsing and matching - lock and static context">
         <compile files="ParsingAndMatching1.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ParsingAndMatching1">
@@ -148,7 +148,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="using lock with LTW - missing flag">
         <compile files="LockAspect1.java" options="-1.5">
           <message kind="warning" line="6" text="lock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
@@ -163,11 +163,11 @@
             </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="transform with LTW">
         <compile files="CaptureLock.aj" options="-1.5"/>
         <compile files="Program.java" options="-1.5"/>
-        <run class="Program" ltw="aop1.xml" usefullltw="true">
+        <run class="Program" ltw="aop1.xml">
         	<stdout>
         	  <line text="Before a lock or unlock"/>
         	  <line text="hello from b()"/>
@@ -184,7 +184,7 @@
             </stdout>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="using lock with LTW">
         <compile files="LockAspect1.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <compile files="BasicProgram1.java" options="-1.5 -Xjoinpoints:synchronization"/>
@@ -199,7 +199,7 @@
             </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="using unlock with LTW">
         <compile files="UnlockAspect1.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <compile files="BasicProgram1.java" options="-1.5 -Xjoinpoints:synchronization"/>
@@ -214,7 +214,7 @@
             </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="using unlock with LTW - missing flag">
         <compile files="UnlockAspect1.java" options="-1.5">
           <message kind="warning" line="6" text="unlock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
@@ -238,7 +238,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="parsing and matching - lock and non-static context">
         <compile files="ParsingAndMatching3.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ParsingAndMatching3">
@@ -258,7 +258,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="a useful program - with lock">
         <compile files="Useful2.java" options="-1.5 -showWeaveInfo -Xjoinpoints:synchronization">
         	<message kind="weave" text="Join point 'method-execution(void Useful2.main(java.lang.String[]))' in Type 'Useful2' (Useful2.java:33) advised by afterReturning advice from 'LockMonitor' (Useful2.java:25)"/>
@@ -272,7 +272,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="combining pcds - lock and this">
         <compile files="CombiningPCDs1.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="CombiningPCDs1">
@@ -283,7 +283,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="combining pcds - unlock and this">
         <compile files="CombiningPCDs2.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="CombiningPCDs2">
@@ -294,7 +294,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="thisjoinpoint - monitor entry">
         <compile files="ThisJoinPointLock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ThisJoinPointLock">
@@ -305,7 +305,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="thisjoinpoint - monitor exit">
         <compile files="ThisJoinPointUnlock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ThisJoinPointUnlock">
@@ -316,7 +316,7 @@
           </stderr>
         </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="prevent double unlock weaving messages and model contents">
         <compile files="ThisJoinPointUnlock.java" options="-1.5 -Xjoinpoints:synchronization -showWeaveInfo -emacssym">
           <message kind="weave" text="Join point 'lock(void java.lang.Object.&lt;lock&gt;(java.lang.Object))' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:38) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
@@ -324,7 +324,7 @@
           <message kind="weave" text="Join point 'unlock(void java.lang.Object.&lt;unlock&gt;(java.lang.Object))' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:38) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
         </compile>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="before advice - lock">
         <compile files="BeforeLock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="BeforeLock">
@@ -336,8 +336,8 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>
-
+    </ajc-test>   
+    
     <ajc-test dir="features152/synchronization" title="before advice - unlock">
         <compile files="BeforeUnlock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="BeforeUnlock">
@@ -349,8 +349,8 @@
             <line text="before() unlock: advice running at BeforeUnlock.java:21"/>
           </stderr>
         </run>
-    </ajc-test>
-
+    </ajc-test>   
+    
     <ajc-test dir="features152/synchronization" title="after advice - lock">
         <compile files="AfterLock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="AfterLock">
@@ -362,8 +362,8 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>
-
+    </ajc-test>   
+    
     <ajc-test dir="features152/synchronization" title="after advice - unlock">
         <compile files="AfterUnlock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="AfterUnlock">
@@ -375,8 +375,8 @@
             <line text="after() unlock: advice running at AfterUnlock.java:21"/>
           </stderr>
         </run>
-    </ajc-test>
-
+    </ajc-test>   
+    
     <ajc-test dir="features152/synchronization" title="around advice - lock">
         <compile files="AroundLock.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="11" text="Around advice is not supported on the lock and unlock join points (compiler limitation)"/>
@@ -395,8 +395,8 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>
-
+    </ajc-test>   
+    
     <ajc-test dir="features152/synchronization" title="around advice - unlock">
         <compile files="AroundUnlock.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="5" text="Around advice is not supported on the lock and unlock join points (compiler limitation)"/>
@@ -415,22 +415,22 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>
-
+    </ajc-test>   
+    
     <ajc-test dir="features152/synchronization/transformed" title="investigation">
       <compile files="Investigation.java">
       </compile>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="One">
       <compile files="One.java -Xjoinpoints:synchronization">
       </compile>
       <run class="One"/><!-- will check verification ... -->
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="Two">
       <compile files="Two.java -Xjoinpoints:synchronization">
-        <message kind="warning" line="14" text="advice matching the synchronized method shadow 'method-execution(void C.ma())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
+        <message kind="warning" line="14" text="advice matching the synchronized method shadow 'method-execution(void C.ma())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>        
       </compile>
       <run class="Two">
         <stderr>
@@ -439,7 +439,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="Two - xlintoff">
       <compile files="Two.java -Xjoinpoints:synchronization -Xlint:ignore"/>
       <run class="Two">
@@ -449,11 +449,11 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="Three">
       <compile files="Three.java -Xjoinpoints:synchronization">
-        <message kind="warning" line="20" text="advice matching the synchronized method shadow 'method-execution(void C.m3())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
-        <message kind="warning" line="24" text="advice matching the synchronized method shadow 'method-execution(void C.m32())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
+        <message kind="warning" line="20" text="advice matching the synchronized method shadow 'method-execution(void C.m3())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>        
+        <message kind="warning" line="24" text="advice matching the synchronized method shadow 'method-execution(void C.m32())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>        
       </compile>
       <run class="Three">
         <stderr>
@@ -468,7 +468,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="Four">
       <compile files="Four.java -Xjoinpoints:synchronization">
          <message kind="warning" line="16" text="advice matching the synchronized method shadow 'method-execution(void C.m())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
@@ -483,7 +483,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="Five - Java5">
       <compile files="Five.java -1.5 -Xjoinpoints:synchronization">
       </compile>
@@ -500,7 +500,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="Six - preJava5">
       <compile files="Six.java -Xjoinpoints:synchronization">
       </compile>
@@ -513,7 +513,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="lock pcd on transformed non-static method">
       <compile files="Seven.java -Xjoinpoints:synchronization">
       </compile>
@@ -537,7 +537,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="lock pcd on transformed static method - J5">
       <compile files="Nine.java -1.5 -Xjoinpoints:synchronization">
       </compile>
@@ -561,7 +561,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="lock pcd on transformed static method - preJ5">
       <compile files="Eleven.java -Xjoinpoints:synchronization">
       </compile>
@@ -585,8 +585,8 @@
         </stderr>
       </run>
     </ajc-test>
-
-
+    
+    
     <ajc-test dir="features152/synchronization/transformed" title="transform static method - preJ5">
       <compile files="Fifteen.java" options="-Xjoinpoints:synchronization -1.4">
       </compile>
@@ -598,8 +598,8 @@
         </stderr>
       </run>
     </ajc-test>
-
-
+    
+    
     <ajc-test dir="features152/synchronization/transformed" title="transform static method - packages - preJ5">
       <compile files="Sixteen.java" options="-Xjoinpoints:synchronization -1.4">
       </compile>
@@ -611,7 +611,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization" title="obtaining locked object through getArgs">
       <compile files="LockingWithTJP.java" options="-Xjoinpoints:synchronization">
       </compile>
@@ -626,7 +626,7 @@
         </stderr>
       </run>
     </ajc-test>
-
+    
     <ajc-test dir="features152/synchronization/transformed" title="other targeters">
       <compile files="OtherTargeters.java" options="-Xjoinpoints:synchronization">
          <message kind="warning" line="8" text="advice matching the synchronized "/>
@@ -638,8 +638,8 @@
         </stderr>
       </run>
     </ajc-test>
-
-
+    
+    
     <ajc-test dir="features152/synchronization/transformed" title="joinpoints enabled but no lock">
       <compile files="Fourteen.java" options="-Xjoinpoints:synchronization">
          <!--message kind="warning" line="8" text="advice matching the synchronized "/-->

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc153/ajc153.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc153/ajc153.xml
@@ -742,7 +742,7 @@
         </compile>
         <compile files="AbstractSuperAspect.aj" options="-1.4"/>
         <compile files="TestAdvice.aj" options="-1.4"/>
-        <run class="HelloWorld" ltw="aop-advice.xml" usefullltw="true">
+        <run class="HelloWorld" ltw="aop-advice.xml">
         	<stdout>
                 <line text="? ConcreteAspectWithAdvice()"/>
                 <line text="? void HelloWorld.main(String[])"/>
@@ -773,7 +773,7 @@
         <compile files="TestITD.aj">
             <message line="3" kind="warning" text="this affected type is not exposed to the weaver: AbstractSuperAspectWithInterface"/>
         </compile>
-        <run class="HelloWorld" ltw="aop-itd.xml" usefullltw="true">
+        <run class="HelloWorld" ltw="aop-itd.xml">
         	<stdout>
                 <line text="? void TestITD.interfaceMethod()"/>
                 <line text="? void HelloWorld.main(String[])"/>
@@ -789,7 +789,7 @@
         <compile files="HelloWorld.java"/>
         <compile files="AbstractSuperAspect.aj" options="-1.4"/>
         <compile files="TestAroundClosure.aj" options="-1.4"/>
-        <run class="HelloWorld" ltw="aop-aroundclosure.xml" usefullltw="true">
+        <run class="HelloWorld" ltw="aop-aroundclosure.xml">
         	<stdout>
                 <line text="&gt; ConcreteAspectWithAroundClosure()"/>
                 <line text="&lt; ConcreteAspectWithAroundClosure()"/>
@@ -804,7 +804,7 @@
     <ajc-test dir="bugs153/pr149096" title="Weave concrete sub-aspect with cflow">
 		<compile files="SimpleTracing.aj" outjar="out.jar"/>
 		<compile files="TestMain.aj"/>
-		<run class="TestMain" ltw="aop-pr149096.xml" usefullltw="true"/>
+		<run class="TestMain" ltw="aop-pr149096.xml"/>
     </ajc-test>
 
 	<ajc-test dir="bugs153/pr158957" title="NPE with LTW, pointcut library and missing aspect dependency" keywords="ltw">

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc154/ajc154.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc154/ajc154.xml
@@ -118,7 +118,7 @@
    <ajc-test dir="bugs154/pr148381/simple" title="argNames does not work - simple">
      <!-- this compile is just to get code.jar into the sandbox, all the code is already precompiled in code.jar -->
      <compile options="-1.5" files="PerformanceMonitor.java" classpath="code.jar"/>
-     <run class="test.Main" classpath="code.jar" ltw="META-INF/aop.xml" usefullltw="true">
+     <run class="test.Main" classpath="code.jar" ltw="META-INF/aop.xml">
        <stdout>
          <line text="This method was intercepted by the advice: Main.foo()"/>
        </stdout>
@@ -212,7 +212,7 @@
    <!-- now loadtime weaving -->
    <ajc-test dir="bugs154/pr209019/case3" title="various issues with ltw and around advice - 4">
      <compile options="-1.5" files="A.java,AbstractDurationMethod.java,Runner.java"/>
-     <run class="Runner" ltw="aop.xml" usefullltw="true">
+     <run class="Runner" ltw="aop.xml">
        <stdout>
          <line text="Proceeded at joinpoint call(Object a.b.A.m3())"/>
          <line text="Proceeded at joinpoint call(Object a.b.A.m2())"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1612/ajc1612.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1612/ajc1612.xml
@@ -24,7 +24,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 2">
      <compile files="Hello.java JavaHelper.java"/>
-     <run class="Hello" ltw="aop2.xml" usefullltw="true">
+     <run class="Hello" ltw="aop2.xml">
        <stdout>
            <line text="Hello"/>
            <line text="World"/>
@@ -42,7 +42,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 3">
      <compile files="Hello.java JavaHelper.java"/>
-     <run class="Hello" ltw="aop3.xml" usefullltw="true">
+     <run class="Hello" ltw="aop3.xml">
        <stdout>
            <line text="Hello"/>
            <line text="World"/>
@@ -60,7 +60,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 4">
      <compile files="Hello.java JavaHelper.java"/>
-     <run class="Hello" ltw="aop4.xml" usefullltw="true">
+     <run class="Hello" ltw="aop4.xml">
        <stdout>
            <line text="Hello"/>
            <line text="World"/>
@@ -79,7 +79,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 5">
      <compile files="Hello2.java JavaHelper.java"/>
-     <run class="Hello2" ltw="aop5.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop5.xml">
        <stdout>
            <line text="hello"/>
            <line text="in advice: s=world"/>
@@ -91,7 +91,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 6">
      <compile files="Hello2.java JavaHelper.java"/>
-     <run class="Hello2" ltw="aop6.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop6.xml">
        <stdout>
            <line text="hello"/>
            <line text="in advice: s=world"/>
@@ -103,7 +103,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 7">
      <compile files="Hello2.java JavaHelper.java"/>
-     <run class="Hello2" ltw="aop7.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop7.xml">
        <stdout>
            <line text="hello"/>
            <line text="in advice4: s=world at execution(int Hello2.say2(String))"/>
@@ -115,7 +115,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 8">
      <compile files="Hello2.java JavaHelper.java"/>
-     <run class="Hello2" ltw="aop8.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop8.xml">
        <stdout>
            <line text="hello"/>
            <line text="in advice6: s=world at execution(int Hello2.say2(String))"/>
@@ -127,7 +127,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 9">
      <compile files="Hello2.java JavaHelper.java"/>
-     <run class="Hello2" ltw="aop9.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop9.xml">
        <stdout>
            <line text="in around advice: s=hello at execution(void Hello2.say1(String))"/>
        </stdout>
@@ -136,7 +136,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 10">
      <compile files="Hello2.java JavaHelper.java"/>
-     <run class="Hello2" ltw="aop10.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop10.xml">
        <stdout>
            <line text="hello"/>
            <line text="in around2 advice: s=world at execution(int Hello2.say2(String))"/>
@@ -146,7 +146,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 11">
      <compile files="Hello2.java JavaHelper.java"/>
-     <run class="Hello2" ltw="aop11.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop11.xml">
        <stdout>
            <line text="hello"/>
            <line text="abcde"/>
@@ -156,7 +156,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 12">
      <compile files="Hello3.java JavaHelper.java"/>
-     <run class="Hello3" ltw="aop12.xml" usefullltw="true">
+     <run class="Hello3" ltw="aop12.xml">
        <stdout>
            <line text="hello"/>
            <line text="around4 running"/>
@@ -168,7 +168,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice 13">
      <compile files="Hello2.java JavaHelper2.java"/>
-     <run class="Hello2" ltw="aop13.xml" usefullltw="true">
+     <run class="Hello2" ltw="aop13.xml">
        <stdout>
            <line text="in advice"/>
            <line text="hello"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1612/ajc1612.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1612/ajc1612.xml
@@ -13,7 +13,7 @@
 
  <ajc-test dir="bugs1612/xmldefs" title="xml defined advice">
      <compile files="Hello.java JavaHelper.java"/>
-     <run class="Hello" ltw="aop.xml" usefullltw="true">
+     <run class="Hello" ltw="aop.xml">
        <stdout>
            <line text="Hello"/>
            <line text="in advice"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc162/ajc162.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc162/ajc162.xml
@@ -15,7 +15,7 @@
    <ajc-test dir="bugs162/pr246918" title="ltw perclause">
      <compile options="-1.5" files="Code.java Dode.java" outjar="code.jar"/>
      <compile options="-1.5 -Xlint:ignore" files="Base.java" outjar="aspects.jar"/>
-     <run class="Code" classpath="aspects.jar,code.jar" ltw="aop1.xml" usefullltw="true">
+     <run class="Code" classpath="aspects.jar,code.jar" ltw="aop1.xml">
        <stderr>
          <line text="advice fired class Code"/>
          <line text="advice fired class Dode"/>
@@ -26,7 +26,7 @@
    <ajc-test dir="bugs162/pr246918" title="ltw perclause - 2">
      <compile options="-1.5" files="Code.java Dode.java" outjar="code.jar"/>
      <compile options="-1.5 -Xlint:ignore" files="Base.java" outjar="aspects.jar"/>
-     <run class="Code" classpath="aspects.jar,code.jar" ltw="aop2.xml" usefullltw="true">
+     <run class="Code" classpath="aspects.jar,code.jar" ltw="aop2.xml">
        <stderr>
          <line text="advice fired class Dode"/>
        </stderr>
@@ -36,7 +36,7 @@
    <ajc-test dir="bugs162/pr246918" title="ltw perclause - 3">
      <compile options="-1.5" files="Code.java Dode.java" outjar="code.jar"/>
      <compile options="-1.5 -Xlint:ignore" files="Base2.java" outjar="aspects.jar"/>
-     <run class="Code" classpath="aspects.jar,code.jar" ltw="aop3.xml" usefullltw="true">
+     <run class="Code" classpath="aspects.jar,code.jar" ltw="aop3.xml">
        <stderr>
          <line text="advice fired class Dode"/>
        </stderr>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc164/ajc164.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc164/ajc164.xml
@@ -56,7 +56,7 @@
     <ajc-test dir="bugs164/pr266220" title="generics and aop.xml">
         <compile files="Code.java"/>
         <compile files="Isolator.java" outjar="aspects.jar" options="-1.5"/>
-        <run class="Code" classpath="aspects.jar" ltw="aop.xml" usefullltw="true">
+        <run class="Code" classpath="aspects.jar" ltw="aop.xml">
           <stdout>
             <line text="execution(void Code.main(String[]))"/>
             <line text="execution(void Code.run())"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc170/ajc170.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc170/ajc170.xml
@@ -134,7 +134,7 @@
 
  	<ajc-test dir="bugs170/xmldefs" title="xml defined dec at method">
      <compile files="Hello.java Anno.java" options="-1.5"/>
-     <run class="Hello" ltw="aop.xml" usefullltw="true">
+     <run class="Hello" ltw="aop.xml">
        <stdout>
            <line text="Hello"/>
            <line text="World"/>
@@ -147,7 +147,7 @@
 
  	<ajc-test dir="bugs170/xmldefs" title="xml defined dec at method 2">
      <compile files="Hello.java Anno2.java" options="-1.5"/>
-     <run class="Hello" ltw="aop2.xml" usefullltw="true">
+     <run class="Hello" ltw="aop2.xml">
        <stdout>
            <line text="Hello"/>
            <line text="World"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc180/ajc180.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc180/ajc180.xml
@@ -5,19 +5,19 @@
 	<ajc-test dir="bugs180/432178" title="percflow ltw">
 		<compile options="-1.8" files="A.java B.java"/>
 		<compile options="-1.8" files="PerCFlowBug.java"/>
-		<run class="A" ltw="aop.xml" usefullltw="true">
+		<run class="A" ltw="aop.xml">
 		<stdout>
 		  <line text="foo"/>
 		  <line text="bar"/>
 		</stdout>
 		</run>
 	</ajc-test>
-
+	
 	<ajc-test dir="bugs180/pr432714" title="stackmapframe">
 		<compile options="-1.8" files="Code.java"/>
 		<run class="Code"/>
 	</ajc-test>
-
+	
 	<ajc-test dir="bugs180/pr431976" title="thisJoinPoint not initialized">
 		<compile options="-1.8" files="Code.java"/>
 	</ajc-test>
@@ -25,7 +25,7 @@
 	<ajc-test dir="bugs180/pr431541" title="NullAnnotationMatching exception">
 		<compile options="-1.8" files="Test.aj"/>
 	</ajc-test>
-
+	
 	<ajc-test dir="bugs180/415957" title="annotations with 1.8 flags">
 		<compile files="MyAspect.aj MyClass.java Resource.java" options="-1.8 -showWeaveInfo">
 			<message kind="weave" text="Join point 'method-execution(void MyClass.method())' in Type 'MyClass' (MyClass.java:3) advised by before advice from 'MyAspect' (MyAspect.aj:5)"/>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1810/ajc1810.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1810/ajc1810.xml
@@ -5,7 +5,7 @@
 	<ajc-test dir="bugs1810/508661" title="various ltw">
 		<compile options="-1.8" files="CacheMethodResult.java A_yes.java B_no.java Run.java" outjar="classes.jar"/>
 		<compile options="-1.8 -Xlint:ignore" files="CacheMethodResultAspect.java" outjar="aspects.jar"/>
-		<run class="Run" ltw="aop.xml" usefullltw="true">
+		<run class="Run" ltw="aop.xml">
 			<stdout>
 				<line text="around: void A_yes.m()"/>
 				<line text="A_yes.m()"/>


### PR DESCRIPTION
The benefit is that a few dozen LTW tests which I had switched to "full LTW" mode (running in separate JVMs), because I misunderstood the failures, not seeing my own mistake, can now be reverted to run in process. The side-effect that I fixed full LTW mode, so it is working again now when needed, remains intact, I only reverted the XML test configs from 3 commits, but left other changes intact.