### PR TITLE
Do not use String literal as synchronized lock

### DIFF
--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
@@ -1131,7 +1131,7 @@ public class ClassLoaderWeavingAdaptor extends WeavingAdaptor {
 		}
 	}
 	static Method defineClassMethod;
-	private static String lock = "lock";
+	private static final Object lock = new Object();
 
 
 //    /*


### PR DESCRIPTION
Synchronizing on a String literal is dangerous anti-pattern. String literals are interned by VM and any code that uses the same literal gets the same java object.