### PR TITLE
Fix #366085 concerning declared annotations with source retention

### DIFF
--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareAnnotation.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/DeclareAnnotation.java
@@ -380,6 +380,8 @@ public class DeclareAnnotation extends Declare {
 				int idx = 0;
 				if (annos.length > 0
 						&& annos[0].getType().getSignature().equals("Lorg/aspectj/internal/lang/annotation/ajcDeclareAnnotation;")) {
+					if (annos.length < 2)
+						continue;
 					idx = 1;
 				}
 				annotation = annos[idx];
@@ -441,6 +443,8 @@ public class DeclareAnnotation extends Declare {
 					int idx = 0;
 					if (annoTypes[0].getSignature().equals("Lorg/aspectj/internal/lang/annotation/ajcDeclareAnnotation;")) {
 						idx = 1;
+						if (annoTypes.length < 2)
+							continue;
 					}
 					annotationType = annoTypes[idx];
 					break;

--- a/tests/bugs1919/366085/Application.java
+++ b/tests/bugs1919/366085/Application.java
@@ -1,0 +1,11 @@
+public class Application {
+  public int number;
+
+  public Application(int number) {
+    this.number = number;
+  }
+
+  public int getNumber() {
+    return number;
+  }
+}

--- a/tests/bugs1919/366085/DeclareAnnotationsAspect.aj
+++ b/tests/bugs1919/366085/DeclareAnnotationsAspect.aj
@@ -1,0 +1,13 @@
+public aspect DeclareAnnotationsAspect {
+  // These should be ignored, because @ToString has SOURCE retention
+  declare @type : Application : @ToString;
+  declare @method : * Application.*(..) : @ToString;
+  declare @constructor : Application.new(..) : @ToString;
+  declare @field : * Application.* : @ToString;
+
+  // These should be applied, because @Marker has RUNTIME retention
+  declare @type : Application : @Marker;
+  declare @method : * Application.*(..) : @Marker;
+  declare @constructor : Application.new(..) : @Marker;
+  declare @field : * Application.* : @Marker;
+}

--- a/tests/bugs1919/366085/Marker.java
+++ b/tests/bugs1919/366085/Marker.java
@@ -1,0 +1,4 @@
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Marker { }

--- a/tests/bugs1919/366085/ToString.java
+++ b/tests/bugs1919/366085/ToString.java
@@ -1,0 +1,4 @@
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+@Retention(RetentionPolicy.SOURCE)
+public @interface ToString { }

--- a/tests/src/test/java/org/aspectj/systemtest/ajc1919/Bugs1919Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc1919/Bugs1919Tests.java
@@ -15,8 +15,8 @@ import org.aspectj.testing.XMLBasedAjcTestCase;
  */
 public class Bugs1919Tests extends XMLBasedAjcTestCase {
 
-  public void testDummyBug() {
-    //runTest("dummy Java 19 bug");
+  public void testDeclareAnnotationWithSourceRetention() {
+    runTest("declare annotation with SOURCE retention");
   }
 
   public static Test suite() {

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1919/ajc1919.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1919/ajc1919.xml
@@ -162,8 +162,14 @@
 		</run>
 	</ajc-test>
 
-	<!-- Currently, there are no bugfixes with tests in this AspectJ vesion -->
-	<ajc-test dir="bugs1919/github_99999" vm="19" title="dummy Java 19">
-	</ajc-test>
+	<!-- Weaver error when declaring annotation with SOURCE retention, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=366085 -->
+	 <ajc-test dir="bugs1919/366085" vm="1.5" title="declare annotation with SOURCE retention">
+		 <compile files="Application.java DeclareAnnotationsAspect.aj ToString.java Marker.java" options="-1.5 -showWeaveInfo">
+			 <message kind="weave" text="'Application' (Application.java:1) is annotated with @Marker type annotation from 'DeclareAnnotationsAspect'"/>
+			 <message kind="weave" text="'public void Application.new(int)' (Application.java:4) is annotated with @Marker constructor annotation from 'DeclareAnnotationsAspect'"/>
+			 <message kind="weave" text="'public int Application.getNumber()' (Application.java:8) is annotated with @Marker method annotation from 'DeclareAnnotationsAspect'"/>
+			 <message kind="weave" text="'public int number' of type 'Application' (Application.java) is annotated with @Marker field annotation from 'DeclareAnnotationsAspect'"/>
+		 </compile>
+		</ajc-test>
 
 </suite>

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelClassWeaver.java
@@ -1023,7 +1023,12 @@ class BcelClassWeaver implements IClassWeaver {
 							if (annotationsToAdd == null) {
 								annotationsToAdd = new ArrayList<>();
 							}
-							AnnotationGen a = ((BcelAnnotation) decaM.getAnnotation()).getBcelAnnotation();
+							BcelAnnotation decaMAnnotation = (BcelAnnotation) decaM.getAnnotation();
+							if (decaMAnnotation == null) {
+								unusedDecams.remove(decaM);
+								continue;
+							}
+							AnnotationGen a = decaMAnnotation.getBcelAnnotation();
 							AnnotationGen ag = new AnnotationGen(a, clazz.getConstantPool(), true);
 							annotationsToAdd.add(ag);
 							mg.addAnnotation(decaM.getAnnotation());
@@ -1423,7 +1428,8 @@ class BcelClassWeaver implements IClassWeaver {
 					// go through all the declare @field statements
 					for (DeclareAnnotation decaf : decafs) {
 						if (decaf.getAnnotation() == null) {
-							return false;
+							unusedDecafs.remove(decaf);
+							continue;
 						}
 						if (decaf.matches(field, world)) {
 							if (decaf.isRemover()) {


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=366085.
See https://stackoverflow.com/q/74618269/1082681.

The issue described in the Bugzilla issue is about `declare @type`, but similar issues also existed for `declare @field`, `declare @method`, `declare @constructor`. This fix is rather superficial and leaves things to be desired, because it is rather hacky and simply ignores errors source retention annotation declarations during weaving. A better fix would drop the corresponding declarations while parsing and also issue compiler warnings in each case.

@aclement, please do take some time to review this PR, before I merge in into the _java-19_ branch. Sorry for not creating a separate branch against master in this case, but in the Java 19 branch I already have the infrastructure for new tests and could just easily add it one more test case. By all means, if you can come up with a better way of solving this, I will be happy to drop this commit. You may also commit on top of this PR, if you choose to do so - whatever suits your needs.