### PR TITLE
Avoid calling SoftReference.get() twice

### DIFF
--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassLoaderRepository.java
@@ -214,10 +214,7 @@ public class ClassLoaderRepository implements Repository {
 			SpecialValue value = map.remove(k);
 			if (value == null)
 				return null;
-			if (value.get() != null) {
-				return value.get();
-			}
-			return null;
+			return value.get();
 		}
 	}
 

--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/NonCachingClassLoaderRepository.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/NonCachingClassLoaderRepository.java
@@ -164,10 +164,7 @@ public class NonCachingClassLoaderRepository implements Repository {
 			SpecialValue value = map.remove(k);
 			if (value == null)
 				return null;
-			if (value.get() != null) {
-				return value.get();
-			}
-			return null;
+			return value.get();
 		}
 	}
 

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjState.java
@@ -706,10 +706,7 @@ public class AjState implements CompilerConfigurationChangeFlags, TypeDelegateRe
 			if (value == null) {
 				return null;
 			}
-			if (value.get() != null) {
-				return value.get();
-			}
-			return null;
+			return value.get();
 		}
 	}
 


### PR DESCRIPTION
SoftReference.get() is not supposed to be called more than once. It's because between two `.get()` calls GC could clear the reference and code could get an expected result.
In AspectJ it called twice in a few places, which we could easily update.