### PR TITLE
Synchronise HandleProviderDelimiter constants with JDT Core and AJDT

### DIFF
--- a/asm/src/main/java/org/aspectj/asm/internal/HandleProviderDelimiter.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/HandleProviderDelimiter.java
@@ -17,35 +17,52 @@ import org.aspectj.asm.IProgramElement;
  */
 public class HandleProviderDelimiter {
 
-	// taken from JavaElement
+	// TODO:
+	//   Keep constants in sync between
+	//     - org.eclipse.jdt.internal.core.JavaElement (JDT Core),
+	//     - org.eclipse.ajdt.core.javaelements.AspectElement (AJDT Core),
+	//     - org.aspectj.asm.internal.HandleProviderDelimiter (AspectJ).
+	//   The reason is that JDT Core introduces new delimiters for new Java language constructs once in a while.
+	//   This led to clashes with existing AJDT symbols in the past already, which consequently had to be changed
+	//   to use other characters. Therefore, manual synchronisation with JDT Core is necessary.
+
+	// Taken from org.eclipse.jdt.internal.core.JavaElement (JDT Core)
+	public static final HandleProviderDelimiter ESCAPE = new HandleProviderDelimiter('\\');
 	public static final HandleProviderDelimiter JAVAPROJECT = new HandleProviderDelimiter('=');
+	public static final HandleProviderDelimiter PACKAGEFRAGMENTROOT = new HandleProviderDelimiter('/');
 	public static final HandleProviderDelimiter PACKAGEFRAGMENT = new HandleProviderDelimiter('<');
 	public static final HandleProviderDelimiter FIELD = new HandleProviderDelimiter('^');
 	public static final HandleProviderDelimiter METHOD = new HandleProviderDelimiter('~');
 	public static final HandleProviderDelimiter INITIALIZER = new HandleProviderDelimiter('|');
 	public static final HandleProviderDelimiter COMPILATIONUNIT = new HandleProviderDelimiter('{');
 	public static final HandleProviderDelimiter CLASSFILE = new HandleProviderDelimiter('(');
+	public static final HandleProviderDelimiter JEM_MODULAR_CLASSFILE = new HandleProviderDelimiter('\'');
 	public static final HandleProviderDelimiter TYPE = new HandleProviderDelimiter('[');
+	public static final HandleProviderDelimiter PACKAGEDECLARATION = new HandleProviderDelimiter('%');
 	public static final HandleProviderDelimiter IMPORTDECLARATION = new HandleProviderDelimiter('#');
 	public static final HandleProviderDelimiter COUNT = new HandleProviderDelimiter('!');
-	public static final HandleProviderDelimiter ESCAPE = new HandleProviderDelimiter('\\');
-	public static final HandleProviderDelimiter PACKAGEDECLARATION = new HandleProviderDelimiter('%');
-	public static final HandleProviderDelimiter PACKAGEFRAGMENTROOT = new HandleProviderDelimiter('/');
 	// these below are not currently used because no iprogramelement.kind
 	// equivalent
 	public static final HandleProviderDelimiter LOCALVARIABLE = new HandleProviderDelimiter('@');
 	public static final HandleProviderDelimiter TYPE_PARAMETER = new HandleProviderDelimiter(']');
+	public static final HandleProviderDelimiter ANNOTATION = new HandleProviderDelimiter('}');
+	public static final HandleProviderDelimiter LAMBDA_EXPRESSION = new HandleProviderDelimiter(')');
+	public static final HandleProviderDelimiter LAMBDA_METHOD = new HandleProviderDelimiter('&');
+	public static final HandleProviderDelimiter STRING = new HandleProviderDelimiter('"');
+	public static final HandleProviderDelimiter MODULE = new HandleProviderDelimiter('`');
+	public static final HandleProviderDelimiter DELIMITER_ESCAPE = new HandleProviderDelimiter('=');
 
-	// AspectJ specific ones
+	// Taken from org.aspectj.asm.internal.HandleProviderDelimiter (AspectJ)
 	public static final HandleProviderDelimiter ASPECT_CU = new HandleProviderDelimiter('*');
-	public static final HandleProviderDelimiter ADVICE = new HandleProviderDelimiter('&');
-	public static final HandleProviderDelimiter ASPECT_TYPE = new HandleProviderDelimiter('\'');
+	public static final HandleProviderDelimiter ADVICE = new HandleProviderDelimiter('§');
+	public static final HandleProviderDelimiter ASPECT_TYPE = new HandleProviderDelimiter('>');
 	public static final HandleProviderDelimiter CODEELEMENT = new HandleProviderDelimiter('?');
 	public static final HandleProviderDelimiter ITD_FIELD = new HandleProviderDelimiter(',');
-	public static final HandleProviderDelimiter ITD = new HandleProviderDelimiter(')');
-	public static final HandleProviderDelimiter DECLARE = new HandleProviderDelimiter('`');
-	public static final HandleProviderDelimiter POINTCUT = new HandleProviderDelimiter('"');
+	public static final HandleProviderDelimiter ITD_METHOD = new HandleProviderDelimiter('°');
+	public static final HandleProviderDelimiter DECLARE = new HandleProviderDelimiter('´');
+	public static final HandleProviderDelimiter POINTCUT = new HandleProviderDelimiter('©');
 
+	// Special delimiter for phantom handles
 	public static final HandleProviderDelimiter PHANTOM = new HandleProviderDelimiter(';');
 
 	private static char empty = ' ';
@@ -99,7 +116,7 @@ public class HandleProviderDelimiter {
 			return ITD_FIELD.getDelimiter();
 		} else if (kind.equals(IProgramElement.Kind.INTER_TYPE_METHOD) || kind.equals(IProgramElement.Kind.INTER_TYPE_CONSTRUCTOR)
 				|| kind.equals(IProgramElement.Kind.INTER_TYPE_PARENT)) {
-			return ITD.getDelimiter();
+			return ITD_METHOD.getDelimiter();
 		} else if (kind.equals(IProgramElement.Kind.CONSTRUCTOR) || kind.equals(IProgramElement.Kind.METHOD)) {
 			return METHOD.getDelimiter();
 		} else if (kind.equals(IProgramElement.Kind.FIELD) || kind.equals(IProgramElement.Kind.ENUM_VALUE)) {

--- a/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
+++ b/asm/src/main/java/org/aspectj/asm/internal/JDTLikeHandleProvider.java
@@ -20,11 +20,13 @@ import org.aspectj.bridge.ISourceLocation;
 
 /**
  * Creates JDT-like handles, for example
- *
- * method with string argument: &lt;tjp{Demo.java[Demo~main~\[QString; method with generic argument:
- * &lt;pkg{MyClass.java[MyClass~myMethod~QList\&lt;QString;&gt;; an aspect: &lt;pkg*A1.aj}A1 advice with Integer arg:
- * &lt;pkg*A8.aj}A8&amp;afterReturning&amp;QInteger; method call: &lt;pkg*A10.aj[C~m1?method-call(void pkg.C.m2())
- *
+ * <ul>
+ *   <li>method with string argument: {@code <tjp}<code>{</code>{@code Demo.java[Demo~main~\[QString;}</li>
+ *   <li>method with generic argument: {@code <pkg}<code>{</code>{@code MyClass.java[MyClass~myMethod~QList\<QString;>;}</li>
+ *   <li>aspect: {@code <pkg*A1.aj}<code>}</code>{@code A1}</li>
+ *   <li>advice with Integer arg: {@code <pkg*A8.aj}<code>}</code>{@code A8&afterReturning&QInteger;}</li>
+ *   <li>method call: {@code <pkg*A10.aj[C~m1?method-call(void pkg.C.m2())}</li>
+ * </ul>
  */
 public class JDTLikeHandleProvider implements IElementHandleProvider {
 

--- a/tests/model/expected/pr115607.txt
+++ b/tests/model/expected/pr115607.txt
@@ -1,16 +1,16 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     pr115607.java  [java source file] TEST_SANDBOX\pr115607.java:1:
-        [import reference] 
+        [import reference]
       I  [annotation] TEST_SANDBOX\pr115607.java:1:
       Simple  [class] TEST_SANDBOX\pr115607.java:3:
       pr115607  [aspect] TEST_SANDBOX\pr115607.java:5:
         declare @type: Simple : @I  [declare @type] TEST_SANDBOX\pr115607.java:6:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <{pr115607.java[Simple (annotated by) <{pr115607.java'pr115607`declare \@type
-(targets=1) <{pr115607.java'pr115607`declare \@type (annotates) <{pr115607.java[Simple
+(targets=1) <{pr115607.java[Simple (annotated by) <{pr115607.java>pr115607´declare \@type
+(targets=1) <{pr115607.java>pr115607´declare \@type (annotates) <{pr115607.java[Simple
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 import reference=1

--- a/tests/model/expected/pr120356.txt
+++ b/tests/model/expected/pr120356.txt
@@ -1,8 +1,8 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     A.java  [java source file] TEST_SANDBOX\A.java:1:
-        [import reference] 
+        [import reference]
         org.aspectj.lang.annotation.DeclareError  [import reference] TEST_SANDBOX\A.java:4:
         org.aspectj.lang.annotation.DeclareWarning  [import reference] TEST_SANDBOX\A.java:3:
         org.aspectj.lang.annotation.Aspect  [import reference] TEST_SANDBOX\A.java:2:
@@ -10,7 +10,7 @@
         warning  [field] TEST_SANDBOX\A.java:10:
         error  [field] TEST_SANDBOX\A.java:13:
     C.java  [java source file] TEST_SANDBOX\C.java:1:
-        [import reference] 
+        [import reference]
       C  [class] TEST_SANDBOX\C.java:3:
         warningMethod()  [method] TEST_SANDBOX\C.java:5:
         badMethod()  [method] TEST_SANDBOX\C.java:8:

--- a/tests/model/expected/pr131932.txt
+++ b/tests/model/expected/pr131932.txt
@@ -1,8 +1,8 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     pr131932.aj  [java source file] TEST_SANDBOX\pr131932.aj:1:
-        [import reference] 
+        [import reference]
         java.util.List  [import reference] TEST_SANDBOX\pr131932.aj:1:
       Slide74  [aspect] TEST_SANDBOX\pr131932.aj:3:
         Bar  [class] TEST_SANDBOX\pr131932.aj:13:
@@ -13,12 +13,12 @@
       Foo  [class] TEST_SANDBOX\pr131932.aj:19:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <*pr131932.aj'Slide74,Bar.children (declared on) <*pr131932.aj'Slide74[Bar
-(targets=2) <*pr131932.aj'Slide74[Bar (aspect declarations) <*pr131932.aj'Slide74)Bar.getFirst
-(targets=2) <*pr131932.aj'Slide74[Bar (aspect declarations) <*pr131932.aj'Slide74,Bar.children
-(targets=1) <*pr131932.aj'Slide74)Foo.Foo_new)QList\<QT;>; (declared on) <*pr131932.aj[Foo
-(targets=1) <*pr131932.aj'Slide74)Bar.getFirst (declared on) <*pr131932.aj'Slide74[Bar
-(targets=1) <*pr131932.aj[Foo (aspect declarations) <*pr131932.aj'Slide74)Foo.Foo_new)QList\<QT;>;
+(targets=1) <*pr131932.aj>Slide74,Bar.children (declared on) <*pr131932.aj>Slide74[Bar
+(targets=2) <*pr131932.aj>Slide74[Bar (aspect declarations) <*pr131932.aj>Slide74°Bar.getFirst
+(targets=2) <*pr131932.aj>Slide74[Bar (aspect declarations) <*pr131932.aj>Slide74,Bar.children
+(targets=1) <*pr131932.aj>Slide74°Foo.Foo_new°QList\<QT;>; (declared on) <*pr131932.aj[Foo
+(targets=1) <*pr131932.aj>Slide74°Bar.getFirst (declared on) <*pr131932.aj>Slide74[Bar
+(targets=1) <*pr131932.aj[Foo (aspect declarations) <*pr131932.aj>Slide74°Foo.Foo_new°QList\<QT;>;
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 import reference=2

--- a/tests/model/expected/pr132130.txt
+++ b/tests/model/expected/pr132130.txt
@@ -1,8 +1,8 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     pr132130.aj  [java source file] TEST_SANDBOX\pr132130.aj:1:
-        [import reference] 
+        [import reference]
       basic  [aspect] TEST_SANDBOX\pr132130.aj:1:
         declare @method: * debit(..) : @Secured(role = "supervisor")  [declare @method] TEST_SANDBOX\pr132130.aj:3:
         declare @constructor: BankAccount+.new(..) : @Secured(role = "supervisor")  [declare @constructor] TEST_SANDBOX\pr132130.aj:4:
@@ -12,10 +12,10 @@
       Secured  [annotation] TEST_SANDBOX\pr132130.aj:15:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <*pr132130.aj'basic`declare \@method (annotates) <*pr132130.aj[BankAccount~debit~J~J
-(targets=1) <*pr132130.aj[BankAccount~debit~J~J (annotated by) <*pr132130.aj'basic`declare \@method
-(targets=1) <*pr132130.aj'basic`declare \@constructor (annotates) <*pr132130.aj[BankAccount~BankAccount~QString;~I
-(targets=1) <*pr132130.aj[BankAccount~BankAccount~QString;~I (annotated by) <*pr132130.aj'basic`declare \@constructor
+(targets=1) <*pr132130.aj>basic´declare \@method (annotates) <*pr132130.aj[BankAccount~debit~J~J
+(targets=1) <*pr132130.aj[BankAccount~debit~J~J (annotated by) <*pr132130.aj>basic´declare \@method
+(targets=1) <*pr132130.aj>basic´declare \@constructor (annotates) <*pr132130.aj[BankAccount~BankAccount~QString;~I
+(targets=1) <*pr132130.aj[BankAccount~BankAccount~QString;~I (annotated by) <*pr132130.aj>basic´declare \@constructor
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=1

--- a/tests/model/expected/pr141730_1.txt
+++ b/tests/model/expected/pr141730_1.txt
@@ -1,8 +1,8 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     pr141730.aj  [java source file] TEST_SANDBOX\pr141730.aj:1:
-        [import reference] 
+        [import reference]
       A  [aspect] TEST_SANDBOX\pr141730.aj:1:
         p()  [pointcut] TEST_SANDBOX\pr141730.aj:3:
         before(): p..  [advice] TEST_SANDBOX\pr141730.aj:5:
@@ -19,28 +19,28 @@
       MyClass  [class] TEST_SANDBOX\pr141730.aj:33:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <*pr141730.aj[C~intArray~\[I (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~myClassMethod~QMyClass; (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~method (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~intMethod~I (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~C (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~multiMethod~\[\[QString; (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~twoArgsMethod~I~QString; (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[MyClass (advised by) <*pr141730.aj'A&before
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj'A
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[MyClass
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~C
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~method
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~intMethod~I
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~stringMethod~QString;
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~myClassMethod~QMyClass;
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~twoArgsMethod~I~QString;
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~main~\[QString;
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~multiMethod~\[\[QString;
-(targets=11) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~intArray~\[I
-(targets=1) <*pr141730.aj'A (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~main~\[QString; (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C~stringMethod~QString; (advised by) <*pr141730.aj'A&before
+(targets=1) <*pr141730.aj[C~intArray~\[I (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~myClassMethod~QMyClass; (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~method (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~intMethod~I (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~C (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~multiMethod~\[\[QString; (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~twoArgsMethod~I~QString; (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[MyClass (advised by) <*pr141730.aj>A§before
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj>A
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[MyClass
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~C
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~method
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~intMethod~I
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~stringMethod~QString;
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~myClassMethod~QMyClass;
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~twoArgsMethod~I~QString;
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~main~\[QString;
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~multiMethod~\[\[QString;
+(targets=11) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~intArray~\[I
+(targets=1) <*pr141730.aj>A (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~main~\[QString; (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C~stringMethod~QString; (advised by) <*pr141730.aj>A§before
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=8

--- a/tests/model/expected/pr141730_2.txt
+++ b/tests/model/expected/pr141730_2.txt
@@ -1,8 +1,8 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     pr141730.aj  [java source file] TEST_SANDBOX\pr141730.aj:1:
-        [import reference] 
+        [import reference]
         java.util.List  [import reference] TEST_SANDBOX\pr141730.aj:1:
       A  [aspect] TEST_SANDBOX\pr141730.aj:3:
         p()  [pointcut] TEST_SANDBOX\pr141730.aj:5:
@@ -14,18 +14,18 @@
       MyGenericClass  [class] TEST_SANDBOX\pr141730.aj:22:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <*pr141730.aj[C~genericMethod2~QMyGenericClass\<QString;QMyClass;>; (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[MyClass (advised by) <*pr141730.aj'A&before
-(targets=6) <*pr141730.aj'A&before (advises) <*pr141730.aj'A
-(targets=6) <*pr141730.aj'A&before (advises) <*pr141730.aj[MyGenericClass
-(targets=6) <*pr141730.aj'A&before (advises) <*pr141730.aj[C
-(targets=6) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~genericMethod~QList\<QString;>;
-(targets=6) <*pr141730.aj'A&before (advises) <*pr141730.aj[C~genericMethod2~QMyGenericClass\<QString;QMyClass;>;
-(targets=6) <*pr141730.aj'A&before (advises) <*pr141730.aj[MyClass
-(targets=1) <*pr141730.aj[C~genericMethod~QList\<QString;>; (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[MyGenericClass (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj'A (advised by) <*pr141730.aj'A&before
-(targets=1) <*pr141730.aj[C (advised by) <*pr141730.aj'A&before
+(targets=1) <*pr141730.aj[C~genericMethod2~QMyGenericClass\<QString;QMyClass;>; (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[MyClass (advised by) <*pr141730.aj>A§before
+(targets=6) <*pr141730.aj>A§before (advises) <*pr141730.aj>A
+(targets=6) <*pr141730.aj>A§before (advises) <*pr141730.aj[MyGenericClass
+(targets=6) <*pr141730.aj>A§before (advises) <*pr141730.aj[C
+(targets=6) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~genericMethod~QList\<QString;>;
+(targets=6) <*pr141730.aj>A§before (advises) <*pr141730.aj[C~genericMethod2~QMyGenericClass\<QString;QMyClass;>;
+(targets=6) <*pr141730.aj>A§before (advises) <*pr141730.aj[MyClass
+(targets=1) <*pr141730.aj[C~genericMethod~QList\<QString;>; (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[MyGenericClass (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj>A (advised by) <*pr141730.aj>A§before
+(targets=1) <*pr141730.aj[C (advised by) <*pr141730.aj>A§before
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=2

--- a/tests/model/expected/pr141730_3.txt
+++ b/tests/model/expected/pr141730_3.txt
@@ -1,9 +1,9 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  foo  [package] 
+<root>  [java source file]
+  foo  [package]
     MyFoo.java  [java source file] TEST_SANDBOX\MyFoo.java:1:
       foo  [package declaration] TEST_SANDBOX\MyFoo.java:1:
-        [import reference] 
+        [import reference]
       MyFoo  [class] TEST_SANDBOX\MyFoo.java:3:
         callMain()  [method] TEST_SANDBOX\MyFoo.java:5:
           method-call(void foo.MyFoo.main())  [code] TEST_SANDBOX\MyFoo.java:6:

--- a/tests/model/expected/pr141730_4.txt
+++ b/tests/model/expected/pr141730_4.txt
@@ -1,9 +1,9 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  bar  [package] 
+<root>  [java source file]
+  bar  [package]
     MyBar.aj  [java source file] TEST_SANDBOX\MyBar.aj:1:
       bar  [package declaration] TEST_SANDBOX\MyBar.aj:1:
-        [import reference] 
+        [import reference]
         foo.*  [import reference] TEST_SANDBOX\MyBar.aj:3:
       MyBar  [aspect] TEST_SANDBOX\MyBar.aj:5:
         before(): <anonymous pointcut>  [advice] TEST_SANDBOX\MyBar.aj:7:
@@ -15,18 +15,18 @@
         declare @field: int *Foo.* : @MyAnnotation  [declare @field] TEST_SANDBOX\MyBar.aj:16:
     MyAnnotation.java  [java source file] TEST_SANDBOX\MyAnnotation.java:1:
       bar  [package declaration] TEST_SANDBOX\MyAnnotation.java:1:
-        [import reference] 
+        [import reference]
       MyAnnotation  [annotation] TEST_SANDBOX\MyAnnotation.java:3:
     NewClass.java  [java source file] TEST_SANDBOX\NewClass.java:1:
       bar  [package declaration] TEST_SANDBOX\NewClass.java:1:
-        [import reference] 
+        [import reference]
       NewClass  [class] TEST_SANDBOX\NewClass.java:3:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <bar*MyBar.aj'MyBar`declare \@type (annotates) {MyFoo.java
-(targets=1) {MyFoo.java (annotated by) <bar*MyBar.aj'MyBar`declare \@type
-(targets=1) <bar*MyBar.aj'MyBar`declare parents (declared on) /;<foo(MyFoo.class[MyFoo
-(targets=1) /;<foo(MyFoo.class[MyFoo (aspect declarations) <bar*MyBar.aj'MyBar`declare parents
+(targets=1) <bar*MyBar.aj>MyBar´declare \@type (annotates) {MyFoo.java
+(targets=1) {MyFoo.java (annotated by) <bar*MyBar.aj>MyBar´declare \@type
+(targets=1) <bar*MyBar.aj>MyBar´declare parents (declared on) /;<foo(MyFoo.class[MyFoo
+(targets=1) /;<foo(MyFoo.class[MyFoo (aspect declarations) <bar*MyBar.aj>MyBar´declare parents
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 import reference=4

--- a/tests/model/expected/pr143924.txt
+++ b/tests/model/expected/pr143924.txt
@@ -1,8 +1,8 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     pr143924.aj  [java source file] TEST_SANDBOX\pr143924.aj:1:
-        [import reference] 
+        [import reference]
       DeclareAnnotation  [aspect] TEST_SANDBOX\pr143924.aj:1:
         declare @method: * debit(..) : @Secured(role = "supervisor")  [declare @method] TEST_SANDBOX\pr143924.aj:2:
       BankAccount  [class] TEST_SANDBOX\pr143924.aj:5:
@@ -10,8 +10,8 @@
       Secured  [annotation] TEST_SANDBOX\pr143924.aj:11:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <*pr143924.aj[BankAccount~debit~QString;~J (annotated by) <*pr143924.aj'DeclareAnnotation`declare \@method
-(targets=1) <*pr143924.aj'DeclareAnnotation`declare \@method (annotates) <*pr143924.aj[BankAccount~debit~QString;~J
+(targets=1) <*pr143924.aj[BankAccount~debit~QString;~J (annotated by) <*pr143924.aj>DeclareAnnotation´declare \@method
+(targets=1) <*pr143924.aj>DeclareAnnotation´declare \@method (annotates) <*pr143924.aj[BankAccount~debit~QString;~J
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=1

--- a/tests/model/expected/pr145963_1.txt
+++ b/tests/model/expected/pr145963_1.txt
@@ -1,22 +1,22 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  pkg  [package] 
+<root>  [java source file]
+  pkg  [package]
     SourceAspect.aj  [java source file] TEST_SANDBOX\SourceAspect.aj:1:
       pkg  [package declaration] TEST_SANDBOX\SourceAspect.aj:1:
-        [import reference] 
+        [import reference]
       SourceAspect  [aspect] TEST_SANDBOX\SourceAspect.aj:3:
         declare warning: "There should be n.."  [declare warning] TEST_SANDBOX\SourceAspect.aj:5:
         p()  [pointcut] TEST_SANDBOX\SourceAspect.aj:7:
         before(): p..  [advice] TEST_SANDBOX\SourceAspect.aj:9:
-  pack  [package] 
+  pack  [package]
     C.java  [java source file] TEST_SANDBOX\C.java:1:
       pack  [package declaration] TEST_SANDBOX\C.java:1:
-        [import reference] 
+        [import reference]
       C  [class] TEST_SANDBOX\C.java:3:
         method1()  [method] TEST_SANDBOX\C.java:5:
           field-get(java.io.PrintStream java.lang.System.out)  [code] TEST_SANDBOX\C.java:6:
-  binaries  [source folder] 
-    pkg  [package] 
+  binaries  [source folder]
+    pkg  [package]
       BinaryAspect.class  [file] TEST_SANDBOX\simple.jar!pkg\BinaryAspect.class:1:
         BinaryAspect  [aspect] TEST_SANDBOX\simple.jar!pkg\BinaryAspect.class:1:
           p()  [pointcut] TEST_SANDBOX\simple.jar!pkg\BinaryAspect.class:7:
@@ -24,14 +24,14 @@
           declare warning: "There should be n.."  [declare warning] TEST_SANDBOX\simple.jar!pkg\BinaryAspect.class:5:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) /binaries<pkg(BinaryAspect.class'BinaryAspect`declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
-(targets=1) <pkg*SourceAspect.aj'SourceAspect`declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
-(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) <pkg*SourceAspect.aj'SourceAspect`declare warning
-(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<pkg(BinaryAspect.class'BinaryAspect`declare warning
-(targets=1) <pkg*SourceAspect.aj'SourceAspect&before (advises) <pack{C.java[C~method1
-(targets=1) /binaries<pkg(BinaryAspect.class'BinaryAspect&before (advises) <pack{C.java[C~method1
-(targets=2) <pack{C.java[C~method1 (advised by) <pkg*SourceAspect.aj'SourceAspect&before
-(targets=2) <pack{C.java[C~method1 (advised by) /binaries<pkg(BinaryAspect.class'BinaryAspect&before
+(targets=1) /binaries<pkg(BinaryAspect.class>BinaryAspect´declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
+(targets=1) <pkg*SourceAspect.aj>SourceAspect´declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
+(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) <pkg*SourceAspect.aj>SourceAspect´declare warning
+(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<pkg(BinaryAspect.class>BinaryAspect´declare warning
+(targets=1) <pkg*SourceAspect.aj>SourceAspect§before (advises) <pack{C.java[C~method1
+(targets=1) /binaries<pkg(BinaryAspect.class>BinaryAspect§before (advises) <pack{C.java[C~method1
+(targets=2) <pack{C.java[C~method1 (advised by) <pkg*SourceAspect.aj>SourceAspect§before
+(targets=2) <pack{C.java[C~method1 (advised by) /binaries<pkg(BinaryAspect.class>BinaryAspect§before
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=1

--- a/tests/model/expected/pr145963_2.txt
+++ b/tests/model/expected/pr145963_2.txt
@@ -1,22 +1,22 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  pkg  [package] 
+<root>  [java source file]
+  pkg  [package]
     SourceAspect.aj  [java source file] TEST_SANDBOX\SourceAspect.aj:1:
       pkg  [package declaration] TEST_SANDBOX\SourceAspect.aj:1:
-        [import reference] 
+        [import reference]
       SourceAspect  [aspect] TEST_SANDBOX\SourceAspect.aj:3:
         declare warning: "There should be n.."  [declare warning] TEST_SANDBOX\SourceAspect.aj:5:
         p()  [pointcut] TEST_SANDBOX\SourceAspect.aj:7:
         before(): p..  [advice] TEST_SANDBOX\SourceAspect.aj:9:
-  pack  [package] 
+  pack  [package]
     C.java  [java source file] TEST_SANDBOX\C.java:1:
       pack  [package declaration] TEST_SANDBOX\C.java:1:
-        [import reference] 
+        [import reference]
       C  [class] TEST_SANDBOX\C.java:3:
         method1()  [method] TEST_SANDBOX\C.java:5:
           field-get(java.io.PrintStream java.lang.System.out)  [code] TEST_SANDBOX\C.java:6:
-  binaries  [source folder] 
-    pkg  [package] 
+  binaries  [source folder]
+    pkg  [package]
       BinaryAspect.class  [file] TEST_SANDBOX!pkg\BinaryAspect.class:1:
         BinaryAspect  [aspect] TEST_SANDBOX!pkg\BinaryAspect.class:1:
           p()  [pointcut] TEST_SANDBOX!pkg\BinaryAspect.class:7:
@@ -24,14 +24,14 @@
           declare warning: "There should be n.."  [declare warning] TEST_SANDBOX!pkg\BinaryAspect.class:5:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) /binaries<pkg(BinaryAspect.class'BinaryAspect`declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
-(targets=1) <pkg*SourceAspect.aj'SourceAspect`declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
-(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) <pkg*SourceAspect.aj'SourceAspect`declare warning
-(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<pkg(BinaryAspect.class'BinaryAspect`declare warning
-(targets=1) <pkg*SourceAspect.aj'SourceAspect&before (advises) <pack{C.java[C~method1
-(targets=1) /binaries<pkg(BinaryAspect.class'BinaryAspect&before (advises) <pack{C.java[C~method1
-(targets=2) <pack{C.java[C~method1 (advised by) <pkg*SourceAspect.aj'SourceAspect&before
-(targets=2) <pack{C.java[C~method1 (advised by) /binaries<pkg(BinaryAspect.class'BinaryAspect&before
+(targets=1) /binaries<pkg(BinaryAspect.class>BinaryAspect´declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
+(targets=1) <pkg*SourceAspect.aj>SourceAspect´declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
+(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) <pkg*SourceAspect.aj>SourceAspect´declare warning
+(targets=2) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<pkg(BinaryAspect.class>BinaryAspect´declare warning
+(targets=1) <pkg*SourceAspect.aj>SourceAspect§before (advises) <pack{C.java[C~method1
+(targets=1) /binaries<pkg(BinaryAspect.class>BinaryAspect§before (advises) <pack{C.java[C~method1
+(targets=2) <pack{C.java[C~method1 (advised by) <pkg*SourceAspect.aj>SourceAspect§before
+(targets=2) <pack{C.java[C~method1 (advised by) /binaries<pkg(BinaryAspect.class>BinaryAspect§before
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=1

--- a/tests/model/expected/pr145963_3.txt
+++ b/tests/model/expected/pr145963_3.txt
@@ -1,20 +1,20 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     C.java  [java source file] TEST_SANDBOX\C.java:1:
-        [import reference] 
+        [import reference]
       C  [class] TEST_SANDBOX\C.java:3:
         method1()  [method] TEST_SANDBOX\C.java:5:
           field-get(java.io.PrintStream java.lang.System.out)  [code] TEST_SANDBOX\C.java:6:
-  binaries  [source folder] 
-      [package] 
+  binaries  [source folder]
+      [package]
       AspectInDefaultPackage.class  [file] TEST_SANDBOX\simple.jar!\AspectInDefaultPackage.class:1:
         AspectInDefaultPackage  [aspect] TEST_SANDBOX\simple.jar!\AspectInDefaultPackage.class:1:
           declare warning: "There should be n.."  [declare warning] TEST_SANDBOX\simple.jar!\AspectInDefaultPackage.class:4:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) /binaries<(AspectInDefaultPackage.class'AspectInDefaultPackage`declare warning (matched by) <{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
-(targets=1) <{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<(AspectInDefaultPackage.class'AspectInDefaultPackage`declare warning
+(targets=1) /binaries<(AspectInDefaultPackage.class>AspectInDefaultPackage´declare warning (matched by) <{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
+(targets=1) <{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<(AspectInDefaultPackage.class>AspectInDefaultPackage´declare warning
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=1

--- a/tests/model/expected/pr145963_4.txt
+++ b/tests/model/expected/pr145963_4.txt
@@ -1,21 +1,21 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  pack  [package] 
+<root>  [java source file]
+  pack  [package]
     C.java  [java source file] TEST_SANDBOX\C.java:1:
       pack  [package declaration] TEST_SANDBOX\C.java:1:
-        [import reference] 
+        [import reference]
       C  [class] TEST_SANDBOX\C.java:3:
         method1()  [method] TEST_SANDBOX\C.java:5:
           field-get(java.io.PrintStream java.lang.System.out)  [code] TEST_SANDBOX\C.java:6:
-  binaries  [source folder] 
-      [package] 
+  binaries  [source folder]
+      [package]
       A.class  [file] TEST_SANDBOX\simple.jar!\A.class:1:
         A  [aspect] TEST_SANDBOX\simple.jar!\A.class:1:
           declare warning: "There should be n.."  [declare warning] TEST_SANDBOX\simple.jar!\A.class:4:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) /binaries<(A.class'A`declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
-(targets=1) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<(A.class'A`declare warning
+(targets=1) /binaries<(A.class>A´declare warning (matched by) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out)
+(targets=1) <pack{C.java[C~method1?field-get(java.io.PrintStream java.lang.System.out) (matches declare) /binaries<(A.class>A´declare warning
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=1

--- a/tests/model/expected/pr148027.txt
+++ b/tests/model/expected/pr148027.txt
@@ -1,15 +1,15 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  pkg  [package] 
+<root>  [java source file]
+  pkg  [package]
     A.aj  [java source file] TEST_SANDBOX\A.aj:1:
-      import declarations  [import reference] 
+      import declarations  [import reference]
       A  [aspect] TEST_SANDBOX\A.aj:3:
         before(): pointcutInClass..  [advice] TEST_SANDBOX\A.aj:5:
         pointcutInAspect()  [pointcut] TEST_SANDBOX\A.aj:8:
         before(): pointcutInAspect..  [advice] TEST_SANDBOX\A.aj:10:
         aMethod()  [method] TEST_SANDBOX\A.aj:13:
     C.aj  [java source file] TEST_SANDBOX\C.aj:1:
-      import declarations  [import reference] 
+      import declarations  [import reference]
       C  [class] TEST_SANDBOX\C.aj:3:
         pointcutInClass()  [pointcut] TEST_SANDBOX\C.aj:5:
         cMethod()  [method] TEST_SANDBOX\C.aj:7:

--- a/tests/model/expected/pr160469_1.txt
+++ b/tests/model/expected/pr160469_1.txt
@@ -1,13 +1,13 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  test  [package] 
+<root>  [java source file]
+  test  [package]
     Simple.java  [java source file] TEST_SANDBOX\Simple.java:1:
       test  [package declaration] TEST_SANDBOX\Simple.java:1:
-        [import reference] 
+        [import reference]
       Simple  [class] TEST_SANDBOX\Simple.java:3:
         Simple()  [constructor] TEST_SANDBOX\Simple.java:5:
-  binaries  [source folder] 
-    pkg  [package] 
+  binaries  [source folder]
+    pkg  [package]
       AbstractBeanConfigurerAspect.class  [file] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:1:
         AbstractBeanConfigurerAspect  [aspect] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:1:
           beanCreation()  [pointcut] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:1:
@@ -15,10 +15,10 @@
           before(): beanCreation..  [advice] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:11:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) /binaries<pkg(AbstractBeanConfigurerAspect.class'AbstractBeanConfigurerAspect&before (advises) <test{Simple.java[Simple~Simple
-(targets=2) <test{Simple.java[Simple~Simple (advised by) /binaries<pkg(AbstractBeanConfigurerAspect.class'AbstractBeanConfigurerAspect&afterReturning
-(targets=2) <test{Simple.java[Simple~Simple (advised by) /binaries<pkg(AbstractBeanConfigurerAspect.class'AbstractBeanConfigurerAspect&before
-(targets=1) /binaries<pkg(AbstractBeanConfigurerAspect.class'AbstractBeanConfigurerAspect&afterReturning (advises) <test{Simple.java[Simple~Simple
+(targets=1) /binaries<pkg(AbstractBeanConfigurerAspect.class>AbstractBeanConfigurerAspect§before (advises) <test{Simple.java[Simple~Simple
+(targets=2) <test{Simple.java[Simple~Simple (advised by) /binaries<pkg(AbstractBeanConfigurerAspect.class>AbstractBeanConfigurerAspect§afterReturning
+(targets=2) <test{Simple.java[Simple~Simple (advised by) /binaries<pkg(AbstractBeanConfigurerAspect.class>AbstractBeanConfigurerAspect§before
+(targets=1) /binaries<pkg(AbstractBeanConfigurerAspect.class>AbstractBeanConfigurerAspect§afterReturning (advises) <test{Simple.java[Simple~Simple
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 import reference=1

--- a/tests/model/expected/pr160469_2.txt
+++ b/tests/model/expected/pr160469_2.txt
@@ -1,21 +1,21 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  test  [package] 
+<root>  [java source file]
+  test  [package]
     Simple.java  [java source file] TEST_SANDBOX\Simple.java:1:
       test  [package declaration] TEST_SANDBOX\Simple.java:1:
-        [import reference] 
+        [import reference]
       Simple  [class] TEST_SANDBOX\Simple.java:3:
         Simple()  [constructor] TEST_SANDBOX\Simple.java:5:
-  binaries  [source folder] 
-    pkg  [package] 
+  binaries  [source folder]
+    pkg  [package]
       AbstractBeanConfigurerAspect.class  [file] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:1:
         AbstractBeanConfigurerAspect  [aspect] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:1:
           beanCreation()  [pointcut] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:1:
           declare warning: "warning"  [declare warning] TEST_SANDBOX\aspects.jar!pkg\AbstractBeanConfigurerAspect.class:7:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <test{Simple.java[Simple~Simple (matches declare) /binaries<pkg(AbstractBeanConfigurerAspect.class'AbstractBeanConfigurerAspect`declare warning
-(targets=1) /binaries<pkg(AbstractBeanConfigurerAspect.class'AbstractBeanConfigurerAspect`declare warning (matched by) <test{Simple.java[Simple~Simple
+(targets=1) <test{Simple.java[Simple~Simple (matches declare) /binaries<pkg(AbstractBeanConfigurerAspect.class>AbstractBeanConfigurerAspect´declare warning
+(targets=1) /binaries<pkg(AbstractBeanConfigurerAspect.class>AbstractBeanConfigurerAspect´declare warning (matched by) <test{Simple.java[Simple~Simple
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 import reference=1

--- a/tests/model/expected/pr238054.txt
+++ b/tests/model/expected/pr238054.txt
@@ -1,7 +1,7 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
+<root>  [java source file]
   pr238054.aj  [java source file] TEST_SANDBOX\pr238054.aj:1:
-    import declarations  [import reference] 
+    import declarations  [import reference]
     A  [class] TEST_SANDBOX\pr238054.aj:1:
       x()  [method] TEST_SANDBOX\pr238054.aj:2:
       y()  [method] TEST_SANDBOX\pr238054.aj:3:

--- a/tests/model/expected/pr77269_1.txt
+++ b/tests/model/expected/pr77269_1.txt
@@ -1,9 +1,9 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  pack  [package] 
+<root>  [java source file]
+  pack  [package]
     pr77269.aj  [java source file] TEST_SANDBOX\pack\pr77269.aj:1:
       pack  [package declaration] TEST_SANDBOX\pack\pr77269.aj:1:
-        [import reference] 
+        [import reference]
       Test  [class] TEST_SANDBOX\pack\pr77269.aj:2:
         testMethod()  [method] TEST_SANDBOX\pack\pr77269.aj:4:
           new Runnable() {..}  [class] TEST_SANDBOX\pack\pr77269.aj:5:
@@ -15,8 +15,8 @@
         before(): p..  [advice] TEST_SANDBOX\pack\pr77269.aj:21:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <pack*pr77269.aj[Test~testMethod[~run (advised by) <pack*pr77269.aj'A&before
-(targets=1) <pack*pr77269.aj'A&before (advises) <pack*pr77269.aj[Test~testMethod[~run
+(targets=1) <pack*pr77269.aj[Test~testMethod[~run (advised by) <pack*pr77269.aj>A§before
+(targets=1) <pack*pr77269.aj>A§before (advises) <pack*pr77269.aj[Test~testMethod[~run
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=3

--- a/tests/model/expected/pr77269_2.txt
+++ b/tests/model/expected/pr77269_2.txt
@@ -1,8 +1,8 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-    [package] 
+<root>  [java source file]
+    [package]
     pr77269b.aj  [java source file] TEST_SANDBOX\pr77269b.aj:1:
-        [import reference] 
+        [import reference]
       Test  [class] TEST_SANDBOX\pr77269b.aj:1:
         testMethod()  [method] TEST_SANDBOX\pr77269b.aj:3:
           new Runnable() {..}  [class] TEST_SANDBOX\pr77269b.aj:4:
@@ -14,8 +14,8 @@
         before(): p..  [advice] TEST_SANDBOX\pr77269b.aj:20:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <*pr77269b.aj'A&before (advises) <*pr77269b.aj[Test~testMethod[C~m
-(targets=1) <*pr77269b.aj[Test~testMethod[C~m (advised by) <*pr77269b.aj'A&before
+(targets=1) <*pr77269b.aj>A§before (advises) <*pr77269b.aj[Test~testMethod[C~m
+(targets=1) <*pr77269b.aj[Test~testMethod[C~m (advised by) <*pr77269b.aj>A§before
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=3

--- a/tests/model/expected/pr77269_3.txt
+++ b/tests/model/expected/pr77269_3.txt
@@ -1,9 +1,9 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
-  pack  [package] 
+<root>  [java source file]
+  pack  [package]
     pr77269c.aj  [java source file] TEST_SANDBOX\pack\pr77269c.aj:1:
       pack  [package declaration] TEST_SANDBOX\pack\pr77269c.aj:1:
-        [import reference] 
+        [import reference]
       Test  [class] TEST_SANDBOX\pack\pr77269c.aj:3:
         testMethod()  [method] TEST_SANDBOX\pack\pr77269c.aj:5:
           new Runnable() {..}  [class] TEST_SANDBOX\pack\pr77269c.aj:6:
@@ -14,8 +14,8 @@
         declare warning: "blah blah blah"  [declare warning] TEST_SANDBOX\pack\pr77269c.aj:18:
 === END OF MODEL REPORT =========
 === RELATIONSHIPS REPORT ========= After a batch build
-(targets=1) <pack*pr77269c.aj[Test~testMethod[~run?method-call(void pack.Test.someMethod()) (matches declare) <pack*pr77269c.aj'A`declare warning
-(targets=1) <pack*pr77269c.aj'A`declare warning (matched by) <pack*pr77269c.aj[Test~testMethod[~run?method-call(void pack.Test.someMethod())
+(targets=1) <pack*pr77269c.aj[Test~testMethod[~run?method-call(void pack.Test.someMethod()) (matches declare) <pack*pr77269c.aj>A´declare warning
+(targets=1) <pack*pr77269c.aj>A´declare warning (matched by) <pack*pr77269c.aj[Test~testMethod[~run?method-call(void pack.Test.someMethod())
 === END OF RELATIONSHIPS REPORT ==
 === Properties of the model and relationships map =====
 method=3

--- a/tests/model/expected/prX.txt
+++ b/tests/model/expected/prX.txt
@@ -1,7 +1,7 @@
 === MODEL STATUS REPORT ========= After a batch build
-<root>  [java source file] 
+<root>  [java source file]
   X.java  [java source file] TEST_SANDBOX\X.java:1:
-    import declarations  [import reference] 
+    import declarations  [import reference]
     X  [aspect] TEST_SANDBOX\X.java:1:
       before(): <anonymous pointcut>..  [advice] TEST_SANDBOX\X.java:2:
 === END OF MODEL REPORT =========

--- a/tests/src/test/java/org/aspectj/systemtest/ajc153/JDTLikeHandleProviderTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc153/JDTLikeHandleProviderTests.java
@@ -44,25 +44,25 @@ public class JDTLikeHandleProviderTests extends XMLBasedAjcTestCase {
 		runTest("aspect handle");
 		IHierarchy top = AsmManager.lastActiveStructureModel.getHierarchy();
 		IProgramElement pe = top.findElementForType("pkg", "A1");
-		String expected = "<pkg*A1.aj'A1";
+		String expected = "<pkg*A1.aj>A1";
 		String found = pe.getHandleIdentifier();
 		assertEquals("handleIdentifier - expected " + expected + ", but found " + found, expected, found);
 	}
 
 	public void testAdviceHandle() {
 		runTest("advice handle");
-		compareHandles(IProgramElement.Kind.ADVICE, "before(): <anonymous pointcut>", "<pkg*A2.aj'A2&before");
+		compareHandles(IProgramElement.Kind.ADVICE, "before(): <anonymous pointcut>", "<pkg*A2.aj>A2§before");
 	}
 
 	public void testPointcutHandle() {
 		runTest("pointcut handle");
-		compareHandles(IProgramElement.Kind.POINTCUT, "p()", "<pkg*A4.aj'A4\"p");
+		compareHandles(IProgramElement.Kind.POINTCUT, "p()", "<pkg*A4.aj>A4©p");
 	}
 
 	public void testGetIPEWithAspectHandle() {
 		runTest("get IProgramElement with aspect handle");
 		IHierarchy top = AsmManager.lastActiveStructureModel.getHierarchy();
-		String handle = "<pkg*A1.aj'A1";
+		String handle = "<pkg*A1.aj>A1";
 		IProgramElement ipe = top.getElement(handle);
 		assertNotNull("should have found ipe with handle " + handle, ipe);
 		IProgramElement ipe2 = top.getElement(handle);
@@ -71,49 +71,49 @@ public class JDTLikeHandleProviderTests extends XMLBasedAjcTestCase {
 
 	public void testAdviceHandleWithCrossCutting() {
 		runTest("advice handle with crosscutting");
-		compareHandles(IProgramElement.Kind.ADVICE, "before(): <anonymous pointcut>", "<pkg*A3.aj'A3&before");
+		compareHandles(IProgramElement.Kind.ADVICE, "before(): <anonymous pointcut>", "<pkg*A3.aj>A3§before");
 	}
 
 	public void testPointcutHandleWithArgs() {
 		runTest("pointcut handle with args");
-		compareHandles(IProgramElement.Kind.POINTCUT, "p(java.lang.Integer)", "<*A6.aj'A6\"p\"QInteger;");
+		compareHandles(IProgramElement.Kind.POINTCUT, "p(java.lang.Integer)", "<*A6.aj>A6©p©QInteger;");
 	}
 
 	public void testAdviceHandleWithArgs() {
 		runTest("advice handle with args");
 		compareHandles(IProgramElement.Kind.ADVICE, "afterReturning(java.lang.Integer): p..",
-				"<pkg*A8.aj'A8&afterReturning&QInteger;");
+				"<pkg*A8.aj>A8§afterReturning§QInteger;");
 	}
 
 	public void testFieldITD() {
 		runTest("field itd handle");
-		compareHandles(IProgramElement.Kind.INTER_TYPE_FIELD, "C.x", "<pkg*A9.aj'A9,C.x");
+		compareHandles(IProgramElement.Kind.INTER_TYPE_FIELD, "C.x", "<pkg*A9.aj>A9,C.x");
 	}
 
 	public void testMethodITD() {
 		runTest("method itd handle");
-		compareHandles(IProgramElement.Kind.INTER_TYPE_METHOD, "C.method()", "<pkg*A9.aj'A9)C.method");
+		compareHandles(IProgramElement.Kind.INTER_TYPE_METHOD, "C.method()", "<pkg*A9.aj>A9°C.method");
 	}
 
 	public void testMethodITDWithArgs() {
 		runTest("method itd with args handle");
-		compareHandles(IProgramElement.Kind.INTER_TYPE_METHOD, "C.methodWithArgs(int)", "<pkg*A9.aj'A9)C.methodWithArgs)I");
+		compareHandles(IProgramElement.Kind.INTER_TYPE_METHOD, "C.methodWithArgs(int)", "<pkg*A9.aj>A9°C.methodWithArgs°I");
 	}
 
 	public void testConstructorITDWithArgs() {
 		runTest("constructor itd with args");
 		compareHandles(IProgramElement.Kind.INTER_TYPE_CONSTRUCTOR, "C.C(int,java.lang.String)",
-				"<pkg*A13.aj'A13)C.C_new)I)QString;");
+				"<pkg*A13.aj>A13°C.C_new°I°QString;");
 	}
 
 	public void testDeclareParentsHandle() {
 		runTest("declare parents handle");
-		compareHandles(IProgramElement.Kind.DECLARE_PARENTS, "declare parents: implements C2", "<pkg*A7.aj'A7`declare parents");
+		compareHandles(IProgramElement.Kind.DECLARE_PARENTS, "declare parents: implements C2", "<pkg*A7.aj>A7´declare parents");
 	}
 
 	public void testTwoDeclareParents() {
 		runTest("two declare parents in same file");
-		compareHandles(IProgramElement.Kind.DECLARE_PARENTS, "declare parents: extends C5", "<pkg*A7.aj'A7`declare parents!2");
+		compareHandles(IProgramElement.Kind.DECLARE_PARENTS, "declare parents: extends C5", "<pkg*A7.aj>A7´declare parents!2");
 	}
 
 	public void testMethodCallHandle() {
@@ -125,28 +125,28 @@ public class JDTLikeHandleProviderTests extends XMLBasedAjcTestCase {
 		// AJDT: =AJHandleProject/src<pkg*A.aj}A`declare \@type
 		runTest("declare @type");
 		compareHandles(IProgramElement.Kind.DECLARE_ANNOTATION_AT_TYPE, "declare @type: pkg.C : @MyAnnotation",
-				"<pkg*A12.aj'A`declare \\@type");
+				"<pkg*A12.aj>A´declare \\@type");
 	}
 
 	public void testDeclareAtField() {
 		// AJDT: =AJHandleProject/src<pkg*A.aj}A`declare \@field
 		runTest("declare @field");
 		compareHandles(IProgramElement.Kind.DECLARE_ANNOTATION_AT_FIELD, "declare @field: int pkg.C.someField : @MyAnnotation",
-				"<pkg*A12.aj'A`declare \\@field");
+				"<pkg*A12.aj>A´declare \\@field");
 	}
 
 	public void testDeclareAtMethod() {
 		// AJDT: =AJHandleProject/src<pkg*A.aj}A`declare \@method
 		runTest("declare @method");
 		compareHandles(IProgramElement.Kind.DECLARE_ANNOTATION_AT_METHOD,
-				"declare @method: public void pkg.C.method1() : @MyAnnotation", "<pkg*A12.aj'A`declare \\@method");
+				"declare @method: public void pkg.C.method1() : @MyAnnotation", "<pkg*A12.aj>A´declare \\@method");
 	}
 
 	public void testDeclareAtConstructor() {
 		// AJDT: =AJHandleProject/src<pkg*A.aj}A`declare \@constructor
 		runTest("declare @constructor");
 		compareHandles(IProgramElement.Kind.DECLARE_ANNOTATION_AT_CONSTRUCTOR, "declare @constructor: pkg.C.new() : @MyAnnotation",
-				"<pkg*A12.aj'A`declare \\@constructor");
+				"<pkg*A12.aj>A´declare \\@constructor");
 	}
 
 	// what about 2 pieces of before advice with the same
@@ -168,8 +168,8 @@ public class JDTLikeHandleProviderTests extends XMLBasedAjcTestCase {
 				}
 			}
 		}
-		String expected1 = "<pkg*A5.aj'A5&before";
-		String expected2 = "<pkg*A5.aj'A5&before!2";
+		String expected1 = "<pkg*A5.aj>A5§before";
+		String expected2 = "<pkg*A5.aj>A5§before!2";
 		boolean b = expected1.equals(handle1);
 		if (b) {
 			assertEquals("handleIdentifier - expected " + expected2 + ", but found " + handle2, expected2, handle2);
@@ -182,12 +182,12 @@ public class JDTLikeHandleProviderTests extends XMLBasedAjcTestCase {
 	public void testDeclareWarningHandle() {
 		runTest("declare warning handle");
 		compareHandles(IProgramElement.Kind.DECLARE_WARNING, "declare warning: \"Illegal call.\"",
-				"<pkg*A11.aj'A11`declare warning");
+				"<pkg*A11.aj>A11´declare warning");
 	}
 
 	public void testTwoDeclareWarningHandles() {
 		runTest("two declare warning handles");
-		compareHandles(IProgramElement.Kind.DECLARE_WARNING, "declare warning: \"blah\"", "<pkg*A11.aj'A11`declare warning!2");
+		compareHandles(IProgramElement.Kind.DECLARE_WARNING, "declare warning: \"blah\"", "<pkg*A11.aj>A11´declare warning!2");
 	}
 
 	// this is to ensure the logic for not including '1' in the count
@@ -196,9 +196,9 @@ public class JDTLikeHandleProviderTests extends XMLBasedAjcTestCase {
 	public void testTenDeclareWarningHandles() {
 		runTest("ten declare warning handles");
 		compareHandles(IProgramElement.Kind.DECLARE_WARNING, "declare warning: \"warning 1\"",
-				"<*DeclareWarnings.aj'DeclareWarnings`declare warning");
+				"<*DeclareWarnings.aj>DeclareWarnings´declare warning");
 		compareHandles(IProgramElement.Kind.DECLARE_WARNING, "declare warning: \"warning 10\"",
-				"<*DeclareWarnings.aj'DeclareWarnings`declare warning!10");
+				"<*DeclareWarnings.aj>DeclareWarnings´declare warning!10");
 
 	}
 

--- a/tests/src/test/java/org/aspectj/systemtest/ajc161/Ajc161Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc161/Ajc161Tests.java
@@ -139,7 +139,7 @@ public class Ajc161Tests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		IRelationshipMap irm = AsmManager.lastActiveStructureModel.getRelationshipMap();
 		Set entries = irm.getEntries();
 		boolean gotSomethingValid = false;
-		String expected = "<recursivepackage{RecursiveCatcher.java'RecursiveCatcher~recursiveCall~I?method-call(void recursivepackage.RecursiveCatcher.recursiveCall(int))";
+		String expected = "<recursivepackage{RecursiveCatcher.java>RecursiveCatcher~recursiveCall~I?method-call(void recursivepackage.RecursiveCatcher.recursiveCall(int))";
 		for (Object entry : entries) {
 			String str = (String) entry;
 			if (str.contains(expected)) {

--- a/tests/src/test/java/org/aspectj/systemtest/ajc163/Ajc163Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc163/Ajc163Tests.java
@@ -125,31 +125,31 @@ public class Ajc163Tests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		IHierarchy top = AsmManager.lastActiveStructureModel.getHierarchy();
 		IProgramElement ipe = null;
 		ipe = findElementAtLine(top.getRoot(), 4);// public java.util.List<String> Ship.i(List<String>[][] u)
-		assertEquals("<{Handles.java'Handles)Ship.i)\\[\\[QList\\<QString;>;", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles°Ship.i°\\[\\[QList\\<QString;>;", ipe.getHandleIdentifier());
 
 		ipe = findElementAtLine(top.getRoot(), 7);// public java.util.List<String> Ship.i(Set<String>[][] u)
-		assertEquals("<{Handles.java'Handles)Ship.i)\\[\\[QSet\\<QString;>;", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles°Ship.i°\\[\\[QSet\\<QString;>;", ipe.getHandleIdentifier());
 
 		// public java.util.Set<String> i(java.util.Set<String>[][] u)
 		ipe = findElementAtLine(top.getRoot(), 10);
-		assertEquals("<{Handles.java'Handles~i~\\[\\[Qjava.util.Set\\<QString;>;", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles~i~\\[\\[Qjava.util.Set\\<QString;>;", ipe.getHandleIdentifier());
 
 		ipe = findElementAtLine(top.getRoot(), 13);// public java.util.Set<String> i(java.util.Set<String>[][] u,int i) {
-		assertEquals("<{Handles.java'Handles~i~\\[\\[Qjava.util.Set\\<QString;>;~I", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles~i~\\[\\[Qjava.util.Set\\<QString;>;~I", ipe.getHandleIdentifier());
 
 		ipe = findElementAtLine(top.getRoot(), 16);// public java.util.Set<String> i2(java.util.Set<? extends
 		// Collection<String>>[][] u) {
-		assertEquals("<{Handles.java'Handles~i2~\\[\\[Qjava.util.Set\\<+QCollection\\<QString;>;>;", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles~i2~\\[\\[Qjava.util.Set\\<+QCollection\\<QString;>;>;", ipe.getHandleIdentifier());
 
 		ipe = findElementAtLine(top.getRoot(), 19);// public java.util.Set<String> i3(java.util.Set<? extends
 		// Collection<String[]>>[][] u)
-		assertEquals("<{Handles.java'Handles~i3~\\[\\[Qjava.util.Set\\<+QCollection\\<\\[QString;>;>;", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles~i3~\\[\\[Qjava.util.Set\\<+QCollection\\<\\[QString;>;>;", ipe.getHandleIdentifier());
 
 		ipe = findElementAtLine(top.getRoot(), 22);
-		assertEquals("<{Handles.java'Handles~i4~Qjava.util.Set\\<+QCollection\\<QString;>;>;", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles~i4~Qjava.util.Set\\<+QCollection\\<QString;>;>;", ipe.getHandleIdentifier());
 
 		ipe = findElementAtLine(top.getRoot(), 25);
-		assertEquals("<{Handles.java'Handles~i5~Qjava.util.Set\\<*>;", ipe.getHandleIdentifier());
+		assertEquals("<{Handles.java>Handles~i5~Qjava.util.Set\\<*>;", ipe.getHandleIdentifier());
 
 	}
 

--- a/tests/src/test/java/org/aspectj/systemtest/ajc164/Ajc164Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc164/Ajc164Tests.java
@@ -84,7 +84,7 @@ public class Ajc164Tests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		String itdMethodHandle = ir.getTargets().get(0);
 		// handle when all source: <{Aspect.java}Aspect)Orange.getColor
 		// assertEquals("/binaries<{Aspect.java}Aspect)Orange.getColor", itdMethodHandle);
-		assertEquals("/binaries<(Aspect.class'Aspect)Orange.getColor", itdMethodHandle);
+		assertEquals("/binaries<(Aspect.class>Aspect°Orange.getColor", itdMethodHandle);
 		IProgramElement itdpe = model.getHierarchy().findElementForHandle(itdMethodHandle);
 		assertEquals("java.awt.Color", itdpe.getCorrespondingType(true));
 
@@ -98,7 +98,7 @@ public class Ajc164Tests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		String itdFieldHandle = ir.getTargets().get(0);
 		// source handle <{Aspect.java}Aspect)Strawberry.color
 		// assertEquals("/binaries<{Aspect.java}Aspect)Strawberry.color", itdFieldHandle);
-		assertEquals("/binaries<(Aspect.class'Aspect,Strawberry.color", itdFieldHandle);
+		assertEquals("/binaries<(Aspect.class>Aspect,Strawberry.color", itdFieldHandle);
 		IProgramElement itdfpe = model.getHierarchy().findElementForHandle(itdMethodHandle);
 		assertEquals("java.awt.Color", itdfpe.getCorrespondingType(true));
 
@@ -111,7 +111,7 @@ public class Ajc164Tests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		String itdCtorHandle = ir.getTargets().get(0);
 		// source handle <{Aspect.java}Aspect)Fruit.Fruit_new)QColor;)QString;
 		// assertEquals("/binaries<{Aspect.java}Aspect)Fruit.Fruit_new)QColor;)QString;", itdCtorHandle);
-		assertEquals("/binaries<(Aspect.class'Aspect)Fruit.Fruit_new)QColor;)QString;", itdCtorHandle);
+		assertEquals("/binaries<(Aspect.class>Aspect°Fruit.Fruit_new°QColor;°QString;", itdCtorHandle);
 		IProgramElement itdcpe = model.getHierarchy().findElementForHandle(itdCtorHandle);
 		List<char[]> ptypes = itdcpe.getParameterTypes();
 		assertEquals("java.awt.Color", new String(ptypes.get(0)));
@@ -179,7 +179,7 @@ public class Ajc164Tests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		IHierarchy top = AsmManager.lastActiveStructureModel.getHierarchy();
 		IProgramElement ipe = null;
 		ipe = findElementAtLine(top.getRoot(), 13);
-		assertEquals("<p{HandleTestingAspect.java'HandleTestingAspect[InnerClass'InnerInnerAspect|1", ipe.getHandleIdentifier());
+		assertEquals("<p{HandleTestingAspect.java>HandleTestingAspect[InnerClass>InnerInnerAspect|1", ipe.getHandleIdentifier());
 		// ipe = findElementAtLine(top.getRoot(), 29);
 		// assertEquals("<x*OverrideOptions.aj}OverrideOptions&around!2",
 		// ipe.getHandleIdentifier());
@@ -190,9 +190,9 @@ public class Ajc164Tests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		IHierarchy top = AsmManager.lastActiveStructureModel.getHierarchy();
 		IProgramElement ipe = null;
 		ipe = findElementAtLine(top.getRoot(), 22);
-		assertEquals("<x*OverrideOptions.aj'OverrideOptions&around", ipe.getHandleIdentifier());
+		assertEquals("<x*OverrideOptions.aj>OverrideOptions§around", ipe.getHandleIdentifier());
 		ipe = findElementAtLine(top.getRoot(), 29);
-		assertEquals("<x*OverrideOptions.aj'OverrideOptions&around!2", ipe.getHandleIdentifier());
+		assertEquals("<x*OverrideOptions.aj>OverrideOptions§around!2", ipe.getHandleIdentifier());
 	}
 
 	// Only one of two aspects named

--- a/tests/src/test/java/org/aspectj/systemtest/ajc169/IntertypeTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc169/IntertypeTests.java
@@ -157,7 +157,7 @@ public class IntertypeTests extends org.aspectj.testing.XMLBasedAjcTestCase {
 		pw.flush();
 		String model = baos.toString();
 		assertTrue(model.contains("<{Choice.java[Choice=[aspect declarations]"));
-		assertTrue(model.contains("<{Choice.java'X[Keys=[declared on]"));
+		assertTrue(model.contains("<{Choice.java>X[Keys=[declared on]"));
 	}
 
 	public void testGenerics1() throws Exception {

--- a/tests/src/test/java/org/aspectj/systemtest/incremental/tools/IncrementalCompilationTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/incremental/tools/IncrementalCompilationTests.java
@@ -146,14 +146,14 @@ public class IncrementalCompilationTests extends AbstractMultiProjectIncremental
 		checkWasFullBuild();
 		AspectJElementHierarchy model = (AspectJElementHierarchy) getModelFor(p).getHierarchy();
 		IProgramElement ipe = null;
-		ipe = model.findElementForHandleOrCreate("=annoRemoval<a{Code.java'Remover`declare \\@field", false);
+		ipe = model.findElementForHandleOrCreate("=annoRemoval<a{Code.java>Remover´declare \\@field", false);
 		System.out.println(ipe);
 		assertTrue(ipe.isAnnotationRemover());
 		String[] annos = ipe.getRemovedAnnotationTypes();
 		assertEquals(1, annos.length);
 		assertEquals("a.Anno", annos[0]);
 		assertNull(ipe.getAnnotationType());
-		ipe = model.findElementForHandleOrCreate("=annoRemoval<a{Code.java'Remover`declare \\@field!2", false);
+		ipe = model.findElementForHandleOrCreate("=annoRemoval<a{Code.java>Remover´declare \\@field!2", false);
 		System.out.println(ipe);
 		assertFalse(ipe.isAnnotationRemover());
 		assertEquals("a.Anno", ipe.getAnnotationType());
@@ -835,7 +835,7 @@ public class IncrementalCompilationTests extends AbstractMultiProjectIncremental
 
 		AspectJElementHierarchy model = (AspectJElementHierarchy) getModelFor(p).getHierarchy();
 		IProgramElement ipe = model.findElementForHandleOrCreate(
-				"=PR278496_4<foo{MyOtherClass.java[MyOtherClass[MyInnerClass'MyInnerInnerAspect", false);
+				"=PR278496_4<foo{MyOtherClass.java[MyOtherClass[MyInnerClass>MyInnerInnerAspect", false);
 		assertNotNull(ipe);
 	}
 
@@ -1026,7 +1026,7 @@ public class IncrementalCompilationTests extends AbstractMultiProjectIncremental
 		AspectJElementHierarchy model = (AspectJElementHierarchy) getModelFor(p).getHierarchy();
 		// check handle to anonymous inner:
 		IProgramElement ipe = model.findElementForHandleOrCreate(
-				"=pr278496_8<generics*DeleteActionAspect.aj'DeleteActionAspect~main~\\[QString;[", false);
+				"=pr278496_8<generics*DeleteActionAspect.aj>DeleteActionAspect~main~\\[QString;[", false);
 		assertNotNull(ipe);
 	}
 }

--- a/tests/src/test/java/org/aspectj/systemtest/incremental/tools/MultiProjectIncrementalTests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/incremental/tools/MultiProjectIncrementalTests.java
@@ -228,10 +228,10 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		initialiseProject(p);
 		build(p);
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		List<IRelationship> rels = irm.get("=pr284771<test*AspectTrace.aj'AspectTrace&before");
+		List<IRelationship> rels = irm.get("=pr284771<test*AspectTrace.aj>AspectTrace§before");
 		assertNotNull(rels);
 		assertEquals(2, ((Relationship) rels.get(0)).getTargets().size());
-		rels = irm.get("=pr284771<test*AspectTrace.aj'AspectTrace&before!2");
+		rels = irm.get("=pr284771<test*AspectTrace.aj>AspectTrace§before!2");
 		assertNotNull(rels);
 		assertEquals(2, ((Relationship) rels.get(0)).getTargets().size());
 	}
@@ -242,21 +242,21 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		build(p);
 		printModel(p);
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		List<IRelationship> rels = irm.get("=pr329111<{AJ.java'AJ`declare soft");
+		List<IRelationship> rels = irm.get("=pr329111<{AJ.java>AJ´declare soft");
 		assertNotNull(rels);
-		rels = irm.get("=pr329111<{AJ2.java'AJ2`declare soft");
+		rels = irm.get("=pr329111<{AJ2.java>AJ2´declare soft");
 		assertNotNull(rels);
-		rels = irm.get("=pr329111<{AJ2.java'AJ2`declare soft!2");
+		rels = irm.get("=pr329111<{AJ2.java>AJ2´declare soft!2");
 		assertNotNull(rels);
-		rels = irm.get("=pr329111<{AJ2.java'AJ2`declare soft!3");
+		rels = irm.get("=pr329111<{AJ2.java>AJ2´declare soft!3");
 		assertNotNull(rels);
-		rels = irm.get("=pr329111<{AJ3.java'AJ3`declare warning");
+		rels = irm.get("=pr329111<{AJ3.java>AJ3´declare warning");
 		assertNotNull(rels);
-		rels = irm.get("=pr329111<{AJ3.java'AJ3`declare warning!2");
+		rels = irm.get("=pr329111<{AJ3.java>AJ3´declare warning!2");
 		assertNotNull(rels);
-		rels = irm.get("=pr329111<{AJ3.java'AJ3`declare error");
+		rels = irm.get("=pr329111<{AJ3.java>AJ3´declare error");
 		assertNotNull(rels);
-		rels = irm.get("=pr329111<{AJ3.java'AJ3`declare error!2");
+		rels = irm.get("=pr329111<{AJ3.java>AJ3´declare error!2");
 		assertNotNull(rels);
 	}
 
@@ -271,7 +271,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		// Hid:1:(targets=1) =pr322446<{Class.java[Class (aspect declarations) =pr322446<{AbstractAspect.java'AbstractAspect`declare
 		// parents
 		// Hid:2:(targets=1) =pr322446<{AbstractAspect.java'AbstractAspect`declare parents (declared on) =pr322446<{Class.java[Class
-		List<IRelationship> rels = irm.get("=pr322446<{AbstractAspect.java'AbstractAspect`declare parents");
+		List<IRelationship> rels = irm.get("=pr322446<{AbstractAspect.java>AbstractAspect´declare parents");
 		assertNotNull(rels);
 	}
 
@@ -290,11 +290,11 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 
 		// Check the 'standard build' - the library also has a type affected by the decp so we can check what happens on an 'all
 		// source' build
-		IProgramElement theAspect = getModelFor(lib).getHierarchy().findElementForHandleOrCreate("=pr343001_lib<{Super.java'Super",
+		IProgramElement theAspect = getModelFor(lib).getHierarchy().findElementForHandleOrCreate("=pr343001_lib<{Super.java>Super",
 				false);
 		assertNotNull(theAspect);
 		IProgramElement sourcelevelDecp = getModelFor(lib).getHierarchy().findElementForHandleOrCreate(
-				"=pr343001_lib<{Super.java'Super`declare parents", false);
+				"=pr343001_lib<{Super.java>Super´declare parents", false);
 		assertNotNull(sourcelevelDecp);
 		assertEquals("[java.io.Serializable]", sourcelevelDecp.getParentTypes().toString());
 
@@ -304,10 +304,10 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		build(p);
 
 		IProgramElement theBinaryAspect = getModelFor(p).getHierarchy().findElementForHandleOrCreate(
-				"=pr343001/binaries<(Super.class'Super", false);
+				"=pr343001/binaries<(Super.class>Super", false);
 		assertNotNull(theBinaryAspect);
 		IProgramElement binaryDecp = getModelFor(p).getHierarchy().findElementForHandleOrCreate(
-				"=pr343001/binaries<(Super.class'Super`declare parents", false);
+				"=pr343001/binaries<(Super.class>Super´declare parents", false);
 		assertNotNull(binaryDecp);
 		assertEquals("[java.io.Serializable]", (binaryDecp.getParentTypes() == null ? "" : binaryDecp.getParentTypes().toString()));
 	}
@@ -372,35 +372,34 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		initialiseProject(p);
 		build(p);
 		printModel(p);
-		IProgramElement decpPE = getModelFor(p).getHierarchy().findElementForHandle(
-				"=pr286539<p.q.r{Aspect.java'Asp`declare parents");
+		IProgramElement decpPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java>Asp´declare parents");
 		assertNotNull(decpPE);
 		String s = ((decpPE.getParentTypes()).get(0));
 		assertEquals("p.q.r.Int", s);
 
-		decpPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java'Asp`declare parents!2");
+		decpPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java>Asp´declare parents!2");
 		assertNotNull(decpPE);
 		s = ((decpPE.getParentTypes()).get(0));
 		assertEquals("p.q.r.Int", s);
 
 		IProgramElement decaPE = getModelFor(p).getHierarchy().findElementForHandle(
-				"=pr286539<p.q.r{Aspect.java'Asp`declare \\@type");
+				"=pr286539<p.q.r{Aspect.java>Asp´declare \\@type");
 		assertNotNull(decaPE);
 		assertEquals("p.q.r.Foo", decaPE.getAnnotationType());
 
-		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java'Asp`declare \\@type!2");
+		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java>Asp´declare \\@type!2");
 		assertNotNull(decaPE);
 		assertEquals("p.q.r.Goo", decaPE.getAnnotationType());
 
-		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java'Asp`declare \\@field");
+		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java>Asp´declare \\@field");
 		assertNotNull(decaPE);
 		assertEquals("p.q.r.Foo", decaPE.getAnnotationType());
 
-		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java'Asp`declare \\@method");
+		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java>Asp´declare \\@method");
 		assertNotNull(decaPE);
 		assertEquals("p.q.r.Foo", decaPE.getAnnotationType());
 
-		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java'Asp`declare \\@constructor");
+		decaPE = getModelFor(p).getHierarchy().findElementForHandle("=pr286539<p.q.r{Aspect.java>Asp´declare \\@constructor");
 		assertNotNull(decaPE);
 		assertEquals("p.q.r.Foo", decaPE.getAnnotationType());
 	}
@@ -598,14 +597,14 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		// Hid:5:(targets=1) =pr280380<g*AnAspect.aj}AnAspect)AClass.AClass_new (declared on) =pr280380<f{AClass.java[AClass
 		// Hid:6:(targets=1) =pr280380<g*AnAspect.aj}AnAspect)AClass.xxxx (declared on) =pr280380<f{AClass.java[AClass
 		printModel(p);
-		assertNotNull(getModelFor(p).getRelationshipMap().get("=pr280380<g*AnAspect.aj'AnAspect,AClass.xxxx"));
+		assertNotNull(getModelFor(p).getRelationshipMap().get("=pr280380<g*AnAspect.aj>AnAspect,AClass.xxxx"));
 		alter(p, "inc2");
 		build(p);
 		assertNoErrors(p);
 		printModel(p);
 		// On this build the relationship should have changed to include the fully qualified target
 		assertEquals(4, getModelFor(p).getRelationshipMap().getEntries().size());
-		assertNotNull(getModelFor(p).getRelationshipMap().get("=pr280380<g*AnAspect.aj'AnAspect,AClass.xxxx"));
+		assertNotNull(getModelFor(p).getRelationshipMap().get("=pr280380<g*AnAspect.aj>AnAspect,AClass.xxxx"));
 		// Hid:1:(targets=3) =pr280380<f{AClass.java[AClass (aspect declarations) =pr280380<g*AnAspect.aj}AnAspect)AClass.xxxx
 		// Hid:2:(targets=3) =pr280380<f{AClass.java[AClass (aspect declarations) =pr280380<g*AnAspect.aj}AnAspect)AClass.y
 		// Hid:3:(targets=3) =pr280380<f{AClass.java[AClass (aspect declarations) =pr280380<g*AnAspect.aj}AnAspect)AClass.AClass_new
@@ -620,7 +619,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		build(p);
 		printModel(p);
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		List<IRelationship> rels = irm.get("=pr322039<p{Azpect.java'Azpect)q2.Code.something2");
+		List<IRelationship> rels = irm.get("=pr322039<p{Azpect.java>Azpect°q2.Code.something2");
 		assertNotNull(rels);
 	}
 
@@ -630,7 +629,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		build(p);
 		printModel(p);
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		List<IRelationship> rels = irm.get("=pr280383<f{AnAspect.java'AnAspect)f.AClass.f_AClass_new");
+		List<IRelationship> rels = irm.get("=pr280383<f{AnAspect.java>AnAspect°f.AClass.f_AClass_new");
 		assertNotNull(rels);
 	}
 
@@ -654,9 +653,9 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		// Hid:3:(targets=2) =pr283657<{Aspect.java[Target (aspect declarations) =pr283657<{Aspect.java}Aspect)Target.foo
 		// Hid:4:(targets=2) =pr283657<{Aspect.java[Target (aspect declarations) =pr283657<{Aspect.java}Aspect)Target.foo!2
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		List<IRelationship> rels = irm.get("=pr283657<{Aspect.java'Aspect,Target.foo");
+		List<IRelationship> rels = irm.get("=pr283657<{Aspect.java>Aspect,Target.foo");
 		assertNotNull(rels);
-		rels = irm.get("=pr283657<{Aspect.java'Aspect)Target.foo!2");
+		rels = irm.get("=pr283657<{Aspect.java>Aspect°Target.foo!2");
 		assertNotNull(rels);
 	}
 
@@ -667,13 +666,13 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		addSourceFolderForSourceFile(p, getProjectRelativePath(p, "src/C.java"), "src");
 		build(p);
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		IRelationship ir = irm.get("=pr276399/src<*X.aj'X&after").get(0);
+		IRelationship ir = irm.get("=pr276399/src<*X.aj>X§after").get(0);
 		assertNotNull(ir);
 		alter(p, "inc1");
 		build(p);
 		printModel(p);
 		irm = getModelFor(p).getRelationshipMap();
-		List<IRelationship> rels = irm.get("=pr276399/src<*X.aj'X&after"); // should be gone after the inc build
+		List<IRelationship> rels = irm.get("=pr276399/src<*X.aj>X§after"); // should be gone after the inc build
 		assertNull(rels);
 	}
 
@@ -685,7 +684,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 			printModelAndRelationships(p);
 		}
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		List<IRelationship> l = irm.get("=pr278255<{A.java'X`declare \\@type");
+		List<IRelationship> l = irm.get("=pr278255<{A.java>X´declare \\@type");
 		assertNotNull(l);
 		IRelationship ir = l.get(0);
 		assertNotNull(ir);
@@ -883,9 +882,9 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		}
 		// ITD from the test program:
 		// public String InterTypeAspectInterface.foo(int i,List list,App a) {
-		assertEquals("=pr265729_client/binaries<be.cronos.aop.aspects(InterTypeAspect.class'InterTypeAspect`declare parents", h1);
+		assertEquals("=pr265729_client/binaries<be.cronos.aop.aspects(InterTypeAspect.class>InterTypeAspect´declare parents", h1);
 		assertEquals(
-				"=pr265729_client/binaries<be.cronos.aop.aspects(InterTypeAspect.class'InterTypeAspect)InterTypeAspectInterface.foo)I)QList;)QSerializable;",
+				"=pr265729_client/binaries<be.cronos.aop.aspects(InterTypeAspect.class>InterTypeAspect°InterTypeAspectInterface.foo°I°QList;°QSerializable;",
 				h2);
 		IProgramElement binaryDecp = getModelFor(cli).getHierarchy().getElement(h1);
 		assertNotNull(binaryDecp);
@@ -929,7 +928,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		String p = "decps";
 		initialiseProject(p);
 		build(p);
-		IProgramElement decp = getModelFor(p).getHierarchy().findElementForHandle("=decps<a{A.java'A`declare parents");
+		IProgramElement decp = getModelFor(p).getHierarchy().findElementForHandle("=decps<a{A.java>A´declare parents");
 		List<String> ps = decp.getParentTypes();
 		assertNotNull(ps);
 		assertEquals(2, ps.size());
@@ -950,7 +949,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		initialiseProject(p);
 		build(p);
 		IRelationshipMap irm = getModelFor(p).getRelationshipMap();
-		IRelationship ir = irm.get("=261380<test{C.java'X&before").get(0);
+		IRelationship ir = irm.get("=261380<test{C.java>X§before").get(0);
 		List<String> targets = ir.getTargets();
 		assertEquals(1, targets.size());
 		System.out.println(targets.get(0));
@@ -1115,7 +1114,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		assertEquals("java.io.Serializable", l.get(0));
 		ProgramElement ctorDecp = (ProgramElement) findElementAtLine(root, 16);
 		String ctordecphandle = ctorDecp.getHandleIdentifier();
-		assertEquals("=itdfq<a.b.c{A.java'XX)B.B_new)QString;", ctordecphandle); // 252702
+		assertEquals("=itdfq<a.b.c{A.java>XX°B.B_new°QString;", ctordecphandle); // 252702
 		// ,
 		// comment
 		// 7
@@ -1133,11 +1132,11 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 
 		IProgramElement root = model.getHierarchy().getRoot();
 		IProgramElement ipe = findElementAtLine(root, 4);
-		assertEquals("=BrokenHandles<p{GetInfo.java'GetInfo`declare warning", ipe.getHandleIdentifier());
+		assertEquals("=BrokenHandles<p{GetInfo.java>GetInfo´declare warning", ipe.getHandleIdentifier());
 		ipe = findElementAtLine(root, 5);
-		assertEquals("=BrokenHandles<p{GetInfo.java'GetInfo`declare warning!2", ipe.getHandleIdentifier());
+		assertEquals("=BrokenHandles<p{GetInfo.java>GetInfo´declare warning!2", ipe.getHandleIdentifier());
 		ipe = findElementAtLine(root, 6);
-		assertEquals("=BrokenHandles<p{GetInfo.java'GetInfo`declare parents", ipe.getHandleIdentifier());
+		assertEquals("=BrokenHandles<p{GetInfo.java>GetInfo´declare parents", ipe.getHandleIdentifier());
 	}
 
 	public void testNPEIncremental_pr262218() {
@@ -1312,7 +1311,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		// the advice relationship
 		IProgramElement root = getModelFor(p).getHierarchy().getRoot();
 		IProgramElement code = findElementAtLine(root, 5);
-		assertEquals("=pr253067<aa*AdvisesC.aj'AdvisesC)C.nothing?method-call(int aa.C.nothing())", code.getHandleIdentifier());
+		assertEquals("=pr253067<aa*AdvisesC.aj>AdvisesC°C.nothing?method-call(int aa.C.nothing())", code.getHandleIdentifier());
 		// dumptree(getModelFor(p).getHierarchy().getRoot(), 0);
 		// Ajc.dumpAJDEStructureModel(getModelFor("pr253067"),
 		// "after inc build where first advised line is gone");
@@ -1325,7 +1324,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		IProgramElement root = getModelFor(p).getHierarchy().getRoot();
 		IProgramElement code = findElementAtLine(root, 4);
 		// the @ should be escapified
-		assertEquals("=pr249216<{Deca.java'X`declare \\@type", code.getHandleIdentifier());
+		assertEquals("=pr249216<{Deca.java>X´declare \\@type", code.getHandleIdentifier());
 		// dumptree(getModelFor(p).getHierarchy().getRoot(), 0);
 		// Ajc.dumpAJDEStructureModel(getModelFor(p),
 		// "after inc build where first advised line is gone");
@@ -1424,48 +1423,48 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		build(p);
 		IProgramElement root = getModelFor(p).getHierarchy().getRoot();
 		IProgramElement typeDecl = findElementAtLine(root, 4);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles", typeDecl.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles", typeDecl.getHandleIdentifier());
 
 		IProgramElement advice1 = findElementAtLine(root, 7);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&before", advice1.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§before", advice1.getHandleIdentifier());
 
 		IProgramElement advice2 = findElementAtLine(root, 11);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&before!2", advice2.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§before!2", advice2.getHandleIdentifier());
 
 		IProgramElement advice3 = findElementAtLine(root, 15);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&before&I", advice3.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§before§I", advice3.getHandleIdentifier());
 
 		IProgramElement advice4 = findElementAtLine(root, 20);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&before&I!2", advice4.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§before§I!2", advice4.getHandleIdentifier());
 
 		IProgramElement advice5 = findElementAtLine(root, 25);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&after", advice5.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§after", advice5.getHandleIdentifier());
 
 		IProgramElement advice6 = findElementAtLine(root, 30);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&afterReturning", advice6.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§afterReturning", advice6.getHandleIdentifier());
 
 		IProgramElement advice7 = findElementAtLine(root, 35);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&afterThrowing", advice7.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§afterThrowing", advice7.getHandleIdentifier());
 
 		IProgramElement advice8 = findElementAtLine(root, 40);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles&afterThrowing&I", advice8.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles§afterThrowing§I", advice8.getHandleIdentifier());
 
 		IProgramElement namedInnerClass = findElementAtLine(root, 46);
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles~x[NamedClass", namedInnerClass.getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles~x[NamedClass", namedInnerClass.getHandleIdentifier());
 
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles~foo[", findElementAtLine(root, 55).getHandleIdentifier());
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles~foo[!2", findElementAtLine(root, 56).getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles~foo[", findElementAtLine(root, 55).getHandleIdentifier());
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles~foo[!2", findElementAtLine(root, 56).getHandleIdentifier());
 
 		// From 247742: comment 3: two anon class declarations
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles~b~QString;[", findElementAtLine(root, 62)
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles~b~QString;[", findElementAtLine(root, 62)
 				.getHandleIdentifier());
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles~b~QString;[!2", findElementAtLine(root, 63)
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles~b~QString;[!2", findElementAtLine(root, 63)
 				.getHandleIdentifier());
 
 		// From 247742: comment 6: two diff anon class declarations
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles~c~QString;[", findElementAtLine(root, 66)
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles~c~QString;[", findElementAtLine(root, 66)
 				.getHandleIdentifier());
-		assertEquals("=AdviceHandles/src<spacewar*Handles.aj'Handles~c~QString;[!2", findElementAtLine(root, 67)
+		assertEquals("=AdviceHandles/src<spacewar*Handles.aj>Handles~c~QString;[!2", findElementAtLine(root, 67)
 				.getHandleIdentifier());
 
 		// // From 247742: comment 4
@@ -1661,8 +1660,8 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		getModelFor(bug2).dumprels(pw);
 		pw.flush();
 		IProgramElement root = getModelFor(bug2).getHierarchy().getRoot();
-		assertEquals("=AspectPathTwo/binaries<pkg(Asp.class'Asp&before", findElementAtLine(root, 5).getHandleIdentifier());
-		assertEquals("=AspectPathTwo/binaries<(Asp2.class'Asp2&before", findElementAtLine(root, 16).getHandleIdentifier());
+		assertEquals("=AspectPathTwo/binaries<pkg(Asp.class>Asp§before", findElementAtLine(root, 5).getHandleIdentifier());
+		assertEquals("=AspectPathTwo/binaries<(Asp2.class>Asp2§before", findElementAtLine(root, 16).getHandleIdentifier());
 	}
 
 	public void testAspectPath_pr274558() throws Exception {
@@ -1676,7 +1675,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		build(depending);
 		printModel(depending);
 		IProgramElement root = getModelFor(depending).getHierarchy().getRoot();
-		assertEquals("=bug274558base/binaries<r(DeclaresITD.class'DeclaresITD,InterfaceForITD.x", findElementAtLine(root, 5)
+		assertEquals("=bug274558base/binaries<r(DeclaresITD.class>DeclaresITD,InterfaceForITD.x", findElementAtLine(root, 5)
 				.getHandleIdentifier());
 		// assertEquals("=AspectPathTwo/binaries<(Asp2.class}Asp2&before", findElementAtLine(root, 16).getHandleIdentifier());
 	}
@@ -1764,7 +1763,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		assertEquals("=pr269286<{Logger.java[Logger~aroo", findElementAtLine(root, 15).getHandleIdentifier()); // around
 
 		// pointcuts are not fixed - seems to buggy handling of them internally
-		assertEquals("=pr269286<{Logger.java[Logger\"ooo", findElementAtLine(root, 20).getHandleIdentifier());
+		assertEquals("=pr269286<{Logger.java[Logger©ooo", findElementAtLine(root, 20).getHandleIdentifier());
 
 		// DeclareWarning
 		assertEquals("=pr269286<{Logger.java[Logger^message", findElementAtLine(root, 24).getHandleIdentifier());
@@ -1784,9 +1783,9 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		// getModelFor(p).dumprels(pw);
 		// pw.flush();
 		IProgramElement ff = findFile(root, "ProcessAspect.aj");
-		assertEquals("=prx<com.kronos.aspects*ProcessAspect.aj'ProcessAspect&after&QMyProcessor;", findElementAtLine(root, 22)
+		assertEquals("=prx<com.kronos.aspects*ProcessAspect.aj>ProcessAspect§after§QMyProcessor;", findElementAtLine(root, 22)
 				.getHandleIdentifier());
-		assertEquals("=prx<com.kronos.aspects*ProcessAspect.aj'ProcessAspect&after&QMyProcessor;!2", findElementAtLine(root, 68)
+		assertEquals("=prx<com.kronos.aspects*ProcessAspect.aj>ProcessAspect§after§QMyProcessor;!2", findElementAtLine(root, 68)
 				.getHandleIdentifier());
 	}
 
@@ -3174,7 +3173,7 @@ public class MultiProjectIncrementalTests extends AbstractMultiProjectIncrementa
 		build("JDTLikeHandleProvider");
 		IHierarchy top = getModelFor("JDTLikeHandleProvider").getHierarchy();
 		IProgramElement pe = top.findElementForType("pkg", "A");
-		String expectedHandle = "=JDTLikeHandleProvider<pkg*A.aj'A";
+		String expectedHandle = "=JDTLikeHandleProvider<pkg*A.aj>A";
 		assertEquals("expected handle to be " + expectedHandle + ", but found " + pe.getHandleIdentifier(), expectedHandle,
 				pe.getHandleIdentifier());
 		// } finally {

--- a/tests/src/test/java/org/aspectj/systemtest/model/ModelTestCase.java
+++ b/tests/src/test/java/org/aspectj/systemtest/model/ModelTestCase.java
@@ -141,6 +141,8 @@ public abstract class ModelTestCase extends XMLBasedAjcTestCase {
 			// String tempDir = expect.readLine();
 			String expectedLine = null;
 			while ((expectedLine = expect.readLine()) != null) {
+				// Remove trailing whitespace
+				expectedLine = expectedLine.replaceAll("[\t ]+$", "");
 				fileContents.add(expectedLine);
 			}
 			List<String> expectedFileContents = new ArrayList<>(fileContents);
@@ -150,6 +152,8 @@ public abstract class ModelTestCase extends XMLBasedAjcTestCase {
 			String foundLine = null;
 			List<String> foundFileContents = new ArrayList<>();
 			while ((foundLine = found.readLine()) != null) {
+				// Remove trailing whitespace
+				foundLine = foundLine.replaceAll("[\t ]+$", "");
 				// int i = foundLine.indexOf(sandboxDir);
 				// if (i == -1) {
 				// int j = foundLine.indexOf("(targets=");


### PR DESCRIPTION
New constants:
 - `JEM_MODULAR_CLASSFILE` - `'` (single quote)
 - `ANNOTATION` - `}`
 - `LAMBDA_EXPRESSION` - `)`
 - `LAMBDA_METHOD` - `&`
 - `STRING` - `"`
 - `MODULE` - `` ` ``
 - `DELIMITER_ESCAPE` - `=`

Updated AspectJ constants due to JDT Core using constants (see above) previously used by AspectJ:

 - `ADVICE` - `&` to `§`
 - `ASPECT_TYPE` - `'` to `>`
 - `ITD_METHOD` - `)` to `°`
 - `DECLARE` - `` ` `` to `´`
 - `POINTCUT` - `"` to `©`

Detected while trying to fix #223, both projects need to be adjusted in sync.