### PR TITLE
Remove redundant casts after generics update

### DIFF
--- a/ajde/src/main/java/org/aspectj/ajde/ui/javaoptions/JavaCompilerWarningsOptionsPanel.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/javaoptions/JavaCompilerWarningsOptionsPanel.java
@@ -107,7 +107,7 @@ public class JavaCompilerWarningsOptionsPanel extends OptionsPanel {
 		panel.add(label,BorderLayout.WEST);
 
 		JComboBox warnings = new JComboBox(ignoreOrWarning);
-		String value = (String) javaBuildOptions.getJavaBuildOptionsMap().get(javaOptionToSet);
+		String value = javaBuildOptions.getJavaBuildOptionsMap().get(javaOptionToSet);
 		if (value.equals(JavaOptions.IGNORE)) {
 			warnings.setSelectedIndex(0);
 		} else {

--- a/ajde/src/main/java/org/aspectj/ajde/ui/javaoptions/JavaOtherOptionsPanel.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/javaoptions/JavaOtherOptionsPanel.java
@@ -89,7 +89,7 @@ public class JavaOtherOptionsPanel extends OptionsPanel {
 		characterEncoding.setPreferredSize(new Dimension(150, 21));
 		panel.add(characterEncoding,BorderLayout.EAST);
 
-		String option = (String) javaBuildOptions.getJavaBuildOptionsMap().get(
+		String option = javaBuildOptions.getJavaBuildOptionsMap().get(
 				JavaOptions.CHARACTER_ENCODING);
 		if (option != null) {
 			characterEncoding.setText(option);

--- a/ajdoc/src/main/java/org/aspectj/tools/ajdoc/StructureUtil.java
+++ b/ajdoc/src/main/java/org/aspectj/tools/ajdoc/StructureUtil.java
@@ -107,7 +107,7 @@ public class StructureUtil {
 
 	public static String getPackageDeclarationFromFile(AsmManager model, File file) {
 		IProgramElement fileNode = model.getHierarchy().findElementForSourceFile(file.getAbsolutePath());
-		String packageName = ((IProgramElement) fileNode.getChildren().get(0)).getPackageName();
+		String packageName = fileNode.getChildren().get(0).getPackageName();
 		return packageName;
 	}
 
@@ -143,7 +143,7 @@ public class StructureUtil {
 			for (int i = 0; i < node.getParameterTypes().size(); i++) {
 				sb.append(String.valueOf(node.getParameterTypes().get(i)));
 				sb.append(' ');
-				sb.append((String) node.getParameterNames().get(i));
+				sb.append(node.getParameterNames().get(i));
 				if (i < node.getParameterTypes().size() - 1) {
 					sb.append(", ");
 				}

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/SwitchBuilder.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/generic/SwitchBuilder.java
@@ -84,8 +84,8 @@ public final class SwitchBuilder {
    * @param max_gap maximum gap that may between case branches
    */
   public SwitchBuilder(int[] match, InstructionHandle[] targets,InstructionHandle target, int max_gap) {
-    this.match   = (int[])match.clone();
-    this.targets = (InstructionHandle[])targets.clone();
+    this.match   = match.clone();
+    this.targets = targets.clone();
 
     if((match_length = match.length) < 2) // (almost) empty switch, or just default
       if (match.length==0) {

--- a/build/src/main/java/org/aspectj/internal/tools/build/Modules.java
+++ b/build/src/main/java/org/aspectj/internal/tools/build/Modules.java
@@ -47,7 +47,7 @@ public class Modules {
         if (null == name) {
             return null;
         }
-        Module result = (Module) modules.get(name);
+        Module result = modules.get(name);
         if (null == result) {
             File moduleDir = new File(baseDir, name);
             if (!Util.canReadDir(moduleDir)) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/ajc/BuildArgParser.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/ajc/BuildArgParser.java
@@ -400,8 +400,7 @@ public class BuildArgParser extends Main {
 		if (parser.classpath == null) {
 			addClasspath(System.getProperty("java.class.path", ""), ret);
 			List<String> fixedList = new ArrayList<>();
-			for (Object o : ret) {
-				String entry = (String) o;
+			for (String entry : ret) {
 				if (!entry.endsWith("aspectjtools.jar")) {
 					fixedList.add(entry);
 				}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjCompilerAdapter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/AjCompilerAdapter.java
@@ -273,8 +273,7 @@ public class AjCompilerAdapter extends AbstractCompilerAdapter {
 	private List<InterimCompilationResult> getBinarySourcesFrom(Map<String, List<UnwovenClassFile>> binarySourceEntries) {
 		// Map is fileName |-> List<UnwovenClassFile>
 		List<InterimCompilationResult> ret = new ArrayList<>();
-		for (Object o : binarySourceEntries.keySet()) {
-			String sourceFileName = (String) o;
+		for (String sourceFileName : binarySourceEntries.keySet()) {
 			List<UnwovenClassFile> unwovenClassFiles = binarySourceEntries.get(sourceFileName);
 			// XXX - see bugs 57432,58679 - final parameter on next call should be "compiler.options.maxProblemsPerUnit"
 			CompilationResult result = new CompilationResult(sourceFileName.toCharArray(), 0, 0, Integer.MAX_VALUE);
@@ -286,16 +285,14 @@ public class AjCompilerAdapter extends AbstractCompilerAdapter {
 	}
 
 	private void notifyRequestor() {
-		for (Object o : resultsPendingWeave) {
-			InterimCompilationResult iresult = (InterimCompilationResult) o;
+		for (InterimCompilationResult iresult : resultsPendingWeave) {
 			compiler.requestor.acceptResult(iresult.result().tagAsAccepted());
 		}
 	}
 
 	private void weave() throws IOException {
 		// ensure weaver state is set up correctly
-		for (Object o : resultsPendingWeave) {
-			InterimCompilationResult iresult = (InterimCompilationResult) o;
+		for (InterimCompilationResult iresult : resultsPendingWeave) {
 			for (int i = 0; i < iresult.unwovenClassFiles().length; i++) {
 				weaver.addClassFile(iresult.unwovenClassFiles()[i], false);
 			}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverAdapter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverAdapter.java
@@ -93,13 +93,13 @@ public class WeaverAdapter implements IClassFileProvider, IWeaveRequestor, Itera
 		if (nowProcessing == null) {
 			if (!resultIterator.hasNext())
 				return false;
-			nowProcessing = (InterimCompilationResult) resultIterator.next();
+			nowProcessing = resultIterator.next();
 			classFileIndex = 0;
 		}
 		while (nowProcessing.unwovenClassFiles().length == 0) {
 			if (!resultIterator.hasNext())
 				return false;
-			nowProcessing = (InterimCompilationResult) resultIterator.next();
+			nowProcessing = resultIterator.next();
 		}
 		if (classFileIndex < nowProcessing.unwovenClassFiles().length) {
 			return true;
@@ -107,11 +107,11 @@ public class WeaverAdapter implements IClassFileProvider, IWeaveRequestor, Itera
 			classFileIndex = 0;
 			if (!resultIterator.hasNext())
 				return false;
-			nowProcessing = (InterimCompilationResult) resultIterator.next();
+			nowProcessing = resultIterator.next();
 			while (nowProcessing.unwovenClassFiles().length == 0) {
 				if (!resultIterator.hasNext())
 					return false;
-				nowProcessing = (InterimCompilationResult) resultIterator.next();
+				nowProcessing = resultIterator.next();
 			}
 		}
 		return true;

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverMessageHandler.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/WeaverMessageHandler.java
@@ -211,8 +211,7 @@ public class WeaverMessageHandler implements IMessageHandler {
 			boolean usedBinarySourceFileName) {
 		List<IProblem> ret = new ArrayList<>();
 
-		for (Object sourceLocation : sourceLocations) {
-			ISourceLocation loc = (ISourceLocation) sourceLocation;
+		for (ISourceLocation loc : sourceLocations) {
 			if (loc != null) {
 				DefaultProblem dp = new DefaultProblem(loc.getSourceFile().getPath().toCharArray(), "see also", 0, new String[]{},
 						ProblemSeverities.Ignore, getStartPos(loc, null), getEndPos(loc, null), loc.getLine(), loc.getColumn());
@@ -229,7 +228,7 @@ public class WeaverMessageHandler implements IMessageHandler {
 					ProblemSeverities.Ignore, 0, 0, 0, 0);
 			ret.add(dp);
 		}
-		IProblem[] retValue = (IProblem[]) ret.toArray(new IProblem[] {});
+		IProblem[] retValue = ret.toArray(new IProblem[] {});
 		return retValue;
 	}
 

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AccessForInlineVisitor.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AccessForInlineVisitor.java
@@ -237,7 +237,7 @@ public class AccessForInlineVisitor extends ASTVisitor {
 		ResolvedMember m = world.makeResolvedMember(binding);
 		ResolvedMember superAccessMember = AjcMemberMaker.superAccessMethod(inAspect.typeX, m);
 		if (inAspect.superAccessForInline.containsKey(superAccessMember)) {
-			return ((SuperAccessMethodPair) inAspect.superAccessForInline.get(superAccessMember)).accessMethod;
+			return inAspect.superAccessForInline.get(superAccessMember).accessMethod;
 		}
 		MethodBinding ret = world.makeMethodBinding(superAccessMember);
 		inAspect.superAccessForInline.put(superAccessMember, new SuperAccessMethodPair(m, ret));

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/DeclareDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/DeclareDeclaration.java
@@ -77,7 +77,7 @@ public class DeclareDeclaration extends AjMethodDeclaration {
 			Collection<UnresolvedType> parentPatterns = dp.getParents().getExactTypes();
 			StringBuilder parents = new StringBuilder();
 			for (Iterator<UnresolvedType> iter = parentPatterns.iterator(); iter.hasNext();) {
-				UnresolvedType urt = ((UnresolvedType) iter.next());
+				UnresolvedType urt = iter.next();
 				parents.append(urt.getName());
 				if (iter.hasNext()) {
 					parents.append(", ");

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ValidateAtAspectJAnnotationsVisitor.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ValidateAtAspectJAnnotationsVisitor.java
@@ -214,7 +214,7 @@ public class ValidateAtAspectJAnnotationsVisitor extends ASTVisitor {
 	private boolean insideAspect() {
 		if (typeStack.empty())
 			return false;
-		TypeDeclaration typeDecl = (TypeDeclaration) typeStack.peek();
+		TypeDeclaration typeDecl = typeStack.peek();
 		return isAspect(typeDecl);
 	}
 
@@ -401,8 +401,8 @@ public class ValidateAtAspectJAnnotationsVisitor extends ASTVisitor {
 			UnresolvedType[] paramTypes = new UnresolvedType[bindings.length];
 			for (int i = 0; i < paramTypes.length; i++)
 				paramTypes[i] = bindings[i].getType();
-			ResolvedPointcutDefinition resPcutDef = new ResolvedPointcutDefinition(factory.fromBinding(((TypeDeclaration) typeStack
-					.peek()).binding), methodDeclaration.modifiers, "anonymous", paramTypes, pc);
+			ResolvedPointcutDefinition resPcutDef = new ResolvedPointcutDefinition(factory.fromBinding(typeStack.peek().binding),
+					methodDeclaration.modifiers, "anonymous", paramTypes, pc);
 			AjAttribute attr = new AjAttribute.PointcutDeclarationAttribute(resPcutDef);
 			((AjMethodDeclaration) methodDeclaration).addAttribute(new EclipseAttributeAdapter(attr));
 		} catch (ParserException pEx) {
@@ -500,7 +500,7 @@ public class ValidateAtAspectJAnnotationsVisitor extends ASTVisitor {
 	}
 
 	private void convertToPointcutDeclaration(MethodDeclaration methodDeclaration, ClassScope scope) {
-		TypeDeclaration typeDecl = (TypeDeclaration) typeStack.peek();
+		TypeDeclaration typeDecl = typeStack.peek();
 		if (typeDecl.binding != null) {
 			if (!typeDecl.binding.isClass()) {
 				methodDeclaration.scope.problemReporter().signalError(methodDeclaration.sourceStart, methodDeclaration.sourceEnd,
@@ -547,7 +547,7 @@ public class ValidateAtAspectJAnnotationsVisitor extends ASTVisitor {
 			}
 			pcDecl.pointcutDesignator = (pc == null) ? null : new PointcutDesignator(pc);
 			pcDecl.setGenerateSyntheticPointcutMethod();
-			TypeDeclaration onType = (TypeDeclaration) typeStack.peek();
+			TypeDeclaration onType = typeStack.peek();
 			pcDecl.postParse(onType);
 			// EclipseFactory factory =
 			// EclipseFactory.fromScopeLookupEnvironment

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
@@ -699,9 +699,8 @@ public class AjLookupEnvironment extends LookupEnvironment implements AnonymousC
 			// Check if the type we are looking at is the topMostImplementor of a
 			// dangerous interface -
 			// report a problem if it is.
-			for (Object o : dangerousInterfaces.entrySet()) {
-				Map.Entry<ResolvedType, String> entry = (Map.Entry) o;
-				ResolvedType interfaceType = (ResolvedType) entry.getKey();
+			for (Map.Entry<ResolvedType, String> entry : dangerousInterfaces.entrySet()) {
+				ResolvedType interfaceType = entry.getKey();
 				if (onType.isTopmostImplementor(interfaceType)) {
 					factory.showMessage(IMessage.ERROR, onType + ": " + entry.getValue(), onType.getSourceLocation(), null);
 				}
@@ -1442,7 +1441,7 @@ public class AjLookupEnvironment extends LookupEnvironment implements AnonymousC
 			if (pendingTypesToFinish.size() > 0) {
 				processingTheQueue = true;
 				while (!pendingTypesToFinish.isEmpty()) {
-					BinaryTypeBinding nextVictim = (BinaryTypeBinding) pendingTypesToFinish.remove(0);
+					BinaryTypeBinding nextVictim = pendingTypesToFinish.remove(0);
 					// During this call we may recurse into this method and add
 					// more entries to the pendingTypesToFinish list.
 					weaveInterTypeDeclarations(nextVictim);

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PrivilegedHandler.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PrivilegedHandler.java
@@ -143,8 +143,8 @@ public class PrivilegedHandler implements IPrivilegedHandler {
 		int len = m.size();
 		ResolvedMember[] ret = new ResolvedMember[len];
 		int index = 0;
-		for (Object o : m) {
-			ret[index++] = (ResolvedMember) o;
+		for (ResolvedMember o : m) {
+			ret[index++] = o;
 		}
 		return ret;
 	}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
@@ -564,8 +564,7 @@ public class AjProblemReporter extends ProblemReporter {
 							Collection<ResolvedMember> privvies = ((ReferenceType) theAspect).getPrivilegedAccesses();
 							// On an incremental compile the information is in the bcel delegate
 							if (privvies != null) {
-								for (Object privvy : privvies) {
-									ResolvedMember priv = (ResolvedMember) privvy;
+								for (ResolvedMember priv : privvies) {
 									if (priv.getName().equals(fname)) {
 										return;
 									}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
@@ -734,7 +734,7 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
                     if (!outputDirsToAspects.containsKey(outputDir)) {
                         outputDirsToAspects.put(outputDir, new ArrayList<>());
                     }
-                    ((List) outputDirsToAspects.get(outputDir)).add(aspectName);
+                    outputDirsToAspects.get(outputDir).add(aspectName);
                 }
 			}
 		}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmHierarchyBuilder.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AsmHierarchyBuilder.java
@@ -172,7 +172,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 			// -- remove duplicates before adding (XXX use them instead?)
 			if (addToNode != null && addToNode.getChildren() != null) {
 				for (ListIterator<IProgramElement> itt = addToNode.getChildren().listIterator(); itt.hasNext();) {
-					IProgramElement child = (IProgramElement) itt.next();
+					IProgramElement child = itt.next();
 					ISourceLocation childLoc = child.getSourceLocation();
 					if (null == childLoc) {
 						// XXX ok, packages have null source locations
@@ -413,7 +413,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 		peNode.setFormalComment(generateJavadocComment(memberTypeDeclaration));
 		peNode.setAnnotationStyleDeclaration(isAnnotationStyleAspect);
 
-		((IProgramElement) stack.peek()).addChild(peNode);
+		stack.peek().addChild(peNode);
 		stack.push(peNode);
 		return true;
 	}
@@ -482,11 +482,11 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 			}
 		}
 
-		IProgramElement ipe = (IProgramElement)stack.peek();
+		IProgramElement ipe = stack.peek();
 		if (ipe!=null) {
 			// With AspectJ 1.8.9 the type structure must be slightly different as the guard
 			// is required (the null is due to a default constructor).
-			((IProgramElement) stack.peek()).addChild(peNode);
+			stack.peek().addChild(peNode);
 		}
 		stack.push(peNode);
 		return true;
@@ -597,7 +597,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 							.equals("main(java.lang.String[])"))
 					&& peNode.getModifiers().contains(IProgramElement.Modifiers.STATIC)
 					&& peNode.getAccessibility().equals(IProgramElement.Accessibility.PUBLIC)) {
-				((IProgramElement) stack.peek()).setRunnable(true);
+				stack.peek().setRunnable(true);
 			}
 		}
 
@@ -763,7 +763,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 				npe.printStackTrace();
 			}
 		}
-		((IProgramElement) stack.peek()).addChild(peNode);
+		stack.peek().addChild(peNode);
 	}
 
 	public void endVisit(MethodDeclaration methodDeclaration, ClassScope scope) {
@@ -791,7 +791,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 			// create Source signature for import
 			peNode.setSourceSignature(genSourceSignature(importRef));
 
-			IProgramElement containingTypeElement = (IProgramElement) stack.peek();
+			IProgramElement containingTypeElement = stack.peek();
 			ProgramElement imports = getImportReferencesRoot();
 			imports.addChild(0, peNode);
 			stack.push(peNode);
@@ -800,7 +800,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 	}
 
 	private ProgramElement getImportReferencesRoot() {
-		IProgramElement element = (IProgramElement) stack.peek();
+		IProgramElement element = stack.peek();
 		boolean hasPackageDeclaration = (element.getChildren().get(0)).getKind().isPackageDeclaration();
 		return (ProgramElement) element.getChildren().get(hasPackageDeclaration ? 1 : 0);
 	}
@@ -870,7 +870,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 		peNode.setFormalComment(generateJavadocComment(fieldDeclaration));
 		// peNode.setBytecodeSignature(new String(fieldDeclaration.binding.type.signature()));
 
-		((IProgramElement) stack.peek()).addChild(peNode);
+		stack.peek().addChild(peNode);
 		stack.push(peNode);
 		return true;
 	}
@@ -1022,7 +1022,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 			peNode.setBytecodeSignature(memberBytecodeSignature);
 		}
 
-		((IProgramElement) stack.peek()).addChild(peNode);
+		stack.peek().addChild(peNode);
 		stack.push(peNode);
 		return true;
 	}
@@ -1101,7 +1101,7 @@ public class AsmHierarchyBuilder extends ASTVisitor {
 				makeLocation(initializer), initializer.modifiers, null, null);
 		// "",
 		// new ArrayList());
-		((IProgramElement) stack.peek()).addChild(peNode);
+		stack.peek().addChild(peNode);
 		stack.push(peNode);
 		initializer.block.traverse(this, scope);
 		stack.pop();

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/IncrementalStateManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/IncrementalStateManager.java
@@ -58,7 +58,7 @@ public class IncrementalStateManager {
 			System.out.println("Name " + entry.getKey());
 			File f = new File("n:/temp/foo.ajstate");
 			try {
-				AjState state = (AjState) entry.getValue();
+				AjState state = entry.getValue();
 				CompressingDataOutputStream dos = new CompressingDataOutputStream(new FileOutputStream(f));
 				state.write(dos);
 				dos.close();
@@ -87,7 +87,7 @@ public class IncrementalStateManager {
 	}
 
 	public static AjState retrieveStateFor(String configFile) {
-		return (AjState) incrementalStates.get(configFile);
+		return incrementalStates.get(configFile);
 	}
 
 	// now, managing changes to entries on a classpath
@@ -117,8 +117,7 @@ public class IncrementalStateManager {
 			CompilationResultDestinationManager outputManager = ajbc.getCompilationResultDestinationManager();
 			if (outputManager != null) {
 				List<File> outputDirs = outputManager.getAllOutputLocations();
-				for (Object o : outputDirs) {
-					File dir = (File) o;
+				for (File dir : outputDirs) {
 					if (dir.equals(location)) {
 						if (debugIncrementalStates) {
 							System.err.println("< findStateManagingOutputLocation(" + location + ") returning " + element);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Lint.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Lint.java
@@ -231,10 +231,8 @@ public class Lint {
 		setFromProperties(p);
 	}
 
-	@SuppressWarnings("rawtypes")
 	public void setFromProperties(Properties properties) {
-		for (Map.Entry<Object, Object> objectObjectEntry : properties.entrySet()) {
-			Map.Entry entry = (Map.Entry) objectObjectEntry;
+		for (Map.Entry<Object, Object> entry : properties.entrySet()) {
 			Kind kind = kinds.get(entry.getKey());
 			if (kind == null) {
 				MessageUtil.error(world.getMessageHandler(), WeaverMessages.format(WeaverMessages.XLINT_KEY_ERROR, entry.getKey()));

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ReferenceType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ReferenceType.java
@@ -1034,7 +1034,7 @@ public class ReferenceType extends ResolvedType {
 		// If we are raw, we have a generic type - we should ensure it uses the
 		// same delegate
 		if (isRawType() && getGenericType() != null) {
-			ReferenceType genType = (ReferenceType) getGenericType();
+			ReferenceType genType = getGenericType();
 			if (genType.getDelegate() != delegate) { // avoids circular updates
 				genType.setDelegate(delegate);
 			}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/WeakClassLoaderReference.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/WeakClassLoaderReference.java
@@ -50,7 +50,7 @@ public class WeakClassLoaderReference{
 	}
 
 	public ClassLoader getClassLoader() {
-		ClassLoader instance = (ClassLoader) loaderRef.get();
+		ClassLoader instance = loaderRef.get();
 		// Assert instance!=null
 		return instance;
 	}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPatternList.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/AnnotationPatternList.java
@@ -50,7 +50,7 @@ public class AnnotationPatternList extends PatternNode {
 	}
 
 	public AnnotationPatternList(List<AnnotationTypePattern> l) {
-		this((AnnotationTypePattern[]) l.toArray(AnnotationTypePattern.NONE));
+		this(l.toArray(AnnotationTypePattern.NONE));
 	}
 
 	protected AnnotationTypePattern[] getAnnotationPatterns() {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/BasicTokenSource.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/BasicTokenSource.java
@@ -160,7 +160,7 @@ public class BasicTokenSource implements ITokenSource {
 
 		//System.out.println(tokens);
 
-		return new BasicTokenSource((IToken[])tokens.toArray(new IToken[0]), context);
+		return new BasicTokenSource(tokens.toArray(new IToken[0]), context);
 	}
 
 	private static String makeString(char ch) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/Bindings.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/Bindings.java
@@ -109,10 +109,7 @@ public class Bindings {
 	}
 
 	public Bindings copy() {
-		// int len = bindings.length;
-		// boolean[] a = new boolean[len];
-		// System.arraycopy(bindings, 0, a, 0, len);
-		return new Bindings((BindingPattern[]) bindings.clone());
+		return new Bindings(bindings.clone());
 	}
 
 	public void checkAllBound(IScope scope) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ConcreteCflowPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ConcreteCflowPointcut.java
@@ -83,7 +83,7 @@ public class ConcreteCflowPointcut extends Pointcut {
 		}
 		int[] indices = new int[slots.size()];
 		for (int i = 0; i < indices.length; i++) {
-			indices[i] = ((Slot) slots.get(i)).formalIndex;
+			indices[i] = slots.get(i).formalIndex;
 		}
 		return indices;
 	}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/HasMemberTypePattern.java
@@ -62,7 +62,7 @@ public class HasMemberTypePattern extends TypePattern {
 		// TODO what about ITDs
 		World world = type.getWorld();
 		for (Iterator<ResolvedMember> iter = type.getFields(); iter.hasNext();) {
-			Member field = (Member) iter.next();
+			Member field = iter.next();
 			if (field.getName().startsWith(declareAtPrefix)) {
 				continue;
 			}
@@ -82,7 +82,7 @@ public class HasMemberTypePattern extends TypePattern {
 		// TODO what about ITDs
 		World world = type.getWorld();
 		for (Iterator<ResolvedMember> iter = type.getMethods(true, true); iter.hasNext();) {
-			Member method = (Member) iter.next();
+			Member method = iter.next();
 			if (method.getName().startsWith(declareAtPrefix)) {
 				continue;
 			}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/IfPointcut.java
@@ -90,7 +90,7 @@ public class IfPointcut extends Pointcut {
 				if ((extraParameterFlags & Advice.ConstantValue) != 0) {
 					return FuzzyBoolean.YES;
 				} else {
-					return FuzzyBoolean.NO;   
+					return FuzzyBoolean.NO;
 				}
 			}
 		}
@@ -274,10 +274,10 @@ public class IfPointcut extends Pointcut {
 						args.add(shadow.getThisEnclosingJoinPointStaticPartVar());
 					} else {
 
-						if (state.size() == 0 || currentStateIndex > state.size()) { // if 'we have nothing else to bind from in the state object' 
+						if (state.size() == 0 || currentStateIndex > state.size()) { // if 'we have nothing else to bind from in the state object'
 							String[] paramNames = testMethod.getParameterNames();
 							StringBuilder errorParameter = new StringBuilder();
-							
+
 							// Support a single special situation: where the if() pointcut takes a parameter bound elsewhere
 							// in the pointcut but the advice does not bind it. For example:
 							//
@@ -299,7 +299,7 @@ public class IfPointcut extends Pointcut {
 									continue;
 								}
 							}
-							
+
 							if (paramNames != null) {
 								errorParameter.append(testMethod.getParameterTypes()[i].getName()).append(" ");
 								errorParameter.append(paramNames[i]);
@@ -334,7 +334,7 @@ public class IfPointcut extends Pointcut {
 				}
 			}
 
-			ret = Test.makeAnd(ret, Test.makeCall(testMethod, (Expr[]) args.toArray(Expr.NONE)));
+			ret = Test.makeAnd(ret, Test.makeCall(testMethod, args.toArray(Expr.NONE)));
 
 			// Remember...
 			ifLastMatchedShadowId = shadow.shadowId;
@@ -381,7 +381,7 @@ public class IfPointcut extends Pointcut {
 			if (def != null) {
 				ResolvedType aspect = inAspect.getWorld().resolve(def.getDeclaringType());
 				for (Iterator<ResolvedMember> memberIter = aspect.getMethods(true, true); memberIter.hasNext();) {
-					ResolvedMember method = (ResolvedMember) memberIter.next();
+					ResolvedMember method = memberIter.next();
 					if (def.getName().equals(method.getName())
 							&& def.getParameterTypes().length == method.getParameterTypes().length) {
 						boolean sameSig = true;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NameBindingPointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NameBindingPointcut.java
@@ -40,7 +40,7 @@ public abstract class NameBindingPointcut extends Pointcut {
 		ResolvedType myType = type.getExactType().resolve(world);
 		if (myType.isParameterizedType()) {
 			// unchecked warning already issued...
-			myType = (ResolvedType) myType.getRawType();
+			myType = myType.getRawType();
 		}
 		return Test.makeInstanceof(var, myType.resolve(world));
 	}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePattern.java
@@ -199,7 +199,7 @@ public abstract class TypePattern extends PatternNode {
 		}
 		// FuzzyBoolean ret = FuzzyBoolean.NO; // ??? -eh
 		for (Iterator<ResolvedType> i = superType.getDirectSupertypes(); i.hasNext();) {
-			ResolvedType superSuperType = (ResolvedType) i.next();
+			ResolvedType superSuperType = i.next();
 			if (matchesSubtypes(superSuperType, annotatedType)) {
 				return true;
 			}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternList.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternList.java
@@ -59,7 +59,7 @@ public class TypePatternList extends PatternNode {
 	}
 
 	public TypePatternList(List<TypePattern> l) {
-		this((TypePattern[]) l.toArray(new TypePattern[0]));
+		this(l.toArray(new TypePattern[0]));
 	}
 
 	public int size() {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternQuestions.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/TypePatternQuestions.java
@@ -37,8 +37,8 @@ public class TypePatternQuestions {
 
 	public Question anyChanges() {
 		for (Map.Entry<Question, FuzzyBoolean> entry : questionsAndAnswers.entrySet()) {
-			Question question = (Question) entry.getKey();
-			FuzzyBoolean expectedAnswer = (FuzzyBoolean) entry.getValue();
+			Question question = entry.getKey();
+			FuzzyBoolean expectedAnswer = entry.getValue();
 
 			FuzzyBoolean currentAnswer = question.ask();
 			//System.out.println(question + ":" + currentAnswer);
@@ -54,8 +54,8 @@ public class TypePatternQuestions {
 		StringBuilder buf = new StringBuilder();
 		buf.append("TypePatternQuestions{");
 		for (Map.Entry<Question,FuzzyBoolean> entry: questionsAndAnswers.entrySet()) {
-			Question question = (Question)entry.getKey();
-			FuzzyBoolean expectedAnswer = (FuzzyBoolean)entry.getValue();
+			Question question = entry.getKey();
+			FuzzyBoolean expectedAnswer = entry.getValue();
 			buf.append(question);
 			buf.append(":");
 			buf.append(expectedAnswer);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
@@ -110,7 +110,7 @@ public class WildTypePattern extends TypePattern {
 	}
 
 	public WildTypePattern(List<NamePattern> names, boolean includeSubtypes, int dim) {
-		this((NamePattern[]) names.toArray(new NamePattern[0]), includeSubtypes, dim, false, TypePatternList.EMPTY);
+		this(names.toArray(new NamePattern[0]), includeSubtypes, dim, false, TypePatternList.EMPTY);
 
 	}
 
@@ -127,7 +127,7 @@ public class WildTypePattern extends TypePattern {
 
 	public WildTypePattern(List<NamePattern> names, boolean includeSubtypes, int dim, int endPos, boolean isVarArg, TypePatternList typeParams,
 			TypePattern upperBound, TypePattern[] additionalInterfaceBounds, TypePattern lowerBound) {
-		this((NamePattern[]) names.toArray(new NamePattern[0]), includeSubtypes, dim, isVarArg, typeParams);
+		this(names.toArray(new NamePattern[0]), includeSubtypes, dim, isVarArg, typeParams);
 		this.end = endPos;
 		this.upperBound = upperBound;
 		this.lowerBound = lowerBound;
@@ -135,7 +135,7 @@ public class WildTypePattern extends TypePattern {
 	}
 
 	public WildTypePattern(List<NamePattern> names, boolean includeSubtypes, int dim, int endPos, boolean isVarArg, TypePatternList typeParams) {
-		this((NamePattern[]) names.toArray(new NamePattern[0]), includeSubtypes, dim, isVarArg, typeParams);
+		this(names.toArray(new NamePattern[0]), includeSubtypes, dim, isVarArg, typeParams);
 		this.end = endPos;
 	}
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionShadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/ReflectionShadow.java
@@ -256,7 +256,7 @@ public class ReflectionShadow extends Shadow {
 			Var v = ReflectionVar.createAtAnnotationVar(annType, this.annotationFinder);
 			annotationVar.put(annType, v);
 		}
-		return (Var) annotationVar.get(annType);
+		return annotationVar.get(annType);
 	}
 
 	/*
@@ -270,7 +270,7 @@ public class ReflectionShadow extends Shadow {
 			Var v = ReflectionVar.createWithinAnnotationVar(annType, this.annotationFinder);
 			withinAnnotationVar.put(annType, v);
 		}
-		return (Var) withinAnnotationVar.get(annType);
+		return withinAnnotationVar.get(annType);
 	}
 
 	/*
@@ -284,7 +284,7 @@ public class ReflectionShadow extends Shadow {
 			Var v = ReflectionVar.createWithinCodeAnnotationVar(annType, this.annotationFinder);
 			withinCodeAnnotationVar.put(annType, v);
 		}
-		return (Var) withinCodeAnnotationVar.get(annType);
+		return withinCodeAnnotationVar.get(annType);
 	}
 
 	/*
@@ -322,7 +322,7 @@ public class ReflectionShadow extends Shadow {
 			Var[] vars = new Var[getArgCount()];
 			atArgsVars.put(annType, vars);
 		}
-		Var[] vars = (Var[]) atArgsVars.get(annType);
+		Var[] vars = atArgsVars.get(annType);
 		if (i > (vars.length - 1))
 			return null;
 		if (vars[i] == null) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/StandardShadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/reflect/StandardShadow.java
@@ -291,7 +291,7 @@ public class StandardShadow extends Shadow {
 			Var v = ReflectionVar.createAtAnnotationVar(annType, this.annotationFinder);
 			annotationVar.put(annType, v);
 		}
-		return (Var) annotationVar.get(annType);
+		return annotationVar.get(annType);
 	}
 
 	/*
@@ -305,7 +305,7 @@ public class StandardShadow extends Shadow {
 			Var v = ReflectionVar.createWithinAnnotationVar(annType, this.annotationFinder);
 			withinAnnotationVar.put(annType, v);
 		}
-		return (Var) withinAnnotationVar.get(annType);
+		return withinAnnotationVar.get(annType);
 	}
 
 	/*
@@ -319,7 +319,7 @@ public class StandardShadow extends Shadow {
 			Var v = ReflectionVar.createWithinCodeAnnotationVar(annType, this.annotationFinder);
 			withinCodeAnnotationVar.put(annType, v);
 		}
-		return (Var) withinCodeAnnotationVar.get(annType);
+		return withinCodeAnnotationVar.get(annType);
 	}
 
 	/*
@@ -357,7 +357,7 @@ public class StandardShadow extends Shadow {
 			Var[] vars = new Var[getArgCount()];
 			atArgsVars.put(annType, vars);
 		}
-		Var[] vars = (Var[]) atArgsVars.get(annType);
+		Var[] vars = atArgsVars.get(annType);
 		if (i > (vars.length - 1))
 			return null;
 		if (vars[i] == null) {

--- a/runtime/src/main/java/org/aspectj/internal/lang/reflect/AjTypeImpl.java
+++ b/runtime/src/main/java/org/aspectj/internal/lang/reflect/AjTypeImpl.java
@@ -120,7 +120,7 @@ public class AjTypeImpl<T> implements AjType<T> {
 	 */
 	public AjType<? super T> getSupertype() {
 		Class<? super T> superclass = clazz.getSuperclass();
-		return superclass==null ? null : (AjType<? super T>) new AjTypeImpl<>(superclass);
+		return superclass==null ? null : new AjTypeImpl<>(superclass);
 	}
 
 	/* (non-Javadoc)

--- a/runtime/src/main/java/org/aspectj/runtime/internal/CFlowStack.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/CFlowStack.java
@@ -91,7 +91,7 @@ public class CFlowStack {
     public Object peek() {
         Stack<?> stack = getThreadStack();
         if (stack.isEmpty()) throw new org.aspectj.lang.NoAspectBoundException();
-        return (Object)stack.peek();
+        return stack.peek();
     }
 
     public Object get(int index) {

--- a/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadCounterImpl11.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadCounterImpl11.java
@@ -34,7 +34,7 @@ public class ThreadCounterImpl11 implements ThreadCounter {
 	private synchronized Counter getThreadCounter() {
 		if (Thread.currentThread() != cached_thread) {
 			cached_thread = Thread.currentThread();
-			cached_counter = (Counter)counters.get(cached_thread);
+			cached_counter = counters.get(cached_thread);
 			if (cached_counter == null) {
 				cached_counter = new Counter();
 				counters.put(cached_thread, cached_counter);
@@ -45,7 +45,7 @@ public class ThreadCounterImpl11 implements ThreadCounter {
 			if (change_count > Math.max(MIN_COLLECT_AT, COLLECT_AT/size)) {
 				List<Thread> dead_stacks = new ArrayList<>();
 				for (Enumeration<Thread> e = counters.keys(); e.hasMoreElements(); ) {
-					Thread t = (Thread)e.nextElement();
+					Thread t = e.nextElement();
 					if (!t.isAlive()) dead_stacks.add(t);
 				}
 				for (Thread t : dead_stacks) {

--- a/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackFactoryImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackFactoryImpl.java
@@ -21,7 +21,7 @@ public class ThreadStackFactoryImpl implements ThreadStackFactory {
 		  return new Stack();
 		}
 		public Stack getThreadStack() {
-			return (Stack)get();
+			return get();
 		}
 		public void removeThreadStack() {
 			this.remove();
@@ -38,7 +38,7 @@ public class ThreadStackFactoryImpl implements ThreadStackFactory {
 		  return new Counter();
 		}
 		public Counter getThreadCounter() {
-			return (Counter)get();
+			return get();
 		}
 
 		public void removeThreadCounter() {

--- a/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackImpl11.java
+++ b/runtime/src/main/java/org/aspectj/runtime/internal/cflowstack/ThreadStackImpl11.java
@@ -39,11 +39,11 @@ public class ThreadStackImpl11 implements ThreadStack {
 			if (change_count > Math.max(MIN_COLLECT_AT, COLLECT_AT/size)) {
 				Stack<Thread> dead_stacks = new Stack<>();
 				for (Enumeration<Thread> e = stacks.keys(); e.hasMoreElements(); ) {
-					Thread t = (Thread)e.nextElement();
+					Thread t = e.nextElement();
 					if (!t.isAlive()) dead_stacks.push(t);
 				}
 				for (Enumeration<Thread> e = dead_stacks.elements(); e.hasMoreElements(); ) {
-					Thread t = (Thread)e.nextElement();
+					Thread t = e.nextElement();
 					stacks.remove(t);
 				}
 				change_count = 0;

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/Factory.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/Factory.java
@@ -59,7 +59,7 @@ public final class Factory {
 	static Class<?> makeClass(String s, ClassLoader loader) {
 		if (s.equals("*"))
 			return null;
-		Class<?> ret = (Class)prims.get(s);
+		Class<?> ret = prims.get(s);
 		if (ret != null)
 			return ret;
 		try {

--- a/runtime/src/main/java/org/aspectj/runtime/reflect/SignatureImpl.java
+++ b/runtime/src/main/java/org/aspectj/runtime/reflect/SignatureImpl.java
@@ -230,7 +230,7 @@ abstract class SignatureImpl implements Signature {
 		}
 
 		private String[] array() {
-			return (String[]) toStringCacheRef.get();
+			return toStringCacheRef.get();
 		}
 
 		private String[] makeCache() {

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -1190,7 +1190,7 @@ public class AjcTask extends MatchingTask {
 		ArrayList<String> result = new ArrayList(cmd.extractArguments());
 		addListArgs(result);
 
-		String[] command = (String[]) result.toArray(new String[0]);
+		String[] command = result.toArray(new String[0]);
 		if (null != commandEditor) {
 			command = commandEditor.editCommand(command);
 		} else if (null != COMMAND_EDITOR) {

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajdoc.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/Ajdoc.java
@@ -169,7 +169,7 @@ public class Ajdoc extends MatchingTask {
 
         Enumeration<FileSet> e = fileSets.elements();
         while (e.hasMoreElements()) {
-            FileSet fs = (FileSet) e.nextElement();
+            FileSet fs = e.nextElement();
             if (!fs.hasPatterns() && !fs.hasSelectors()) {
                 fs = (FileSet) fs.clone();
                 fs.createInclude().setName("**/*.java");

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/compilers/Ajc.java
@@ -137,7 +137,7 @@ public class Ajc extends DefaultCompilerAdapter {
                 argsList.add(args[i]);
             }
         }
-        return (String[])argsList.toArray(new String[0]);
+        return argsList.toArray(new String[0]);
     }
 
     /**

--- a/util/src/main/java/org/aspectj/util/Reflection.java
+++ b/util/src/main/java/org/aspectj/util/Reflection.java
@@ -118,9 +118,9 @@ public class Reflection {
 				// not URL, zip, or dir - unsure what to do
 			}
 		}
-        File[] dirRa = (File[]) dirs.toArray(new File[0]);
-        File[] libRa = (File[]) libs.toArray(new File[0]);
-        URL[] urlRa = (URL[]) urls.toArray(new URL[0]);
+        File[] dirRa = dirs.toArray(new File[0]);
+        File[] libRa = libs.toArray(new File[0]);
+        URL[] urlRa = urls.toArray(new URL[0]);
         runMainInSameVM(urlRa, libRa, dirRa, className, args);
     }
 

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
@@ -2380,7 +2380,7 @@ class BcelClassWeaver implements IClassWeaver {
 					ShadowRange oldRange = (ShadowRange) old;
 					if (oldRange.getStart() == src) {
 						BcelShadow oldShadow = oldRange.getShadow();
-						BcelShadow freshEnclosing = oldShadow.getEnclosingShadow() == null ? null : (BcelShadow) shadowMap
+						BcelShadow freshEnclosing = oldShadow.getEnclosingShadow() == null ? null : shadowMap
 								.get(oldShadow.getEnclosingShadow());
 						BcelShadow freshShadow = oldShadow.copyInto(recipient, freshEnclosing);
 						ShadowRange freshRange = new ShadowRange(recipient.getBody());

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelObjectType.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelObjectType.java
@@ -822,7 +822,7 @@ public class BcelObjectType extends AbstractReferenceTypeDelegate {
 		}
 		if (isGeneric()) {
 			// update resolved typex to point at generic type not raw type.
-			ReferenceType genericType = (ReferenceType) this.resolvedTypeX.getGenericType();
+			ReferenceType genericType = this.resolvedTypeX.getGenericType();
 			// genericType.setSourceContext(this.resolvedTypeX.getSourceContext());
 			// Can be null if unpacking whilst building the bcel delegate (in call hierarchy from BcelWorld.addSourceObjectType()
 			// line 453) - see 317139

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWeaver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWeaver.java
@@ -389,7 +389,7 @@ public class BcelWeaver {
 					Enumeration<JarEntry> entries = inJar.entries();
 
 					while (entries.hasMoreElements()) {
-						JarEntry entry = (JarEntry) entries.nextElement();
+						JarEntry entry = entries.nextElement();
 						InputStream inStream = inJar.getInputStream(entry);
 
 						byte[] bytes = FileUtil.readAsByteArray(inStream);

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/LightXMLParser.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/LightXMLParser.java
@@ -432,7 +432,7 @@ public class LightXMLParser {
 			}
 			buf.append(c);
 		} else {
-			char[] value = (char[]) entities.get(key);
+			char[] value = entities.get(key);
 			if (value == null) {
 				throw new Exception("Unknown entity: " + key);
 			}

--- a/weaver/src/main/java/org/aspectj/weaver/ltw/LTWWorld.java
+++ b/weaver/src/main/java/org/aspectj/weaver/ltw/LTWWorld.java
@@ -230,7 +230,7 @@ public class LTWWorld extends BcelWorld implements IReflectionWorld {
 					typeCompletionInProgress = false;
 				}
 				while (typesForCompletion.size() != 0) {
-					ResolvedType rt = (ResolvedType) typesForCompletion.get(0);
+					ResolvedType rt = typesForCompletion.get(0);
 					completeHierarchyForType(rt);
 					typesForCompletion.remove(0);
 				}


### PR DESCRIPTION
A few PRs with generics were merged. Now code have redundant casts which are now automatically inserted by javac.