### PR TITLE
Implement source location matching for weave messages in XML tests

### DIFF
--- a/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
+++ b/bcel-builder/src/main/java/org/aspectj/apache/bcel/classfile/JavaClass.java
@@ -402,7 +402,7 @@ public class JavaClass extends Modifiers implements Cloneable, Node {
 	}
 
 	/**
-	 * @return sbsolute path to file where this class was read from
+	 * @return absolute path to file where this class was read from
 	 */
 	public String getSourceFileName() {
 		return sourcefileName;

--- a/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
+++ b/bridge/src/main/java/org/aspectj/bridge/MessageUtil.java
@@ -827,7 +827,7 @@ public class MessageUtil {
 		for (Iterator<ISourceLocation> iter = message.getExtraSourceLocations().iterator(); iter.hasNext();) {
 			ISourceLocation element = iter.next();
 			if (element != null) {
-				writer.print("\tsee also: " + element.toString());
+				writer.print("\tsee also: " + element);
 				if (iter.hasNext()) {
 					writer.println();
 				}

--- a/bridge/src/main/java/org/aspectj/bridge/WeaveMessage.java
+++ b/bridge/src/main/java/org/aspectj/bridge/WeaveMessage.java
@@ -39,14 +39,18 @@ public class WeaveMessage extends Message {
 	public static WeaveMessageKind WEAVEMESSAGE_REMOVES_ANNOTATION = new WeaveMessageKind(6,
 			"'%1' (%2) has had %3 %4 annotation removed by '%5' (%6)");
 
-	private String affectedtypename;
-	private String aspectname;
+	private String affectedTypeName;
+	private String aspectName;
 
 	// private ctor - use the static factory method
-	private WeaveMessage(String message, String affectedtypename, String aspectname) {
-		super(message, IMessage.WEAVEINFO, null, null);
-		this.affectedtypename = affectedtypename;
-		this.aspectname = aspectname;
+	private WeaveMessage(
+		String message,
+		String affectedTypeName, String aspectName,
+		ISourceLocation affectedTypeLocation, ISourceLocation aspectLocation
+	) {
+		super(message, null, IMessage.WEAVEINFO, affectedTypeLocation, null, new ISourceLocation[] { aspectLocation });
+		this.affectedTypeName = affectedTypeName;
+		this.aspectName = aspectName;
 	}
 
 	/**
@@ -63,7 +67,7 @@ public class WeaveMessage extends Message {
 			int n = Character.getNumericValue(str.charAt(pos + 1));
 			str.replace(pos, pos + 2, inserts[n - 1]);
 		}
-		return new WeaveMessage(str.toString(), null, null);
+		return new WeaveMessage(str.toString(), null, null, null, null);
 	}
 
 	/**
@@ -71,33 +75,38 @@ public class WeaveMessage extends Message {
 	 *
 	 * @param kind what kind of message (e.g. declare parents)
 	 * @param inserts inserts for the message (inserts are marked %n in the message)
-	 * @param affectedtypename the type which is being advised/declaredUpon
-	 * @param aspectname the aspect that defined the advice or declares
+	 * @param affectedTypeName the type which is being advised/declaredUpon
+	 * @param aspectName the aspect that defined the advice or declares
+   * @param affectedTypeLocation the source location of the advised/declaredUpon type
+   * @param aspectLocation the source location of the declaring/defining advice/declare
 	 * @return new weaving message
 	 */
-	public static WeaveMessage constructWeavingMessage(WeaveMessageKind kind, String[] inserts, String affectedtypename,
-			String aspectname) {
+	public static WeaveMessage constructWeavingMessage(
+		WeaveMessageKind kind, String[] inserts,
+		String affectedTypeName, String aspectName,
+		ISourceLocation affectedTypeLocation, ISourceLocation aspectLocation
+	) {
 		StringBuilder str = new StringBuilder(kind.getMessage());
 		int pos = -1;
 		while ((pos = new String(str).indexOf("%")) != -1) {
 			int n = Character.getNumericValue(str.charAt(pos + 1));
 			str.replace(pos, pos + 2, inserts[n - 1]);
 		}
-		return new WeaveMessage(str.toString(), affectedtypename, aspectname);
+		return new WeaveMessage(str.toString(), affectedTypeName, aspectName, affectedTypeLocation, aspectLocation);
 	}
 
 	/**
 	 * @return Returns the aspectname.
 	 */
-	public String getAspectname() {
-		return aspectname;
+	public String getAspectName() {
+		return aspectName;
 	}
 
 	/**
 	 * @return Returns the affectedtypename.
 	 */
-	public String getAffectedtypename() {
-		return affectedtypename;
+	public String getAffectedTypeName() {
+		return affectedTypeName;
 	}
 
 	public static class WeaveMessageKind {

--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseSourceLocation.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/ajdt/internal/compiler/lookup/EclipseSourceLocation.java
@@ -108,8 +108,12 @@ public class EclipseSourceLocation implements ISourceLocation {
 
     public String getContext() {
         if (null == context) {
-            ICompilationUnit compilationUnit = result.compilationUnit;
-            IProblem[] problems = result.problems;
+            ICompilationUnit compilationUnit = null;
+            IProblem[] problems = null;
+            if (result != null) {
+                compilationUnit = result.compilationUnit;
+                problems = result.problems;
+            }
             if ((null == compilationUnit) || (null == problems)
                 || (1 != problems.length)) { // ?? which of n>1 problems?
                 context = NO_CONTEXT;

--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AbstractReferenceTypeDelegate.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/AbstractReferenceTypeDelegate.java
@@ -75,17 +75,15 @@ public abstract class AbstractReferenceTypeDelegate implements ReferenceTypeDele
 
 	public final void setSourcefilename(String sourceFileName) {
 		sourcefilename = sourceFileName;
-		if (sourceFileName != null && sourceFileName.equals(AbstractReferenceTypeDelegate.UNKNOWN_SOURCE_FILE)) {
+		if (AbstractReferenceTypeDelegate.UNKNOWN_SOURCE_FILE.equals(sourceFileName))
 			sourcefilename = "Type '" + getResolvedTypeX().getName() + "' (no debug info available)";
-		} else {
+		else {
 			String pname = getResolvedTypeX().getPackageName();
-			if (pname != null) {
+			if (pname != null)
 				sourcefilename = pname.replace('.', '/') + '/' + sourceFileName;
-			}
 		}
-		if (sourcefilename != null && sourceContext instanceof SourceContextImpl) {
+		if (sourcefilename != null && sourceContext instanceof SourceContextImpl)
 			((SourceContextImpl) sourceContext).setSourceFileName(sourcefilename);
-		}
 	}
 
 	public ISourceLocation getSourceLocation() {

--- a/testing/src/test/java/org/aspectj/testing/CompileSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/CompileSpec.java
@@ -329,7 +329,7 @@ public class CompileSpec implements ITestStep {
 			} else if (kind.equals("abort")) {
 				fails.add(exMsg.toMessage());
 			} else if (kind.equals("weave")) {
-				weaveInfos.add(exMsg.toMessage());
+				weaveInfos.add(exMsg.toWeaveMessage());
 			} else if (kind.equals("usage")) {
 				weaveInfos.add(exMsg.toMessage());
 			}

--- a/testing/src/test/java/org/aspectj/testing/ExpectedMessageSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/ExpectedMessageSpec.java
@@ -23,12 +23,18 @@ public class ExpectedMessageSpec {
 
 	private String kind = "error";
 	private int line = -1;
+	private int aspectLine = -1;
 	private String text;
 	private String file;
+	private String aspectFile;
 	private String details;
 
 	public AjcTestCase.Message toMessage() {
-		return new AjcTestCase.Message(line,file,text,null);
+		return new AjcTestCase.Message(line, file, text, null);
+	}
+
+	public AjcTestCase.Message toWeaveMessage() {
+		return new AjcTestCase.Message(line, file, aspectLine, aspectFile, text, null);
 	}
 
 	/**
@@ -56,6 +62,18 @@ public class ExpectedMessageSpec {
 		this.file = file;
 	}
 	/**
+	 * @return Returns the aspect file.
+	 */
+	public String getAspectFile() {
+		return aspectFile;
+	}
+	/**
+	 * @param aspectFile The aspect file to set.
+	 */
+	public void setAspectFile(String aspectFile) {
+		this.aspectFile = aspectFile;
+	}
+	/**
 	 * @return Returns the kind.
 	 */
 	public String getKind() {
@@ -78,6 +96,18 @@ public class ExpectedMessageSpec {
 	 */
 	public void setLine(int line) {
 		this.line = line;
+	}
+	/**
+	 * @return Returns the asperct line.
+	 */
+	public int getAspectLine() {
+		return aspectLine;
+	}
+	/**
+	 * @param aspectLine The aspect line to set.
+	 */
+	public void setAspectLine(int aspectLine) {
+		this.aspectLine = aspectLine;
 	}
 	/**
 	 * @return Returns the text.

--- a/tests/ajcTestSuite.dtd
+++ b/tests/ajcTestSuite.dtd
@@ -60,9 +60,13 @@
 
    <!ELEMENT message (source*)>
    <!ATTLIST message kind (abort | fail | error | warning | info | Xlint | weave) #IMPLIED >
+   <!-- Java source code line; in weaving messages it denotes the weaving target, e.g. to where an advice is applied -->
    <!ATTLIST message line CDATA #IMPLIED >
+   <!-- Aspect source code line; only useful for weaving messages where it denotes the source of what is woven in (e.g. advice) -->
+   <!ATTLIST message aspectLine CDATA #IMPLIED >
    <!ATTLIST message text CDATA #IMPLIED >
    <!ATTLIST message file CDATA #IMPLIED >
+   <!ATTLIST message aspectFile CDATA #IMPLIED >
    <!ATTLIST message details CDATA #IMPLIED >
 
    <!ELEMENT source (#PCDATA)>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc150/ataspectj/ltw.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc150/ataspectj/ltw.xml
@@ -95,7 +95,7 @@
                 options="-1.5"/>
         <run class="ataspectj.DumpTest" ltw="ataspectj/aop-dump.xml"/>
     </ajc-test>
-    
+
     <ajc-test dir="java5/ataspectj" title="LTW DumpTest before and after">
         <compile
                 files="ataspectj/EmptyAspect.aj"
@@ -163,7 +163,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>	
+        </compile>
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-silent.xml">
         	<stdout>
  				<line text="execution(Main.target())"/>
@@ -182,7 +182,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>	
+        </compile>
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-verbose.xml">
         	<stdout>
  				<line text="execution(Main.target())"/>
@@ -207,7 +207,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>	
+        </compile>
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-verboseandshow.xml">
         	<stdout>
  				<line text="execution(Main.target())"/>
@@ -218,7 +218,8 @@
                 <line text="info using"/>
 				<line text="info register aspect ataspectj.ltwlog.Aspect1"/>
 				<line text="debug weaving 'ataspectj.ltwlog.Main'"/>
-				<line text="weaveinfo Join point 'method-execution(void ataspectj.ltwlog.Main.target())' in Type 'ataspectj.ltwlog.Main' (Main.java:22) advised by before advice from 'ataspectj.ltwlog.Aspect1' (Aspect1.java)"/>
+				<line text="Join point 'method-execution(void ataspectj.ltwlog.Main.target())' in Type 'ataspectj.ltwlog.Main' (Main.java:22) advised by before advice from 'ataspectj.ltwlog.Aspect1' (Aspect1.java)"/>
+				<line text="see also:"/>
 				<line text="debug weaving 'ataspectj.ltwlog.Aspect1'"/>
             </stderr>
         </run>
@@ -233,7 +234,7 @@
     		files="ataspectj/ltwlog/Aspect1.java"
     		options="-1.5 -XterminateAfterCompilation"
     	>
-        </compile>	
+        </compile>
         <run class="ataspectj.ltwlog.Main" ltw="ataspectj/ltwlog/aop-messagehandler.xml">
         	<stdout>
 				<line text="MessageHolder.MessageHolder()"/>
@@ -257,11 +258,16 @@
         <!--<run class="ataspectj.DeclareParentsInterfaceTest" ltw="ataspectj/aop-decptest.xml"/>-->
         <ant file="ajc-ant.xml" target="ltw.Decp" verbose="true">
         	<stderr>
-                <line text="weaveinfo Extending interface set for type 'ataspectj.DeclareParentsInterfaceTest$Target' (DeclareParentsInterfaceTest.java) to include 'ataspectj.DeclareParentsInterfaceTest$Marker' (DeclareParentsInterfaceTest.java)"/>
-                <line text="weaveinfo Join point 'method-execution(void ataspectj.DeclareParentsInterfaceTest$Target.target())' in Type 'ataspectj.DeclareParentsInterfaceTest$Target' (DeclareParentsInterfaceTest.java:27) advised by before advice from 'ataspectj.DeclareParentsInterfaceTest$TestAspect' (DeclareParentsInterfaceTest.java)"/>
-                <line text="weaveinfo Extending interface set for type 'ataspectj.DeclareParentsImplementsTest$Target' (DeclareParentsImplementsTest.java) to include 'ataspectj.DeclareParentsImplementsTest$Introduced' (DeclareParentsImplementsTest.java)"/>
-                <line text="weaveinfo Type 'ataspectj.DeclareParentsImplementsTest$Target' (DeclareParentsImplementsTest.java) has intertyped method from 'ataspectj.DeclareParentsImplementsTest$TestAspect' (DeclareParentsImplementsTest.java:'void ataspectj.DeclareParentsImplementsTest$Introduced.intro()')"/>
-                <line text="weaveinfo Join point 'method-execution(void ataspectj.DeclareParentsImplementsTest$Implementation.intro())' in Type 'ataspectj.DeclareParentsImplementsTest$Implementation' (DeclareParentsImplementsTest.java:47) advised by before advice from 'ataspectj.DeclareParentsImplementsTest$TestAspect' (DeclareParentsImplementsTest.java)"/>
+                <line text="Extending interface set for type 'ataspectj.DeclareParentsInterfaceTest$Target' (DeclareParentsInterfaceTest.java) to include 'ataspectj.DeclareParentsInterfaceTest$Marker' (DeclareParentsInterfaceTest.java)"/>
+                <line text="see also:"/>
+                <line text="Join point 'method-execution(void ataspectj.DeclareParentsInterfaceTest$Target.target())' in Type 'ataspectj.DeclareParentsInterfaceTest$Target' (DeclareParentsInterfaceTest.java:27) advised by before advice from 'ataspectj.DeclareParentsInterfaceTest$TestAspect' (DeclareParentsInterfaceTest.java)"/>
+                <line text="see also:"/>
+                <line text="Extending interface set for type 'ataspectj.DeclareParentsImplementsTest$Target' (DeclareParentsImplementsTest.java) to include 'ataspectj.DeclareParentsImplementsTest$Introduced' (DeclareParentsImplementsTest.java)"/>
+                <line text="see also:"/>
+                <line text="Type 'ataspectj.DeclareParentsImplementsTest$Target' (DeclareParentsImplementsTest.java) has intertyped method from 'ataspectj.DeclareParentsImplementsTest$TestAspect' (DeclareParentsImplementsTest.java:'void ataspectj.DeclareParentsImplementsTest$Introduced.intro()')"/>
+                <line text="see also:"/>
+                <line text="Join point 'method-execution(void ataspectj.DeclareParentsImplementsTest$Implementation.intro())' in Type 'ataspectj.DeclareParentsImplementsTest$Implementation' (DeclareParentsImplementsTest.java:47) advised by before advice from 'ataspectj.DeclareParentsImplementsTest$TestAspect' (DeclareParentsImplementsTest.java)"/>
+                <line text="see also:"/>
             </stderr>
         </ant>
     </ajc-test>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc150/ltw/ltw.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc150/ltw/ltw.xml
@@ -23,10 +23,10 @@
 			<line text="Main.test2" />
 		</stdout>
 		<stderr>
-			<line
-				text="weaveinfo Join point 'method-execution(void Main.test1())' in Type 'Main' (Main.java:17) advised by before advice from 'Aspect1' (Aspect1.aj:16)" />
-			<line
-				text="weaveinfo Join point 'method-execution(void Main.test2())' in Type 'Main' (Main.java:21) advised by before advice from 'Aspect2' (Aspect2.aj:16)" />
+			<line text="Join point 'method-execution(void Main.test1())' in Type 'Main' (Main.java:17) advised by before advice from 'Aspect1' (Aspect1.aj:16)" />
+			<line text="see also:" />
+			<line text="Join point 'method-execution(void Main.test2())' in Type 'Main' (Main.java:21) advised by before advice from 'Aspect2' (Aspect2.aj:16)" />
+			<line text="see also:" />
 			<line text="Aspect1.before_test1" />
 			<line text="Aspect2.before_test2" />
 		</stderr>
@@ -249,8 +249,8 @@
 			<line text="TestITDMethod.main" />
 		</stdout>
 		<stderr>
-			<line
-				text="weaveinfo Type 'TestITDMethod' (TestITDMethod.java) has intertyped method from 'AbstractAspect' (AbstractAspect.aj:'void TestITDMethod.test()')" />
+			<line text="Type 'TestITDMethod' (TestITDMethod.java) has intertyped method from 'AbstractAspect' (AbstractAspect.aj:'void TestITDMethod.test()')" />
+			<line text="see also:" />
 			<line text="AbstractAspect_TestITDMethod.test" />
 		</stderr>
 	</run>
@@ -359,12 +359,12 @@
 			<line text="T call" />
 		</stdout>
 		<stderr>
-			<line
-				text="weaveinfo Join point 'method-call(void util.A.foo())' in Type 'child.Executor' (Executor.aj:18) advised by before advice from 'child.Advisor' (Advisor.aj:20)" />
-			<line
-				text="weaveinfo Extending interface set for type 'util.A' (A.aj) to include 'util.T' (Advisor.aj)" />
-			<line
-				text="weaveinfo Extending interface set for type 'child.Advisor' (Advisor.aj) to include 'util.T' (Advisor.aj)" />
+			<line text="Join point 'method-call(void util.A.foo())' in Type 'child.Executor' (Executor.aj:18) advised by before advice from 'child.Advisor' (Advisor.aj:20)" />
+			<line text="see also:" />
+			<line text="Extending interface set for type 'util.A' (A.aj) to include 'util.T' (Advisor.aj)" />
+			<line text="see also:" />
+			<line text="Extending interface set for type 'child.Advisor' (Advisor.aj) to include 'util.T' (Advisor.aj)" />
+			<line text="see also:" />
 		</stderr>
 	</run>
 </ajc-test>
@@ -464,10 +464,10 @@
 			<line text="Main.test2" />
 		</stdout>
 		<stderr>
-			<line
-				text="weaveinfo Join point 'method-execution(void Main.test1())' in Type 'Main' (Main.java:17) advised by before advice from 'Aspect1' (Aspect1.aj:16)" />
-			<line
-				text="weaveinfo Join point 'method-execution(void Main.test2())' in Type 'Main' (Main.java:21) advised by before advice from 'Aspect2' (Aspect2.aj:16)" />
+			<line text="Join point 'method-execution(void Main.test1())' in Type 'Main' (Main.java:17) advised by before advice from 'Aspect1' (Aspect1.aj:16)" />
+			<line text="see also:" />
+			<line text="Join point 'method-execution(void Main.test2())' in Type 'Main' (Main.java:21) advised by before advice from 'Aspect2' (Aspect2.aj:16)" />
+			<line text="see also:" />
 			<line text="Aspect1.before_test1" />
 			<line text="Aspect2.before_test2" />
 		</stderr>
@@ -491,10 +491,10 @@
 			<line text="Main.test2" />
 		</stdout>
 		<stderr>
-			<line
-				text="weaveinfo Join point 'method-execution(void Main.test1())' in Type 'Main' (Main.java:17) advised by before advice from 'Aspect1' (Aspect1.aj:16)" />
-			<line
-				text="weaveinfo Join point 'method-execution(void Main.test2())' in Type 'Main' (Main.java:21) advised by before advice from 'Aspect2' (Aspect2.aj:16)" />
+			<line text="Join point 'method-execution(void Main.test1())' in Type 'Main' (Main.java:17) advised by before advice from 'Aspect1' (Aspect1.aj:16)" />
+			<line text="see also:" />
+			<line text="Join point 'method-execution(void Main.test2())' in Type 'Main' (Main.java:21) advised by before advice from 'Aspect2' (Aspect2.aj:16)" />
+			<line text="see also:" />
 			<line text="Aspect1.before_test1" />
 			<line text="Aspect2.before_test2" />
 		</stderr>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc152/ajc152.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc152/ajc152.xml
@@ -442,7 +442,8 @@
       <compile files="AnAspect.java" options="-1.4"/>
       <run class="BigHorribleClass" ltw="aop1.xml">
         <stderr>
-          <line text="weaveinfo Join point 'staticinitialization(void BigHorribleClass.&lt;clinit&gt;())'"/>
+          <line text="Join point 'staticinitialization(void BigHorribleClass.&lt;clinit&gt;())'"/>
+          <line text="see also:" />
           <line text="SerialVersionUID is "/>
         </stderr>
       </run>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc152/synchronization.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc152/synchronization.xml
@@ -2,7 +2,7 @@
 
 <!-- AspectJ v1.5.1 Tests -->
 <suite>
-    
+
     <ajc-test dir="features152/synchronization" title="basic">
         <compile files="Basic.java" options="-1.5 -showWeaveInfo -Xjoinpoints:synchronization">
         </compile>
@@ -15,7 +15,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="basic - within">
         <compile files="Basic2.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -36,7 +36,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="basic - within plus args">
         <compile files="Basic3.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -57,7 +57,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="basic - within plus this">
         <compile files="Basic4.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -78,7 +78,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="basic - within plus target">
         <compile files="Basic5.java" options="-1.5 -Xjoinpoints:synchronization">
         </compile>
@@ -110,19 +110,19 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="parsing - lock">
         <compile files="Parsing1.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="5" text="advice defined in Parsing1 has not been applied [Xlint:adviceDidNotMatch]"/>
         </compile>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="parsing - unlock">
         <compile files="Parsing2.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="5" text="advice defined in Parsing2 has not been applied [Xlint:adviceDidNotMatch]"/>
         </compile>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="parsing - error - lock">
         <compile files="Parsing1.java" options="-1.5">
           <message kind="warning" line="5" text="advice defined in Parsing1 has not been applied [Xlint:adviceDidNotMatch]"/>
@@ -130,7 +130,7 @@
           <message kind="warning" line="5" text="lock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
         </compile>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="parsing - error - unlock">
         <compile files="Parsing2.java" options="-1.5">
           <message kind="warning" line="5" text="advice defined in Parsing2 has not been applied [Xlint:adviceDidNotMatch]"/>
@@ -138,7 +138,7 @@
           <message kind="warning" line="5" text="unlock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
         </compile>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="parsing and matching - lock and static context">
         <compile files="ParsingAndMatching1.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ParsingAndMatching1">
@@ -148,7 +148,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="using lock with LTW - missing flag">
         <compile files="LockAspect1.java" options="-1.5">
           <message kind="warning" line="6" text="lock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
@@ -163,7 +163,7 @@
             </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="transform with LTW">
         <compile files="CaptureLock.aj" options="-1.5"/>
         <compile files="Program.java" options="-1.5"/>
@@ -184,37 +184,41 @@
             </stdout>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="using lock with LTW">
-        <compile files="LockAspect1.java" options="-1.5 -Xjoinpoints:synchronization"/>
-        <compile files="BasicProgram1.java" options="-1.5 -Xjoinpoints:synchronization"/>
-        <run class="BasicProgram1" ltw="aop3.xml">
-        	<stderr>
-        	  <line text="weaveinfo Join point 'lock(void java.lang.Object.&lt;lock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:11) advised by before advice from 'LockAspect1' (LockAspect1.java:6)"/>
-			  <line text="weaveinfo Join point 'lock(void java.lang.Object.&lt;lock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:17) advised by before advice from 'LockAspect1' (LockAspect1.java:6)"/>
-			  <line text="Lock advice running at BasicProgram1.java:17"/>
-			  <line text="nonstatic method running"/>
-			  <line text="Lock advice running at BasicProgram1.java:11"/>
-		      <line text="static method running"/>
-            </stderr>
-        </run>
+      <compile files="LockAspect1.java" options="-1.5 -Xjoinpoints:synchronization"/>
+      <compile files="BasicProgram1.java" options="-1.5 -Xjoinpoints:synchronization"/>
+      <run class="BasicProgram1" ltw="aop3.xml">
+        <stderr>
+          <line text="Join point 'lock(void java.lang.Object.&lt;lock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:11) advised by before advice from 'LockAspect1' (LockAspect1.java:6)"/>
+          <line text="see also:"/>
+          <line text="Join point 'lock(void java.lang.Object.&lt;lock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:17) advised by before advice from 'LockAspect1' (LockAspect1.java:6)"/>
+          <line text="see also:"/>
+          <line text="Lock advice running at BasicProgram1.java:17"/>
+          <line text="nonstatic method running"/>
+          <line text="Lock advice running at BasicProgram1.java:11"/>
+          <line text="static method running"/>
+        </stderr>
+      </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="using unlock with LTW">
-        <compile files="UnlockAspect1.java" options="-1.5 -Xjoinpoints:synchronization"/>
-        <compile files="BasicProgram1.java" options="-1.5 -Xjoinpoints:synchronization"/>
-        <run class="BasicProgram1" ltw="aop4.xml">
-        	<stderr>
-			  <line text="weaveinfo Join point 'unlock(void java.lang.Object.&lt;unlock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:11) advised by before advice from 'UnlockAspect1' (UnlockAspect1.java:6)"/>
-			  <line text="weaveinfo Join point 'unlock(void java.lang.Object.&lt;unlock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:17) advised by before advice from 'UnlockAspect1' (UnlockAspect1.java:6)"/>
-			  <line text="nonstatic method running"/>
-			  <line text="Unlock advice running at BasicProgram1.java:17"/>
-			  <line text="static method running"/>
-			  <line text="Unlock advice running at BasicProgram1.java:11"/>
-            </stderr>
-        </run>
+      <compile files="UnlockAspect1.java" options="-1.5 -Xjoinpoints:synchronization"/>
+      <compile files="BasicProgram1.java" options="-1.5 -Xjoinpoints:synchronization"/>
+      <run class="BasicProgram1" ltw="aop4.xml">
+        <stderr>
+          <line text="Join point 'unlock(void java.lang.Object.&lt;unlock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:11) advised by before advice from 'UnlockAspect1' (UnlockAspect1.java:6)"/>
+          <line text="see also:"/>
+          <line text="Join point 'unlock(void java.lang.Object.&lt;unlock&gt;(java.lang.Object))' in Type 'BasicProgram1' (BasicProgram1.java:17) advised by before advice from 'UnlockAspect1' (UnlockAspect1.java:6)"/>
+          <line text="see also:"/>
+          <line text="nonstatic method running"/>
+          <line text="Unlock advice running at BasicProgram1.java:17"/>
+          <line text="static method running"/>
+          <line text="Unlock advice running at BasicProgram1.java:11"/>
+        </stderr>
+      </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="using unlock with LTW - missing flag">
         <compile files="UnlockAspect1.java" options="-1.5">
           <message kind="warning" line="6" text="unlock() pointcut designator cannot be used without the option -Xjoinpoints:synchronization"/>
@@ -238,7 +242,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="parsing and matching - lock and non-static context">
         <compile files="ParsingAndMatching3.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ParsingAndMatching3">
@@ -258,7 +262,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="a useful program - with lock">
         <compile files="Useful2.java" options="-1.5 -showWeaveInfo -Xjoinpoints:synchronization">
         	<message kind="weave" text="Join point 'method-execution(void Useful2.main(java.lang.String[]))' in Type 'Useful2' (Useful2.java:33) advised by afterReturning advice from 'LockMonitor' (Useful2.java:25)"/>
@@ -272,7 +276,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="combining pcds - lock and this">
         <compile files="CombiningPCDs1.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="CombiningPCDs1">
@@ -283,7 +287,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="combining pcds - unlock and this">
         <compile files="CombiningPCDs2.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="CombiningPCDs2">
@@ -294,7 +298,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="thisjoinpoint - monitor entry">
         <compile files="ThisJoinPointLock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ThisJoinPointLock">
@@ -305,7 +309,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="thisjoinpoint - monitor exit">
         <compile files="ThisJoinPointUnlock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="ThisJoinPointUnlock">
@@ -316,7 +320,7 @@
           </stderr>
         </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="prevent double unlock weaving messages and model contents">
         <compile files="ThisJoinPointUnlock.java" options="-1.5 -Xjoinpoints:synchronization -showWeaveInfo -emacssym">
           <message kind="weave" text="Join point 'lock(void java.lang.Object.&lt;lock&gt;(java.lang.Object))' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:38) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
@@ -324,7 +328,7 @@
           <message kind="weave" text="Join point 'unlock(void java.lang.Object.&lt;unlock&gt;(java.lang.Object))' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:38) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
         </compile>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="before advice - lock">
         <compile files="BeforeLock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="BeforeLock">
@@ -336,8 +340,8 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>   
-    
+    </ajc-test>
+
     <ajc-test dir="features152/synchronization" title="before advice - unlock">
         <compile files="BeforeUnlock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="BeforeUnlock">
@@ -349,8 +353,8 @@
             <line text="before() unlock: advice running at BeforeUnlock.java:21"/>
           </stderr>
         </run>
-    </ajc-test>   
-    
+    </ajc-test>
+
     <ajc-test dir="features152/synchronization" title="after advice - lock">
         <compile files="AfterLock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="AfterLock">
@@ -362,8 +366,8 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>   
-    
+    </ajc-test>
+
     <ajc-test dir="features152/synchronization" title="after advice - unlock">
         <compile files="AfterUnlock.java" options="-1.5 -Xjoinpoints:synchronization"/>
         <run class="AfterUnlock">
@@ -375,8 +379,8 @@
             <line text="after() unlock: advice running at AfterUnlock.java:21"/>
           </stderr>
         </run>
-    </ajc-test>   
-    
+    </ajc-test>
+
     <ajc-test dir="features152/synchronization" title="around advice - lock">
         <compile files="AroundLock.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="11" text="Around advice is not supported on the lock and unlock join points (compiler limitation)"/>
@@ -395,8 +399,8 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>   
-    
+    </ajc-test>
+
     <ajc-test dir="features152/synchronization" title="around advice - unlock">
         <compile files="AroundUnlock.java" options="-1.5 -Xjoinpoints:synchronization">
           <message kind="warning" line="5" text="Around advice is not supported on the lock and unlock join points (compiler limitation)"/>
@@ -415,22 +419,22 @@
             <line text="non-static method running"/>
           </stderr>
         </run>
-    </ajc-test>   
-    
+    </ajc-test>
+
     <ajc-test dir="features152/synchronization/transformed" title="investigation">
       <compile files="Investigation.java">
       </compile>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="One">
       <compile files="One.java -Xjoinpoints:synchronization">
       </compile>
       <run class="One"/><!-- will check verification ... -->
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="Two">
       <compile files="Two.java -Xjoinpoints:synchronization">
-        <message kind="warning" line="14" text="advice matching the synchronized method shadow 'method-execution(void C.ma())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>        
+        <message kind="warning" line="14" text="advice matching the synchronized method shadow 'method-execution(void C.ma())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
       </compile>
       <run class="Two">
         <stderr>
@@ -439,7 +443,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="Two - xlintoff">
       <compile files="Two.java -Xjoinpoints:synchronization -Xlint:ignore"/>
       <run class="Two">
@@ -449,11 +453,11 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="Three">
       <compile files="Three.java -Xjoinpoints:synchronization">
-        <message kind="warning" line="20" text="advice matching the synchronized method shadow 'method-execution(void C.m3())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>        
-        <message kind="warning" line="24" text="advice matching the synchronized method shadow 'method-execution(void C.m32())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>        
+        <message kind="warning" line="20" text="advice matching the synchronized method shadow 'method-execution(void C.m3())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
+        <message kind="warning" line="24" text="advice matching the synchronized method shadow 'method-execution(void C.m32())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
       </compile>
       <run class="Three">
         <stderr>
@@ -468,7 +472,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="Four">
       <compile files="Four.java -Xjoinpoints:synchronization">
          <message kind="warning" line="16" text="advice matching the synchronized method shadow 'method-execution(void C.m())' will be executed outside the lock rather than inside (compiler limitation) [Xlint"/>
@@ -483,7 +487,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="Five - Java5">
       <compile files="Five.java -1.5 -Xjoinpoints:synchronization">
       </compile>
@@ -500,7 +504,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="Six - preJava5">
       <compile files="Six.java -Xjoinpoints:synchronization">
       </compile>
@@ -513,7 +517,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="lock pcd on transformed non-static method">
       <compile files="Seven.java -Xjoinpoints:synchronization">
       </compile>
@@ -537,7 +541,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="lock pcd on transformed static method - J5">
       <compile files="Nine.java -1.5 -Xjoinpoints:synchronization">
       </compile>
@@ -561,7 +565,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="lock pcd on transformed static method - preJ5">
       <compile files="Eleven.java -Xjoinpoints:synchronization">
       </compile>
@@ -585,8 +589,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="transform static method - preJ5">
       <compile files="Fifteen.java" options="-Xjoinpoints:synchronization -1.4">
       </compile>
@@ -598,8 +601,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="transform static method - packages - preJ5">
       <compile files="Sixteen.java" options="-Xjoinpoints:synchronization -1.4">
       </compile>
@@ -611,7 +613,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization" title="obtaining locked object through getArgs">
       <compile files="LockingWithTJP.java" options="-Xjoinpoints:synchronization">
       </compile>
@@ -626,7 +628,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="other targeters">
       <compile files="OtherTargeters.java" options="-Xjoinpoints:synchronization">
          <message kind="warning" line="8" text="advice matching the synchronized "/>
@@ -638,8 +640,7 @@
         </stderr>
       </run>
     </ajc-test>
-    
-    
+
     <ajc-test dir="features152/synchronization/transformed" title="joinpoints enabled but no lock">
       <compile files="Fourteen.java" options="-Xjoinpoints:synchronization">
          <!--message kind="warning" line="8" text="advice matching the synchronized "/-->

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc165/ajc165.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc165/ajc165.xml
@@ -87,16 +87,16 @@
        <message kind="warning" text="advice defined in Iffy2 has not been applied [Xlint:adviceDidNotMatch]"     line="39"/>
        <message kind="warning" text="advice defined in Iffy2 has not been applied [Xlint:adviceDidNotMatch]"     line="48"/>
 
-       <message kind="weave" text="method-execution(void Iffy2.myVoid())' in Type 'Iffy2' (Iffy2.java:50) advised by before advice from 'Iffy2' (Iffy2.java:23)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice from 'Iffy2' (Iffy2.java:35)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice from 'Iffy2' (Iffy2.java:31)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice from 'Iffy2' (Iffy2.java:27)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice from 'Iffy2' (Iffy2.java:23)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice from 'Iffy2' (Iffy2.java:10)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice from 'Iffy2' (Iffy2.java:43)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice from 'Iffy2' (Iffy2.java:27)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice from 'Iffy2' (Iffy2.java:23)"/>
-       <message kind="weave" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice from 'Iffy2' (Iffy2.java:10)"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="23" text="method-execution(void Iffy2.myVoid())' in Type 'Iffy2' (Iffy2.java:50) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="35" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="31" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="27" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="23" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="10" text="method-execution(java.util.Collection[] Iffy2.getCollectionArray())' in Type 'Iffy2' (Iffy2.java:52) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="43" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="27" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="23" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice"/>
+       <message kind="weave" aspectFile="Iffy2.java" aspectLine="10" text="method-execution(java.util.Collection[] Iffy2.getIntegerCollectionArray())' in Type 'Iffy2' (Iffy2.java:56) advised by before advice"/>
 
      </compile>
    </ajc-test>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc166/ajc166.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc166/ajc166.xml
@@ -18,7 +18,7 @@
       </stdout>
     </run>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr286473" title="parents ltw - ltw">
     <compile files="Anno.java Top.java Middle.java Bottom.java" outjar="code.jar" options="-1.5 -Xlint:ignore"/>
     <compile files="Mark.java LTWTest.java" classpath="code.jar" options="-1.5">
@@ -26,8 +26,11 @@
     <run class="LTWTest" ltw="aop.xml">
       <stderr>
         <line text="Extending interface set for type 'Top' (Top.java) to include 'Mark$IMarker' (Mark.java)"/>
+        <line text="see also:"/>
         <line text="Type 'Top' (Top.java) has intertyped method from 'Mark' (Mark.java:'java.lang.String Mark$IMarker.markMethod()')"/>
+        <line text="see also:"/>
         <line text="Type 'Mark$IMarker' (Mark.java) has intertyped method from 'Mark' (Mark.java:'java.lang.String Mark$IMarker.markMethod()')"/>
+        <line text="see also:"/>
 <!--
         <line text="Extending interface set for type 'Bottom' (Bottom.java) to include 'Mark$IMarker' (Mark.java)"/>
         <line text="Type 'Bottom' (Bottom.java) has intertyped method from 'Mark' (Mark.java:'java.lang.String Mark$IMarker.markMethod()')"/>
@@ -50,19 +53,19 @@
   <ajc-test dir="bugs166/pr290227" title="npe for javac built">
     <compile files="" inpath="javacCode.jar" options="-1.5 -Xlint:ignore"/>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr288049" title="itd decanno">
      <compile files="org/othtests/MyClass.java org/othtests/MySubClass.java org/othtests/AddSomeAnnotation.java" options="-1.5 -showWeaveInfo">
      <message kind="weave" text="'public java.lang.String org.othtests.MySubClass.doOne()' (MySubClass.java:5) is annotated with"/>
      <message kind="weave" text="'public java.lang.String org.othtests.MySubClass.doTwo()' (MySubClass.java:9) is annotated with"/>
      </compile>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr288712" title="verifyerror anno style">
     <compile files="answers/Answer2h.java figures/FigureElement.java figures/Line.java figures/Point.java figures/ShapeFigureElement.java Main.java" options="-1.5"/>
     <run class="Main"/>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr288635" title="munger cce - 2">
      <compile files="AddAnnotation.java MakeItd.java InterceptTraceds.java TestClass.java Anno.java" options="-1.5 -XterminateAfterCompilation"/>
      <run class="TestClass" ltw="aop1.xml">
@@ -71,7 +74,7 @@
        </stdout>
      </run>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr288635" title="munger cce">
      <compile files="org/tests/atann/AddAnnotations.aj org/tests/atann/AddITDDoMethod.aj org/tests/atann/InterceptTraceds.aj org/tests/atann/TestClass.java org/tests/atann/Traced.java" options="-1.5"/>
      <run class="org.tests.atann.TestClass">
@@ -82,41 +85,40 @@
        </stdout>
      </run>
   </ajc-test>
-   
+
   <ajc-test dir="bugs166/pr286375" title="npe on bad aspect decl">
      <compile files="DatabaseOperationMonitor.java" options="-1.5" outjar="wibble.jar"/>
      <compile files="" inpath="wibble.jar" options="-1.5"/>
   </ajc-test>
-  
-  
+
   <ajc-test dir="bugs166/pr290087" title="binary decp super rewrite">
      <compile files="Bean.java BeanChild.java GenericParent.java" options="-1.5" outjar="base.jar"/>
      <compile files="Interface.java InterfaceParent.java BeanHasInterface.java" inpath="base.jar" options="-1.5"/>
      <run class="BeanChild"/>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr287597" title="anno modifier ordering - 1">
      <compile files="A.java" options="-1.5 -showWeaveInfo">
        <message kind="weave" text="foo"/>
      </compile>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr287613" title="dec anno compound expressions">
      <compile files="DeclareAnnot.java" options="-1.5"/>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr284862" title="npe hasmember">
      <compile files="InterfaceToAdd.java AnnotatedMethodImpl.aj AspectToMatch.aj AnnotatedMethodInterface.java Entity.java EntityClass.java PresentAnnotation.java SearchAnnotation.java" options="-1.5 -XhasMember"/>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr284862" title="npe hasmember - 2">
      <compile files="AnnotatedMethodInterface.java InterfaceToAdd.java AnnotatedMethodImpl.aj AspectToMatch.aj Entity.java EntityClass.java PresentAnnotation.java SearchAnnotation.java" options="-1.5 -XhasMember"/>
   </ajc-test>
-  
+
   <ajc-test dir="bugs166/pr284862" title="npe hasmember - 3">
      <compile files="AnnotatedMethodInterface.java InterfaceToAdd.java AnnotatedMethodImpl.aj AspectToMatch.aj Entity.java EntityClass.java PresentAnnotation.java SearchAnnotation.java" options="-Xset:pipelineCompilation=false -1.5 -XhasMember"/>
   </ajc-test>
-  
+
   <ajc-test dir="bugs165/pr279983" title="generics bridge">
      <compile files="X.java" options="-1.5"/>
      <run class="X"/>
@@ -125,7 +127,7 @@
   <ajc-test dir="bugs166/pr282299" title="generics and decp">
      <compile files="Code.java" options="-1.5"/>
   </ajc-test>
-   
+
   <ajc-test dir="bugs166/pr284297" title="generic signature problem">
      <compile files="DomainLogic.java DomainObject.java FancyDomainLogic.java" options="-1.5" outjar="code.jar"/>
      <compile files="FancyDomainLogicImpl.java" options="-1.5" classpath="code.jar"/>
@@ -141,7 +143,7 @@
          <line text="if method: public static final boolean X.ajc$if$165()"/>
        </stdout>
        -->
-     </run> 
+     </run>
    </ajc-test>
 
 </suite>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc172/ajc172.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc172/ajc172.xml
@@ -61,7 +61,9 @@
 	     <line text="register aspect AspectD"/>
 	     <line text="deactivating aspect 'AspectD' as it requires type 'a.b.c.Anno2' which cannot be found on the classpath"/>
 	     <line text="Join point 'method-execution(void Code.main(java.lang.String[]))' in Type 'Code' (Code.java:7) advised by before advice from 'AspectC'"/>
+	     <line text="see also:"/>
 	     <line text="Join point 'staticinitialization(void Code.&lt;clinit&gt;())' in Type 'Code' (Code.java) advised by before advice from 'AspectB'"/>
+	     <line text="see also:"/>
 	     <line text="processing reweavable"/>
 	     <line text="processing reweavable"/>
 	     </stderr>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1920/ajc1920.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1920/ajc1920.xml
@@ -379,8 +379,8 @@
 			<message kind="warning" text="can not build thisJoinPoint lazily for this advice since it has no suitable guard [Xlint:noGuardForLazyTjp]"/>
 			<message kind="warning" text="at this shadow method-execution(void Application.greet(java.lang.String)) no precedence is specified between advice applying from aspect FirstAspect and aspect SecondAspect [Xlint:unorderedAdviceAtShadow]"/>
 			<message kind="warning" text="can not implement lazyTjp at joinpoint method-execution(void Application.greet(java.lang.String)) because of advice conflicts, see secondary locations to find conflicting advice [Xlint:multipleAdviceStoppingLazyTjp]"/>
-			<message kind="weave" text="method-execution(void Application.greet(java.lang.String))' in Type 'Application' (Application.java:4) advised by around advice from 'SecondAspect'"/>
-			<message kind="weave" text="method-execution(void Application.greet(java.lang.String))' in Type 'Application' (Application.java:4) advised by before advice from 'FirstAspect'"/>
+			<message kind="weave" aspectFile="SecondAspect.java" aspectLine="8" text="method-execution(void Application.greet(java.lang.String))' in Type 'Application' (Application.java:4) advised by around advice"/>
+			<message kind="weave" aspectFile="FirstAspect.class" aspectLine="0" text="method-execution(void Application.greet(java.lang.String))' in Type 'Application' (Application.java:4) advised by before advice"/>
 		</compile>
 		<run class="Application" classpath="$sandbox/second-aspect.jar,$sandbox/first-aspect.jar">
 			<stdout>

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelObjectType.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelObjectType.java
@@ -159,10 +159,19 @@ public class BcelObjectType extends AbstractReferenceTypeDelegate {
 		// the only class in Java-1.4 with no superclasses
 		isObject = (javaClass.getSuperclassNameIndex() == 0);
 		ensureAspectJAttributesUnpacked();
-		// if (sourceContext instanceof SourceContextImpl) {
-		// ((SourceContextImpl)sourceContext).setSourceFileName(javaClass.
-		// getSourceFileName());
-		// }
+
+		// Experimental code leading to undesired ripple effects elsewhere, requiring more rework
+		/*
+		final String fileName = javaClass.getFileName();
+		final String sourceFileName = javaClass.getSourceFileName();
+		if (fileName == null || !fileName.endsWith(".class"))
+			setSourcefilename(sourceFileName);
+		else if (sourceFileName == null || sourceFileName.isEmpty() || sourceFileName.endsWith(".class"))
+			setSourcefilename(fileName);
+		else
+			setSourcefilename(fileName + " (from " + sourceFileName + ")");
+		*/
+
 		setSourcefilename(javaClass.getSourceFileName());
 	}
 

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelTypeMunger.java
@@ -193,21 +193,36 @@ public class BcelTypeMunger extends ConcreteTypeMunger {
 				NewParentTypeMunger parentTM = (NewParentTypeMunger) munger;
 				if (parentTM.isMixin()) {
 					weaver.getWorld()
-							.getMessageHandler()
-							.handleMessage(
-									WeaveMessage.constructWeavingMessage(WeaveMessage.WEAVEMESSAGE_MIXIN, new String[] {
-											parentTM.getNewParent().getName(), fName, weaver.getLazyClassGen().getType().getName(),
-											tName }, weaver.getLazyClassGen().getClassName(), getAspectType().getName()));
-				} else {
+						.getMessageHandler()
+						.handleMessage(
+							WeaveMessage.constructWeavingMessage(
+								WeaveMessage.WEAVEMESSAGE_MIXIN,
+								new String[] {
+									parentTM.getNewParent().getName(), fName,
+									weaver.getLazyClassGen().getType().getName(), tName
+								},
+								weaver.getLazyClassGen().getClassName(), getAspectType().getName(),
+								parentTM.getNewParent().getSourceLocation(), weaver.getLazyClassGen().getType().getSourceLocation()
+							)
+						);
+				}
+				else {
 					if (parentTM.getNewParent().isInterface()) {
 						weaver.getWorld()
-								.getMessageHandler()
-								.handleMessage(
-										WeaveMessage.constructWeavingMessage(WeaveMessage.WEAVEMESSAGE_DECLAREPARENTSIMPLEMENTS,
-												new String[] { weaver.getLazyClassGen().getType().getName(), tName,
-														parentTM.getNewParent().getName(), fName }, weaver.getLazyClassGen()
-														.getClassName(), getAspectType().getName()));
-					} else {
+							.getMessageHandler()
+							.handleMessage(
+								WeaveMessage.constructWeavingMessage(
+									WeaveMessage.WEAVEMESSAGE_DECLAREPARENTSIMPLEMENTS,
+									new String[] {
+										weaver.getLazyClassGen().getType().getName(), tName,
+										parentTM.getNewParent().getName(), fName
+									},
+									weaver.getLazyClassGen().getClassName(), getAspectType().getName(),
+									parentTM.getNewParent().getSourceLocation(), weaver.getLazyClassGen().getType().getSourceLocation()
+								)
+							);
+					}
+					else {
 						weaver.getWorld()
 								.getMessageHandler()
 								.handleMessage(
@@ -232,11 +247,18 @@ public class BcelTypeMunger extends ConcreteTypeMunger {
 					fromString = fName;
 				}
 				weaver.getWorld()
-						.getMessageHandler()
-						.handleMessage(
-								WeaveMessage.constructWeavingMessage(WeaveMessage.WEAVEMESSAGE_ITD, new String[] {
-										weaver.getLazyClassGen().getType().getName(), tName, kindString, getAspectType().getName(),
-										fromString }, weaver.getLazyClassGen().getClassName(), getAspectType().getName()));
+					.getMessageHandler()
+					.handleMessage(
+						WeaveMessage.constructWeavingMessage(
+							WeaveMessage.WEAVEMESSAGE_ITD,
+							new String[] {
+								weaver.getLazyClassGen().getType().getName(), tName,
+								kindString, getAspectType().getName(), fromString
+							},
+							weaver.getLazyClassGen().getClassName(), getAspectType().getName(),
+							weaver.getLazyClassGen().getType().getSourceLocation(), getAspectType().getSourceLocation()
+						)
+					);
 			}
 		}
 

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWorld.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWorld.java
@@ -273,7 +273,7 @@ public class BcelWorld extends World implements Repository {
 			}
 			// if it's a binary file then also want to give the file name
 			if (isl.getSourceFileName() != null) {
-				nice.append("(from " + isl.getSourceFileName() + ")");
+				nice.append("(from ").append(isl.getSourceFileName()).append(")");
 			}
 		}
 		return nice.toString();

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWorld.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelWorld.java
@@ -190,17 +190,31 @@ public class BcelWorld extends World implements Repository {
 		String advisingType = advice.getConcreteAspect().getName();
 		Message msg = null;
 		if (advice.getKind().equals(AdviceKind.Softener)) {
-			msg = WeaveMessage.constructWeavingMessage(WeaveMessage.WEAVEMESSAGE_SOFTENS, new String[] { advisedType,
-					beautifyLocation(shadow.getSourceLocation()), advisingType, beautifyLocation(munger.getSourceLocation()) },
-					advisedType, advisingType);
-		} else {
+			msg = WeaveMessage.constructWeavingMessage(
+				WeaveMessage.WEAVEMESSAGE_SOFTENS,
+				new String[] {
+					advisedType, beautifyLocation(shadow.getSourceLocation()),
+					advisingType, beautifyLocation(munger.getSourceLocation())
+				},
+				advisedType, advisingType,
+				shadow.getSourceLocation(), munger.getSourceLocation()
+			);
+		}
+		else {
 			boolean runtimeTest = advice.hasDynamicTests();
 			String joinPointDescription = shadow.toString();
-			msg = WeaveMessage
-					.constructWeavingMessage(WeaveMessage.WEAVEMESSAGE_ADVISES,
-							new String[] { joinPointDescription, advisedType, beautifyLocation(shadow.getSourceLocation()),
-									description, advisingType, beautifyLocation(munger.getSourceLocation()),
-									(runtimeTest ? " [with runtime test]" : "") }, advisedType, advisingType);
+			msg = WeaveMessage.constructWeavingMessage(
+				WeaveMessage.WEAVEMESSAGE_ADVISES,
+				new String[] {
+					joinPointDescription,
+					advisedType, beautifyLocation(shadow.getSourceLocation()),
+					description,
+					advisingType, beautifyLocation(munger.getSourceLocation()),
+					(runtimeTest ? " [with runtime test]" : "")
+				},
+				advisedType, advisingType,
+				shadow.getSourceLocation(), munger.getSourceLocation()
+			);
 			// Boolean.toString(runtimeTest)});
 		}
 		getMessageHandler().handleMessage(msg);


### PR DESCRIPTION
_WIP (work in progress)._

@aclement: For now, I committed the solution with extended output via `ISourceLocation`s, see also https://github.com/eclipse/org.aspectj/issues/218#issuecomment-1407720246. In order for this to work, I had to adjust several tests expecting an exact line-by-line console output instead of selectively matching on weave messages. If I would change this to not passing through source locations but rather directly using file names and lines, I could revert the separate commit updating the expected test outputs, because then the change would be transparent, but also contain less specific information, both internally and on the console.

Closes #218.