### PR TITLE
Avoid unnecessary Map.containsKey calls.

### DIFF
--- a/bridge/src/main/java/org/aspectj/bridge/context/CompilationAndWeavingContext.java
+++ b/bridge/src/main/java/org/aspectj/bridge/context/CompilationAndWeavingContext.java
@@ -196,11 +196,7 @@ public class CompilationAndWeavingContext {
 
 	private static ContextFormatter getFormatter(ContextStackEntry entry) {
 		Integer key = entry.phaseId;
-		if (formatterMap.containsKey(key)) {
-			return formatterMap.get(key);
-		} else {
-			return defaultFormatter;
-		}
+		return formatterMap.getOrDefault(key, defaultFormatter);
 	}
 
 	private static class ContextTokenImpl implements ContextToken {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AccessForInlineVisitor.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/ast/AccessForInlineVisitor.java
@@ -179,10 +179,11 @@ public class AccessForInlineVisitor extends ASTVisitor {
 			alreadyResolvedMembers.put(binding, m);
 		}
 
-		if (inAspect.accessForInline.containsKey(m)) {
-			return (FieldBinding) inAspect.accessForInline.get(m);
+		FieldBinding ret = (FieldBinding) inAspect.accessForInline.get(m);
+		if (ret != null) {
+			return ret;
 		}
-		FieldBinding ret = new InlineAccessFieldBinding(inAspect, binding, m);
+		ret = new InlineAccessFieldBinding(inAspect, binding, m);
 		inAspect.accessForInline.put(m, ret);
 		return ret;
 	}
@@ -216,9 +217,11 @@ public class AccessForInlineVisitor extends ASTVisitor {
 			// runtime this will be satisfied by the super).
 			m = world.makeResolvedMember(binding, receiverType);
 		}
-		if (inAspect.accessForInline.containsKey(m))
-			return (MethodBinding) inAspect.accessForInline.get(m);
-		MethodBinding ret = world.makeMethodBinding(AjcMemberMaker.inlineAccessMethodForMethod(inAspect.typeX, m));
+		MethodBinding ret = (MethodBinding) inAspect.accessForInline.get(m);
+		if (ret != null) {
+			return ret;
+		}
+		ret = world.makeMethodBinding(AjcMemberMaker.inlineAccessMethodForMethod(inAspect.typeX, m));
 		inAspect.accessForInline.put(m, ret);
 		return ret;
 	}
@@ -236,8 +239,9 @@ public class AccessForInlineVisitor extends ASTVisitor {
 	private MethodBinding getSuperAccessMethod(MethodBinding binding) {
 		ResolvedMember m = world.makeResolvedMember(binding);
 		ResolvedMember superAccessMember = AjcMemberMaker.superAccessMethod(inAspect.typeX, m);
-		if (inAspect.superAccessForInline.containsKey(superAccessMember)) {
-			return inAspect.superAccessForInline.get(superAccessMember).accessMethod;
+		SuperAccessMethodPair pair = inAspect.superAccessForInline.get(superAccessMember);
+		if (pair != null) {
+			return pair.accessMethod;
 		}
 		MethodBinding ret = world.makeMethodBinding(superAccessMember);
 		inAspect.superAccessForInline.put(superAccessMember, new SuperAccessMethodPair(m, ret));

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/AjLookupEnvironment.java
@@ -885,9 +885,10 @@ public class AjLookupEnvironment extends LookupEnvironment implements AnonymousC
 		List<ResolvedType> newParents = declareParents.findMatchingNewParents(resolvedSourceType, false);
 		if (!newParents.isEmpty()) {
 			for (ResolvedType parent : newParents) {
-				if (dangerousInterfaces.containsKey(parent)) {
+				String dangerous = dangerousInterfaces.get(parent);
+				if (dangerous != null) {
 					ResolvedType onType = factory.fromEclipse(sourceType);
-					factory.showMessage(IMessage.ERROR, onType + ": " + dangerousInterfaces.get(parent),
+					factory.showMessage(IMessage.ERROR, onType + ": " + dangerous,
 							onType.getSourceLocation(), null);
 				}
 				if (Modifier.isFinal(parent.getModifiers())) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseFactory.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseFactory.java
@@ -368,8 +368,9 @@ public class EclipseFactory {
 	 */
 	private UnresolvedType fromTypeVariableBinding(TypeVariableBinding aTypeVariableBinding) {
 		// first, check for recursive call to this method for the same tvBinding
-		if (typeVariableBindingsInProgress.containsKey(aTypeVariableBinding)) {
-			return typeVariableBindingsInProgress.get(aTypeVariableBinding);
+		UnresolvedType alreadyInProgress = typeVariableBindingsInProgress.get(aTypeVariableBinding);
+		if (alreadyInProgress != null) {
+			return alreadyInProgress;
 		}
 
 		// Check if its a type variable binding that we need to recover to an alias...
@@ -382,8 +383,9 @@ public class EclipseFactory {
 			}
 		}
 
-		if (typeVariablesForThisMember.containsKey(new String(aTypeVariableBinding.sourceName))) {
-			return typeVariablesForThisMember.get(new String(aTypeVariableBinding.sourceName));
+		UnresolvedType typeVarForThis = typeVariablesForThisMember.get(new String(aTypeVariableBinding.sourceName));
+		if (typeVarForThis != null) {
+			return typeVarForThis;
 		}
 
 		// Create the UnresolvedTypeVariableReferenceType for the type variable

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PrivilegedHandler.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/PrivilegedHandler.java
@@ -59,8 +59,10 @@ public class PrivilegedHandler implements IPrivilegedHandler {
 			baseField = ((ParameterizedFieldBinding) baseField).originalField;
 		}
 		ResolvedMember key = inAspect.factory.makeResolvedMember(baseField);
-		if (accessors.containsKey(key))
-			return (FieldBinding) accessors.get(key);
+		FieldBinding fieldBinding = (FieldBinding) accessors.get(key);
+		if (fieldBinding != null) {
+			return fieldBinding;
+		}
 		FieldBinding ret = new PrivilegedFieldBinding(inAspect, baseField);
 		checkWeaveAccess(key.getDeclaringType(), location);
 		if (!baseField.alwaysNeedsAccessMethod(true))
@@ -89,8 +91,10 @@ public class PrivilegedHandler implements IPrivilegedHandler {
 		} else {
 			key = inAspect.factory.makeResolvedMember(baseMethod);
 		}
-		if (accessors.containsKey(key))
-			return (MethodBinding) accessors.get(key);
+		MethodBinding methodBinding = (MethodBinding) accessors.get(key);
+		if (methodBinding != null) {
+			return methodBinding;
+		}
 
 		MethodBinding ret;
 		if (baseMethod.isConstructor()) {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/AjBuildManager.java
@@ -697,7 +697,7 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
 
 	/**
 	 * Returns a map where the keys are File objects corresponding to all the output directories and the values are a list of
-	 * aspects which are sent to that ouptut directory
+	 * aspects which are sent to that output directory
 	 */
 	private Map<File, List<String>> findOutputDirsForAspects() {
 		Map<File, List<String>> outputDirsToAspects = new HashMap<>();
@@ -729,10 +729,8 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
                     char[] fileName = entry.getValue();
                     File outputDir = buildConfig.getCompilationResultDestinationManager().getOutputLocationForClass(
                             new File(new String(fileName)));
-                    if (!outputDirsToAspects.containsKey(outputDir)) {
-                        outputDirsToAspects.put(outputDir, new ArrayList<>());
-                    }
-                    outputDirsToAspects.get(outputDir).add(aspectName);
+                    outputDirsToAspects.computeIfAbsent(outputDir, f -> new ArrayList<>())
+                            .add(aspectName);
                 }
 			}
 		}
@@ -1243,9 +1241,7 @@ public class AjBuildManager implements IOutputClassFileNameProvider, IBinarySour
 					if (state.getAspectNamesToFileNameMap() == null) {
 						state.initializeAspectNamesToFileNameMap();
 					}
-					if (!state.getAspectNamesToFileNameMap().containsKey(name)) {
-						state.getAspectNamesToFileNameMap().put(name, fileContainingAspect);
-					}
+					state.getAspectNamesToFileNameMap().putIfAbsent(name, fileContainingAspect);
 				}
 			}
 		};

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/StatefulNameEnvironment.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/core/builder/StatefulNameEnvironment.java
@@ -63,8 +63,9 @@ public class StatefulNameEnvironment implements IModuleAwareNameEnvironment {
 		if (seenOnPreviousBuild != null) {
 			return new NameEnvironmentAnswer(seenOnPreviousBuild, null);
 		}
-		if (this.inflatedClassFilesCache.containsKey(name)) {
-			return this.inflatedClassFilesCache.get(name);
+		NameEnvironmentAnswer cached = this.inflatedClassFilesCache.get(name);
+		if (cached != null) {
+			return cached;
 		} else {
 			File fileOnDisk = classesFromName.get(name);
 			// System.err.println("find: " + name + " found: " + cf);

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembersSet.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/CrosscuttingMembersSet.java
@@ -154,10 +154,10 @@ public class CrosscuttingMembersSet {
 	}
 
 	public void addAdviceLikeDeclares(ResolvedType aspectType) {
-		if (!members.containsKey(aspectType)) {
+		CrosscuttingMembers xcut = members.get(aspectType);
+		if (xcut == null) {
 			return;
 		}
-		CrosscuttingMembers xcut = members.get(aspectType);
 		xcut.addDeclares(aspectType.collectDeclares(true));
 	}
 

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedMemberImpl.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedMemberImpl.java
@@ -881,11 +881,8 @@ public class ResolvedMemberImpl extends MemberImpl implements IHasPosition, Reso
 			boolean inParameterizedType, World w) {
 		if (aType instanceof TypeVariableReference) {
 			String variableName = ((TypeVariableReference) aType).getTypeVariable().getName();
-			if (!typeVariableMap.containsKey(variableName)) {
-				return aType; // if the type variable comes from the method (and
-				// not the type) thats OK
-			}
-			return typeVariableMap.get(variableName);
+			// if the type variable comes from the method (and not the type) that's OK
+			return typeVariableMap.getOrDefault(variableName, aType);
 		} else if (aType.isParameterizedType()) {
 			if (inParameterizedType) {
 				if (w != null) {

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/ResolvedType.java
@@ -1045,8 +1045,9 @@ public abstract class ResolvedType extends UnresolvedType implements AnnotatedEl
 						for (int j = 0; j < ptypes.length; j++) {
 							if (ptypes[j] instanceof TypeVariableReferenceType) {
 								TypeVariableReferenceType tvrt = (TypeVariableReferenceType) ptypes[j];
-								if (typeVariableMap.containsKey(tvrt.getTypeVariable().getName())) {
-									newPTypes[j] = typeVariableMap.get(tvrt.getTypeVariable().getName());
+								UnresolvedType newPType = typeVariableMap.get(tvrt.getTypeVariable().getName());
+								if (newPType != null) {
+									newPTypes[j] = newPType;
 								} else {
 									newPTypes[j] = ptypes[j];
 								}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/World.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/World.java
@@ -1427,8 +1427,9 @@ public abstract class World implements Dump.INode {
 		 */
 		public int compareByPrecedence(ResolvedType firstAspect, ResolvedType secondAspect) {
 			PrecedenceCacheKey key = new PrecedenceCacheKey(firstAspect, secondAspect);
-			if (cachedResults.containsKey(key)) {
-				return cachedResults.get(key);
+			Integer cachedOrder = cachedResults.get(key);
+			if (cachedOrder != null) {
+				return cachedOrder;
 			} else {
 				int order = 0;
 				DeclarePrecedence orderer = null; // Records the declare

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/ExactTypePattern.java
@@ -336,9 +336,7 @@ public class ExactTypePattern extends TypePattern {
 		if (type.isTypeVariableReference()) {
 			TypeVariableReference t = (TypeVariableReference) type;
 			String key = t.getTypeVariable().getName();
-			if (typeVariableMap.containsKey(key)) {
-				newType = typeVariableMap.get(key);
-			}
+			newType = typeVariableMap.getOrDefault(key, type);
 		} else if (type.isParameterizedType()) {
 			newType = w.resolve(type).parameterize(typeVariableMap);
 		}

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WildTypePattern.java
@@ -582,8 +582,9 @@ public class WildTypePattern extends TypePattern {
 		if (newNamePatterns.length == 1) {
 			String simpleName = newNamePatterns[0].maybeGetSimpleName();
 			if (simpleName != null) {
-				if (typeVariableMap.containsKey(simpleName)) {
-					String newName = ((ReferenceType) typeVariableMap.get(simpleName)).getName().replace('$', '.');
+				UnresolvedType unresolvedType = typeVariableMap.get(simpleName);
+				if (unresolvedType != null) {
+					String newName = ((ReferenceType) unresolvedType).getName().replace('$', '.');
 					StringTokenizer strTok = new StringTokenizer(newName, ".");
 					newNamePatterns = new NamePattern[strTok.countTokens()];
 					int index = 0;

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/DocumentParser.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/DocumentParser.java
@@ -111,8 +111,11 @@ public class DocumentParser extends DefaultHandler {
 	}
 
 	public static Definition parse(final URL url) throws Exception {
-		if (CACHE && parsedFiles.containsKey(url.toString())) {
-			return parsedFiles.get(url.toString());
+		if (CACHE) {
+			Definition cached = parsedFiles.get(url.toString());
+			if (cached != null) {
+				return cached;
+			}
 		}
 		Definition def = null;
 


### PR DESCRIPTION
Map.containsKey calls are often unnecessary.
Depends on the code, we can:
 1. call get() and then compare result with null. Applicable if we know that Map don't contain null value
 2. use putIfAbsent()/computeIfAbsent() if containsKey() was used before put
 3. use getOrDefault() if we have "fallback" value
 
 I believe it simplifies code and makes it a bit faster.