### PR TITLE
Cleanup redundant null check before instanceof

### DIFF
--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/InterimCompilationResult.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/InterimCompilationResult.java
@@ -56,7 +56,7 @@ public class InterimCompilationResult {
 	}
 
 	public boolean equals(Object other) {
-		if (other == null || !(other instanceof InterimCompilationResult)) {
+		if (!(other instanceof InterimCompilationResult)) {
 			return false;
 		}
 		InterimCompilationResult ir = (InterimCompilationResult) other;

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ProceedVisitor.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ProceedVisitor.java
@@ -83,9 +83,8 @@ public class ProceedVisitor extends ASTVisitor {
 
 	boolean isRef(Expression expr, Binding binding) {
 		//System.err.println("isRef: " + expr + ", " + binding);
-		return expr != null
-			&& expr instanceof NameReference
-			&& isRef((NameReference) expr, binding);
+		return expr instanceof NameReference
+				&& isRef((NameReference)expr, binding);
 	}
 
 	public void endVisit(SingleNameReference ref, BlockScope scope) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ThisJoinPointVisitor.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ThisJoinPointVisitor.java
@@ -102,7 +102,7 @@ public class ThisJoinPointVisitor extends ASTVisitor {
 	}
 
 	boolean isRef(Expression expr, Binding binding) {
-		return expr != null && expr instanceof NameReference && isRef((NameReference) expr, binding);
+		return expr instanceof NameReference && isRef((NameReference)expr, binding);
 	}
 
 	public void endVisit(SingleNameReference ref, BlockScope scope) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/problem/AjProblemReporter.java
@@ -485,7 +485,7 @@ public class AjProblemReporter extends ProblemReporter {
 		// don't output unused type warnings for aspects!
 		if (typeDecl instanceof AspectDeclaration)
 			return;
-		if (typeDecl.enclosingType != null && (typeDecl.enclosingType instanceof AspectDeclaration)) {
+		if (typeDecl.enclosingType instanceof AspectDeclaration) {
 			AspectDeclaration ad = (AspectDeclaration) typeDecl.enclosingType;
 			if (ad.concreteName != null) {
 				List<Declare> declares = ad.concreteName.declares;
@@ -609,7 +609,7 @@ public class AjProblemReporter extends ProblemReporter {
 			Argument arg = (Argument) localDecl;
 			if (arg.binding != null && arg.binding.declaringScope != null) {
 				ReferenceContext context = arg.binding.declaringScope.referenceContext();
-				if (context != null && context instanceof PointcutDeclaration)
+				if (context instanceof PointcutDeclaration)
 					return;
 			}
 		}

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildConfig.java
@@ -115,7 +115,7 @@ public class AjBuildConfig implements CompilerConfigurationChangeFlags {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj != null && (obj instanceof BinarySourceFile)) {
+			if (obj instanceof BinarySourceFile) {
 				BinarySourceFile other = (BinarySourceFile) obj;
 				return (binSrc.equals(other.binSrc));
 			}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembers.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembers.java
@@ -188,7 +188,7 @@ public class CrosscuttingMembers {
 		String signatureToLookFor = typeToExpose.getSignature();
 		for (ConcreteTypeMunger cTM : typeMungers) {
 			ResolvedTypeMunger rTM = cTM.getMunger();
-			if (rTM != null && rTM instanceof ExposeTypeMunger) {
+			if (rTM instanceof ExposeTypeMunger) {
 				String exposedType = ((ExposeTypeMunger) rTM).getExposedTypeSignature();
 				if (exposedType.equals(signatureToLookFor)) {
 					return; // dont need to bother

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/PerObjectInterfaceTypeMunger.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/PerObjectInterfaceTypeMunger.java
@@ -27,7 +27,7 @@ public class PerObjectInterfaceTypeMunger extends ResolvedTypeMunger {
 	private TypePattern lazyTestTypePattern;
 
 	public boolean equals(Object other) {
-		if (other == null || !(other instanceof PerObjectInterfaceTypeMunger)) {
+		if (!(other instanceof PerObjectInterfaceTypeMunger)) {
 			return false;
 		}
 		PerObjectInterfaceTypeMunger o = (PerObjectInterfaceTypeMunger) other;

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/DefaultCacheKeyResolver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/DefaultCacheKeyResolver.java
@@ -55,7 +55,7 @@ public class DefaultCacheKeyResolver implements CacheKeyResolver {
 		StringBuilder hashable = new StringBuilder(256);
 
 		// Add the list of loader urls to the hash list
-		if (cl != null && cl instanceof URLClassLoader) {
+		if (cl instanceof URLClassLoader) {
 			URL[] urls = ((URLClassLoader) cl).getURLs();
 			for (URL url : urls) {
 				hashableStrings.add(url.toString());


### PR DESCRIPTION
`instanceof` returns `false` for `null`. So separate null check is redundant.