### PR TITLE
Avoid compiler errors for implicitly static inner aspects of interfaces

### DIFF
--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AspectDeclaration.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AspectDeclaration.java
@@ -155,7 +155,12 @@ public class AspectDeclaration extends TypeDeclaration {
 		}
 
 		if (this.enclosingType != null) {
-			if (!Modifier.isStatic(modifiers)) {
+			if (
+				!Modifier.isStatic(modifiers) &&
+				// Inner classes/aspects of interfaces are implicitly static,
+				// see https://github.com/eclipse/org.aspectj/issues/162
+				(this.enclosingType.modifiers & ClassFileConstants.AccInterface) == 0
+			) {
 				scope.problemReporter().signalError(sourceStart, sourceEnd, "inner aspects must be static");
 				ignoreFurtherInvestigation = true;
 				return;

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ValidateAtAspectJAnnotationsVisitor.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/ValidateAtAspectJAnnotationsVisitor.java
@@ -36,6 +36,7 @@ import org.aspectj.org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.aspectj.org.eclipse.jdt.internal.compiler.ast.StringLiteral;
 import org.aspectj.org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.aspectj.org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.aspectj.org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.aspectj.org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.aspectj.org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.aspectj.org.eclipse.jdt.internal.compiler.lookup.BlockScope;
@@ -230,7 +231,12 @@ public class ValidateAtAspectJAnnotationsVisitor extends ASTVisitor {
 	private void validateAspectDeclaration(TypeDeclaration typeDecl) {
 		if (typeStack.size() > 1) {
 			// it's a nested aspect
-			if (!Modifier.isStatic(typeDecl.modifiers)) {
+			if (
+				!Modifier.isStatic(typeDecl.modifiers) &&
+				// Inner classes/aspects of interfaces are implicitly static,
+				// see https://github.com/eclipse/org.aspectj/issues/162
+				(typeDecl.enclosingType.modifiers & ClassFileConstants.AccInterface) == 0
+			) {
 				typeDecl.scope.problemReporter().signalError(typeDecl.sourceStart, typeDecl.sourceEnd,
 						"inner aspects must be static");
 				return;

--- a/tests/bugs1919/github_162/InterfaceWithInnerClass.java
+++ b/tests/bugs1919/github_162/InterfaceWithInnerClass.java
@@ -1,0 +1,32 @@
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.JoinPoint;
+
+/**
+ * https://github.com/eclipse/org.aspectj/issues/162
+ */
+public interface InterfaceWithInnerClass {
+  public class ImplicitlyStatic {
+    public int getNumber() {
+      return 11;
+    }
+
+    public static void main(String[] args) {
+      System.out.println(new ImplicitlyStatic().getNumber());
+    }
+  }
+
+  /*static*/ aspect MyAspect {
+    before() : execution(* main(..)) {
+      System.out.println(thisJoinPoint);
+    }
+  }
+
+  @Aspect
+  /*static*/ class MyAnnotationAspect {
+    @Before("execution(* getNumber(..))")
+    public void myAdvice(JoinPoint thisJoinPoint){
+      System.out.println(thisJoinPoint);
+    }
+  }
+}

--- a/tests/src/test/java/org/aspectj/systemtest/ajc1919/Bugs1919Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc1919/Bugs1919Tests.java
@@ -27,6 +27,10 @@ public class Bugs1919Tests extends XMLBasedAjcTestCase {
     runTest("parenthesised expression with AspectJ keyword");
   }
 
+  public void testInterfaceInnerAspectImplicitlyStatic() {
+    runTest("inner aspect of interface is implicitly static");
+  }
+
   public static Test suite() {
     return XMLBasedAjcTestCase.loadSuite(Bugs1919Tests.class);
   }

--- a/tests/src/test/java/org/aspectj/systemtest/ajc1919/Bugs1919Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc1919/Bugs1919Tests.java
@@ -19,11 +19,11 @@ public class Bugs1919Tests extends XMLBasedAjcTestCase {
     runTest("declare annotation with SOURCE retention");
   }
 
-  public void testsSwitchWith_Integer_MAX_VALUE() {
+  public void testSwitchWith_Integer_MAX_VALUE() {
     runTest("switch with Integer.MAX_VALUE case");
   }
 
-  public void testsParenthesisedExpressionWithAjKeyword() {
+  public void testParenthesisedExpressionWithAjKeyword() {
     runTest("parenthesised expression with AspectJ keyword");
   }
 

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1919/ajc1919.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1919/ajc1919.xml
@@ -204,4 +204,22 @@
 		</run>
 	</ajc-test>
 
+	<!--
+		'inner aspects must be static' when compiling an interface with an inner aspect which was not explicitly declared
+		static, see https://github.com/eclipse/org.aspectj/issues/162
+	-->
+	<ajc-test dir="bugs1919/github_162" vm="1.5" title="inner aspect of interface is implicitly static">
+		<compile files="InterfaceWithInnerClass.java" options="-1.5 -showWeaveInfo">
+			<message kind="weave" text="method-execution(int InterfaceWithInnerClass$ImplicitlyStatic.getNumber())' in Type 'InterfaceWithInnerClass$ImplicitlyStatic'"/>
+			<message kind="weave" text="method-execution(void InterfaceWithInnerClass$ImplicitlyStatic.main(java.lang.String[]))' in Type 'InterfaceWithInnerClass$ImplicitlyStatic'"/>
+		</compile>
+		<run class="InterfaceWithInnerClass$ImplicitlyStatic">
+			<stdout>
+				<line text="execution(void InterfaceWithInnerClass.ImplicitlyStatic.main(String[]))"/>
+				<line text="execution(int InterfaceWithInnerClass.ImplicitlyStatic.getNumber())"/>
+				<line text="11"/>
+			</stdout>
+		</run>
+	</ajc-test>
+
 </suite>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1919/ajc1919.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1919/ajc1919.xml
@@ -190,7 +190,7 @@
 		containing AspectJ keywords, e.g. '(before)', see https://github.com/eclipse/org.aspectj/issues/20
 	-->
 	<ajc-test dir="bugs1919/github_20" vm="1.5" title="parenthesised expression with AspectJ keyword">
-		<compile files="ParenthesisedAJKeywords.java" options="-1.8 -showWeaveInfo"/>
+		<compile files="ParenthesisedAJKeywords.java" options="-1.5 -showWeaveInfo"/>
 		<run class="ParenthesisedAJKeywords">
 			<stdout>
 				<line text="before"/>


### PR DESCRIPTION
Fixes #162. Contains regression test `Bugs1919Tests.testInterfaceInnerAspectImplicitlyStatic`.
