### PR TITLE
Reduce 'Object' class usage

### DIFF
--- a/ajde.core/src/main/java/org/aspectj/ajde/core/internal/AjdeCoreBuildManager.java
+++ b/ajde.core/src/main/java/org/aspectj/ajde/core/internal/AjdeCoreBuildManager.java
@@ -167,7 +167,7 @@ public class AjdeCoreBuildManager {
 		+ compilerConfig.getNonStandardOptions() + "\n-> javaoptions:" + formatMap(compilerConfig.getJavaOptionsMap());
 	}
 
-	private String formatCollection(Collection<?> options) {
+	private String formatCollection(Collection<File> options) {
 		if (options == null) {
 			return "<default>";
 		}
@@ -176,7 +176,7 @@ public class AjdeCoreBuildManager {
 		}
 
 		StringBuilder formattedOptions = new StringBuilder();
-		for (Object option : options) {
+		for (File option : options) {
 			String o = option.toString();
 			if (formattedOptions.length() > 0) {
 				formattedOptions.append(", ");

--- a/ajde/src/main/java/org/aspectj/ajde/Ajde.java
+++ b/ajde/src/main/java/org/aspectj/ajde/Ajde.java
@@ -259,9 +259,8 @@ public class Ajde {
 				showWarningMessage("No main class specified");
 			} else {
 				StringBuilder sb = new StringBuilder();
-				List outputDirs = compilerConfig.getOutputLocationManager().getAllOutputLocations();
-				for (Object outputDir : outputDirs) {
-					File dir = (File) outputDir;
+				List<File> outputDirs = compilerConfig.getOutputLocationManager().getAllOutputLocations();
+				for (File dir : outputDirs) {
 					sb.append(dir.getAbsolutePath() + File.pathSeparator);
 				}
 				classpath = LangUtil.makeClasspath(null, compilerConfig.getClasspath(), sb.toString(), compilerConfig.getOutJar());

--- a/ajde/src/main/java/org/aspectj/ajde/ui/internal/TreeStructureViewBuilder.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/internal/TreeStructureViewBuilder.java
@@ -183,7 +183,7 @@ public class TreeStructureViewBuilder {
 				if (properties.getFilteredMemberKinds().contains(pNode.getKind())) {
 					return false;
 				}
-				for (Object element : pNode.getModifiers()) {
+				for (IProgramElement.Modifiers element : pNode.getModifiers()) {
 					if (properties.getFilteredMemberModifiers().contains(element)) {
 						return false;
 					}

--- a/ajde/src/main/java/org/aspectj/ajde/ui/javaoptions/JavaCompilerWarningsOptionsPanel.java
+++ b/ajde/src/main/java/org/aspectj/ajde/ui/javaoptions/JavaCompilerWarningsOptionsPanel.java
@@ -65,11 +65,10 @@ public class JavaCompilerWarningsOptionsPanel extends OptionsPanel {
 	}
 
 	public void saveOptions() throws IOException {
-		Set s = warningComboBoxes.entrySet();
-		for (Object o : s) {
-			Entry entry = (Entry) o;
-			String javaOption = (String) entry.getKey();
-			JComboBox combo = (JComboBox) entry.getValue();
+		Set<Entry<String, JComboBox>> s = warningComboBoxes.entrySet();
+		for (Entry<String, JComboBox> entry : s) {
+			String javaOption = entry.getKey();
+			JComboBox combo = entry.getValue();
 			String value = (String) combo.getSelectedItem();
 			javaBuildOptions.setOption(javaOption, value);
 		}

--- a/asm/src/main/java/org/aspectj/asm/AsmManager.java
+++ b/asm/src/main/java/org/aspectj/asm/AsmManager.java
@@ -551,7 +551,7 @@ public class AsmManager implements IStructureModel {
 		Set<String> deletedNodes = new HashSet<>();
 		for (File fileForCompilation : files) {
 			String correctedPath = getCanonicalFilePath(fileForCompilation);
-			IProgramElement progElem = (IProgramElement) hierarchy.findInFileMap(correctedPath);
+			IProgramElement progElem = hierarchy.findInFileMap(correctedPath);
 			if (progElem != null) {
 				// Found it, let's remove it
 				if (dumpDeltaProcessing) {

--- a/asm/src/main/java/org/aspectj/asm/IHierarchy.java
+++ b/asm/src/main/java/org/aspectj/asm/IHierarchy.java
@@ -45,7 +45,7 @@ public interface IHierarchy extends Serializable {
 		setFileMap((Map<String, IProgramElement>) fileMap);
 	}
 
-	Object findInFileMap(Object key);
+	IProgramElement findInFileMap(String key);
 
 	Set<Map.Entry<String, IProgramElement>> getFileMapEntrySet();
 

--- a/asm/src/main/java/org/aspectj/asm/internal/AspectJElementHierarchy.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/AspectJElementHierarchy.java
@@ -100,7 +100,7 @@ public class AspectJElementHierarchy implements IHierarchy {
 		this.fileMap = fileMap;
 	}
 
-	public Object findInFileMap(Object key) {
+	public IProgramElement findInFileMap(String key) {
 		return fileMap.get(key);
 	}
 
@@ -331,7 +331,7 @@ public class AspectJElementHierarchy implements IHierarchy {
 			} else {
 				String correctedPath = asm.getCanonicalFilePath(new File(sourceFile));
 				// StructureNode node = (StructureNode)getFileMap().get(correctedPath);//findFileNode(filePath, model);
-				IProgramElement node = (IProgramElement) findInFileMap(correctedPath);// findFileNode(filePath, model);
+				IProgramElement node = findInFileMap(correctedPath);// findFileNode(filePath, model);
 				if (node != null) {
 					return node;
 				} else {

--- a/build/src/main/java/$installer$/org/aspectj/Main.java
+++ b/build/src/main/java/$installer$/org/aspectj/Main.java
@@ -839,7 +839,7 @@ abstract class WizardPane {
 			buf.append(text.substring(lastIndex, startIndex));
 			String key = text.substring(startIndex + 2, endIndex);
 			lastIndex = endIndex + 1;
-			Object replaceText = (map == null ? null : map.get(key));
+			String replaceText = (map == null ? null : map.get(key));
 			//System.out.println("key: " + key + " -> " + replaceText);
 			if (replaceText == null) {
 				replaceText = "NOT_FOUND";

--- a/build/src/main/java/org/aspectj/internal/tools/build/Builder.java
+++ b/build/src/main/java/org/aspectj/internal/tools/build/Builder.java
@@ -180,7 +180,7 @@ public abstract class Builder {
 
     private final File tempDir;
 
-    private final List tempFiles;
+    private final List<File> tempFiles;
 
     private final boolean useEclipseCompiles;
 
@@ -190,7 +190,7 @@ public abstract class Builder {
         Util.iaxIfNull(handler, "handler");
         this.useEclipseCompiles = useEclipseCompiles;
         this.handler = handler;
-        this.tempFiles = new ArrayList();
+        this.tempFiles = new ArrayList<>();
         if ((null == tempDir) || !tempDir.canWrite() || !tempDir.isDirectory()) {
             this.tempDir = Util.makeTempDir("Builder");
         } else {
@@ -293,8 +293,7 @@ public abstract class Builder {
      */
     public boolean cleanup() {
         boolean noErr = true;
-		for (Object tempFile : tempFiles) {
-			File file = (File) tempFile;
+		for (File file : tempFiles) {
 			if (!Util.deleteContents(file) || !file.delete()) {
 				if (noErr) {
 					noErr = false;

--- a/build/src/main/java/org/aspectj/internal/tools/build/SampleGatherer.java
+++ b/build/src/main/java/org/aspectj/internal/tools/build/SampleGatherer.java
@@ -804,10 +804,9 @@ class SampleUtil {
     public static final String SAMPLE_BASE_DIR_NAME = "sandbox";
 
     public static void simpleRender(Samples result, StringBuffer sink) {
-        List sortedSamples = result.getSortedSamples();
+        List<Sample> sortedSamples = result.getSortedSamples();
         int i = 0;
-		for (Object sortedSample : sortedSamples) {
-			Sample sample = (Sample) sortedSample;
+		for (Sample sample : sortedSamples) {
 			sink.append(i++ + ": " + sample);
 		}
     }

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/Aj.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/Aj.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.aspectj.weaver.loadtime;
 
+import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.security.ProtectionDomain;
@@ -46,7 +47,7 @@ public class Aj implements ClassPreProcessor {
 	 * should tidy up the adaptor map and remove the adaptor (weaver) from the map we are maintaining from adaptorkey &gt; adaptor
 	 * (weaver)
 	 */
-	private static ReferenceQueue adaptorQueue = new ReferenceQueue();
+	private static ReferenceQueue<ClassLoader> adaptorQueue = new ReferenceQueue<>();
 
 	private static Trace trace = TraceFactory.getTraceFactory().getTrace(Aj.class);
 
@@ -198,11 +199,11 @@ public class Aj implements ClassPreProcessor {
 				System.err.println("Weaver adaptors before queue processing:");
 				Map<AdaptorKey,ExplicitlyInitializedClassLoaderWeavingAdaptor> m = WeaverContainer.weavingAdaptors;
 				Set<AdaptorKey> keys = m.keySet();
-				for (Object object : keys) {
+				for (AdaptorKey object : keys) {
 					System.err.println(object + " = " + WeaverContainer.weavingAdaptors.get(object));
 				}
 			}
-			Object o = adaptorQueue.poll();
+			Reference<?> o = adaptorQueue.poll();
 			while (o != null) {
 				if (displayProgress)
 					System.err.println("Processing referencequeue entry " + o);
@@ -221,7 +222,7 @@ public class Aj implements ClassPreProcessor {
 				System.err.println("Weaver adaptors after queue processing:");
 				Map<AdaptorKey,ExplicitlyInitializedClassLoaderWeavingAdaptor> m = WeaverContainer.weavingAdaptors;
 				Set<AdaptorKey> keys = m.keySet();
-				for (Object object : keys) {
+				for (AdaptorKey object : keys) {
 					System.err.println(object + " = " + WeaverContainer.weavingAdaptors.get(object));
 				}
 			}
@@ -242,7 +243,7 @@ public class Aj implements ClassPreProcessor {
 	 */
 	public static void checkQ() {
 		synchronized (adaptorQueue) {
-			Object o = adaptorQueue.poll();
+			Reference<?> o = adaptorQueue.poll();
 			while (o != null) {
 				AdaptorKey wo = (AdaptorKey) o;
 				// boolean removed =

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
@@ -68,6 +68,7 @@ import org.aspectj.weaver.bcel.BcelAnnotation;
 import org.aspectj.weaver.bcel.BcelObjectType;
 import org.aspectj.weaver.bcel.FakeAnnotation;
 import org.aspectj.weaver.bcel.LazyClassGen;
+import org.aspectj.weaver.patterns.Declare;
 import org.aspectj.weaver.patterns.DeclareAnnotation;
 import org.aspectj.weaver.patterns.DeclareParents;
 
@@ -757,7 +758,7 @@ public class AjLookupEnvironment extends LookupEnvironment implements AnonymousC
 				}
 			}
 
-			List<Object> forRemoval = new ArrayList<>();
+			List<Declare> forRemoval = new ArrayList<>();
 			// now lets loop over and over until we have done all we can
 			while ((anyNewAnnotations || anyNewParents) && (!decpToRepeat.isEmpty() || !decaToRepeat.isEmpty())) {
 				anyNewParents = anyNewAnnotations = false;

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
@@ -489,7 +489,7 @@ public class AjProblemReporter extends ProblemReporter {
 			AspectDeclaration ad = (AspectDeclaration) typeDecl.enclosingType;
 			if (ad.concreteName != null) {
 				List<Declare> declares = ad.concreteName.declares;
-				for (Object dec : declares) {
+				for (Declare dec : declares) {
 					if (dec instanceof DeclareParents) {
 						DeclareParents decp = (DeclareParents) dec;
 						TypePattern[] newparents = decp.getParents().getTypePatterns();

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
@@ -536,9 +536,8 @@ public class AjBuildConfig implements CompilerConfigurationChangeFlags {
 		setMakeReflectable(global.isMakeReflectable());
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	void join(Collection local, Collection global) {
-		for (Object next : global) {
+	<T> void join(Collection<T> local, Collection<T> global) {
+		for (T next : global) {
 			if (!local.contains(next)) {
 				local.add(next);
 			}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
@@ -678,14 +678,13 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
         }
 	}
 
-	private ByteArrayOutputStream getOutxmlContents(List aspectNames) {
+	private ByteArrayOutputStream getOutxmlContents(List<String> aspectNames) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		PrintStream ps = new PrintStream(baos);
 		ps.println("<aspectj>");
 		ps.println("<aspects>");
 		if (aspectNames != null) {
-            for (Object aspectName : aspectNames) {
-                String name = (String) aspectName;
+            for (String name : aspectNames) {
                 ps.println("<aspect name=\"" + name + "\"/>");
             }
 		}
@@ -719,9 +718,8 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
 			}
 			outputDirsToAspects.put(outputDir, aspectNames);
 		} else {
-			List outputDirs = buildConfig.getCompilationResultDestinationManager().getAllOutputLocations();
-            for (Object dir : outputDirs) {
-                File outputDir = (File) dir;
+			List<File> outputDirs = buildConfig.getCompilationResultDestinationManager().getAllOutputLocations();
+            for (File outputDir : outputDirs) {
                 outputDirsToAspects.put(outputDir, new ArrayList<>());
             }
 			if (aspectNamesToFileNames != null) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjCompilerOptions.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjCompilerOptions.java
@@ -152,7 +152,7 @@ public class AjCompilerOptions extends CompilerOptions {
 	@Override
 	public void set(Map<String,String> optionsMap) {
 		super.set(optionsMap);
-		Object optionValue;
+		String optionValue;
 		if ((optionValue = optionsMap.get(OPTION_ReportUnusedPrivateMember)) != null) {
 			updateSeverity(UnusedPrivateMember, optionValue);
 		}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
@@ -974,7 +974,7 @@ public class AjState implements CompilerConfigurationChangeFlags, TypeDelegateRe
 	 * @param outputLocs the output locations that should be ignored if they occur on the paths being compared
 	 * @return true if a change is detected that requires a full build
 	 */
-	private boolean changedAndNeedsFullBuild(List oldPath, List newPath, boolean checkClassFiles, List<File> outputLocs,
+	private boolean changedAndNeedsFullBuild(List<File> oldPath, List<File> newPath, boolean checkClassFiles, List<File> outputLocs,
 			Set<String> alreadyAnalysedPaths, int pathid) {
 		if (oldPath.size() != newPath.size()) {
 			return true;
@@ -983,13 +983,7 @@ public class AjState implements CompilerConfigurationChangeFlags, TypeDelegateRe
 			if (!oldPath.get(i).equals(newPath.get(i))) {
 				return true;
 			}
-			Object o = oldPath.get(i); // String on classpath, File on other paths
-			File f = null;
-			if (o instanceof String) {
-				f = new File((String) o);
-			} else {
-				f = (File) o;
-			}
+			File f = oldPath.get(i);
 			if (f.exists() && !f.isDirectory() && (f.lastModified() >= lastSuccessfulBuildTime)) {
 				return true;
 			}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/EmacsStructureModelManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/EmacsStructureModelManager.java
@@ -42,8 +42,8 @@ public class EmacsStructureModelManager {
 		try {
 			// Set fileSet = StructureModelManager.INSTANCE.getStructureModel().getFileMap().entrySet();
 			Set<Map.Entry<String, IProgramElement>> fileSet = model.getHierarchy().getFileMapEntrySet();
-			for (Object o : fileSet) {
-				IProgramElement peNode = (IProgramElement) ((Map.Entry) o).getValue();
+			for (Map.Entry<String, IProgramElement> o : fileSet) {
+				IProgramElement peNode = o.getValue();
 				dumpStructureToFile(peNode);
 			}
 		} catch (IOException ioe) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjNaiveASTFlattener.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/org/eclipse/jdt/core/dom/AjNaiveASTFlattener.java
@@ -83,9 +83,8 @@ public class AjNaiveASTFlattener extends AjASTVisitor {
 	 * @param ext the list of modifier and annotation nodes
 	 * (element type: <code>IExtendedModifiers</code>)
 	 */
-	void printModifiers(List ext) {
-		for (Object o : ext) {
-			ASTNode p = (ASTNode) o;
+	void printModifiers(List<ASTNode> ext) {
+		for (ASTNode p : ext) {
 			p.accept(this);
 			this.buffer.append(" ");//$NON-NLS-1$
 		}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembers.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembers.java
@@ -340,8 +340,8 @@ public class CrosscuttingMembers {
 		// if we dont care about shadow mungers then ignore those
 		// typeMungers which are created to help with the implementation
 		// of shadowMungers
-		Set<Object> theseTypeMungers = new HashSet<>();
-		Set<Object> otherTypeMungers = new HashSet<>();
+		Set<ConcreteTypeMunger> theseTypeMungers = new HashSet<>();
+		Set<ConcreteTypeMunger> otherTypeMungers = new HashSet<>();
 		if (!careAboutShadowMungers) {
 			for (ConcreteTypeMunger typeMunger : typeMungers) {
 				if (!typeMunger.existsToSupportShadowMunging()) {
@@ -367,17 +367,17 @@ public class CrosscuttingMembers {
 		} else {
 			boolean shouldOverwriteThis = false;
 			boolean foundInequality = false;
-			for (Iterator<Object> iter = theseTypeMungers.iterator(); iter.hasNext() && !foundInequality;) {
-				Object thisOne = iter.next();
+			for (Iterator<ConcreteTypeMunger> iter = theseTypeMungers.iterator(); iter.hasNext() && !foundInequality;) {
+				ConcreteTypeMunger thisOne = iter.next();
 				boolean foundInOtherSet = false;
-				for (Object otherOne : otherTypeMungers) {
+				for (ConcreteTypeMunger otherOne : otherTypeMungers) {
 					if (thisOne instanceof ConcreteTypeMunger) {
-						if (((ConcreteTypeMunger) thisOne).shouldOverwrite()) {
+						if (thisOne.shouldOverwrite()) {
 							shouldOverwriteThis = true;
 						}
 					}
 					if (thisOne instanceof ConcreteTypeMunger && otherOne instanceof ConcreteTypeMunger) {
-						if (((ConcreteTypeMunger) thisOne).equivalentTo(otherOne)) {
+						if (thisOne.equivalentTo(otherOne)) {
 							foundInOtherSet = true;
 						} else if (thisOne.equals(otherOne)) {
 							foundInOtherSet = true;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Shadow.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/Shadow.java
@@ -576,8 +576,8 @@ public abstract class Shadow {
 			// Compare every pair of advice mungers
 			for (int i = max - 1; i >= 0; i--) {
 				for (int j = 0; j < i; j++) {
-					Object a = mungers.get(i);
-					Object b = mungers.get(j);
+					ShadowMunger a = mungers.get(i);
+					ShadowMunger b = mungers.get(j);
 
 					// Make sure they are the right type
 					if (a instanceof Advice && b instanceof Advice) {

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcCompilerAdapter.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcCompilerAdapter.java
@@ -12,6 +12,7 @@
 
 package org.aspectj.tools.ant.taskdefs;
 
+import org.apache.tools.ant.Task;
 import org.apache.tools.ant.taskdefs.Javac;
 import org.apache.tools.ant.taskdefs.compilers.CompilerAdapter;
 import org.apache.tools.ant.BuildException;
@@ -40,7 +41,7 @@ public class AjcCompilerAdapter implements CompilerAdapter {
         if (null == javac) {
             throw new IllegalArgumentException("null javac");
         }
-        Object task = javac.getProject().createTask("ajc");
+        Task task = javac.getProject().createTask("ajc");
         String err = null;
         if (null == task) {
             err = "ajc not defined - put ajc taskdef library on classpath";

--- a/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
+++ b/taskdefs/src/main/java/org/aspectj/tools/ant/taskdefs/AjcTask.java
@@ -1166,7 +1166,7 @@ public class AjcTask extends MatchingTask {
 	// package-private for testing
 	String[] makeCommand() {
 		if (0 < ignored.size()) {
-            for (Object o : ignored) {
+            for (String o : ignored) {
                 logVerbose("ignored: " + o);
             }
 		}


### PR DESCRIPTION
Some code in AspectJ still uses `Object` types, where more strict type is known.
I propose to cleanup such usages.
They are seems leftovers after generic introduction. 