### PR TITLE
Add docs/dist/LICENSE-AspectJ.html to all public artifacts

### DIFF
--- a/aspectjmatcher/aspectjmatcher-assembly.xml
+++ b/aspectjmatcher/aspectjmatcher-assembly.xml
@@ -12,6 +12,13 @@
 
 	<fileSets>
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+		<fileSet>
 			<directory>../util/target/classes</directory>
 			<outputDirectory>.</outputDirectory>
 			<excludes>
@@ -35,4 +42,3 @@
 	</fileSets>
 
 </assembly>
-

--- a/aspectjmatcher/aspectjmatcher-sources-assembly.xml
+++ b/aspectjmatcher/aspectjmatcher-sources-assembly.xml
@@ -13,6 +13,13 @@
 
 	<fileSets>
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+		<fileSet>
 			<directory>../util/src/main/java</directory>
 			<outputDirectory>.</outputDirectory>
 		</fileSet>
@@ -27,4 +34,3 @@
 	</fileSets>
 
 </assembly>
-

--- a/aspectjrt/aspectjrt-assembly.xml
+++ b/aspectjrt/aspectjrt-assembly.xml
@@ -12,6 +12,13 @@
 
 	<fileSets>
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+		<fileSet>
 			<directory>../runtime/target/classes</directory>
 			<outputDirectory>.</outputDirectory>
 			<excludes>
@@ -21,4 +28,3 @@
 	</fileSets>
 
 </assembly>
-

--- a/aspectjrt/aspectjrt-sources-assembly.xml
+++ b/aspectjrt/aspectjrt-sources-assembly.xml
@@ -13,6 +13,13 @@
 
 	<fileSets>
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+		<fileSet>
 			<directory>../runtime/src/main/java</directory>
 			<outputDirectory>.</outputDirectory>
 			<excludes>
@@ -29,4 +36,3 @@
 	</fileSets>
 
 </assembly>
-

--- a/aspectjtools/aspectjtools-assembly.xml
+++ b/aspectjtools/aspectjtools-assembly.xml
@@ -23,6 +23,14 @@
 	</dependencySets>
 
 	<fileSets>
+		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+
 		<!-- runtime -->
 		<fileSet>
 			<directory>../runtime/target/classes</directory>

--- a/aspectjtools/aspectjtools-sources-assembly.xml
+++ b/aspectjtools/aspectjtools-sources-assembly.xml
@@ -14,6 +14,14 @@
 	<fileSets>
 
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+
+		<fileSet>
 			<directory>../weaver/src/main/java</directory>
 			<outputDirectory>.</outputDirectory>
 		</fileSet>

--- a/aspectjweaver/aspectjweaver-assembly.xml
+++ b/aspectjweaver/aspectjweaver-assembly.xml
@@ -23,6 +23,13 @@
 
 	<fileSets>
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+		<fileSet>
 			<directory>../weaver/target/classes</directory>
 			<outputDirectory>.</outputDirectory>
 			<excludes>
@@ -81,4 +88,3 @@
 	</fileSets>
 
 </assembly>
-

--- a/aspectjweaver/aspectjweaver-sources-assembly.xml
+++ b/aspectjweaver/aspectjweaver-sources-assembly.xml
@@ -13,6 +13,13 @@
 
 	<fileSets>
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+		<fileSet>
 			<directory>../weaver/src/main/java</directory>
 			<outputDirectory>.</outputDirectory>
 		</fileSet>
@@ -52,4 +59,3 @@
 	</fileSets>
 
 </assembly>
-

--- a/installer/aspectjinstaller-assembly.xml
+++ b/installer/aspectjinstaller-assembly.xml
@@ -12,6 +12,13 @@
 
 	<fileSets>
 		<fileSet>
+			<directory>../docs/dist</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>LICENSE-AspectJ.html</include>
+			</includes>
+		</fileSet>
+		<fileSet>
 			<directory>../build/target/classes</directory>
 			<outputDirectory>.</outputDirectory>
 			<excludes>
@@ -48,4 +55,3 @@
 	</files>
 
 </assembly>
-


### PR DESCRIPTION
The license file will be included right in the main directory of both binary and source artifacts for
  - AspectJ Matcher,
  - AspectJ Runtime,
  - AspectJ Weaver,
  - AspectJ Tools (Compiler),
  - AspectJ Installer.

Fixes #185.