### PR TITLE
Fix inline accessor method bug in BcelAccessForInlineMunger

### DIFF
--- a/tests/bugs1920/github_250/MyAspect.aj
+++ b/tests/bugs1920/github_250/MyAspect.aj
@@ -1,0 +1,40 @@
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+import java.util.Random;
+
+/**
+ * Reproduces <a href="https://github.com/eclipse-aspectj/aspectj/issues/250">Github bug 250</a>
+ */
+@Aspect
+public class MyAspect {
+  @Around("execution(* Application.*(..))")
+  public Object myAdvice1(ProceedingJoinPoint joinPoint) {
+    System.out.println(joinPoint);
+    a(1, "one");
+    return joinPoint.proceed();
+  }
+
+  @Around("execution(* Application.*(..))")
+  public Object myAdvice2(ProceedingJoinPoint joinPoint) throws Throwable {
+    System.out.println(joinPoint);
+    a(2);
+    return new Random().nextBoolean() ? joinPoint.proceed() : null;
+  }
+
+  private void a(int i) {
+    System.out.println(i);
+  }
+  private void a(int i, String s) {
+    System.out.println(i + " / " + s);
+  }
+
+  public static void main(String[] args) {
+    new Application().doSomething();
+  }
+}
+
+class Application {
+  public void doSomething() {}
+}

--- a/tests/java5/ataspectj/ajc-ant.xml
+++ b/tests/java5/ataspectj/ajc-ant.xml
@@ -107,7 +107,7 @@
     </target>
 
     <target name="ltwlog.LTWLog">
-        <javac target="1.5" destdir="${aj.sandbox}" classpathref="aj.path"
+        <javac target="1.8" destdir="${aj.sandbox}" classpathref="aj.path"
             srcdir="${basedir}"
             includes="ataspectj/ltwlog/*"
             debug="true">

--- a/tests/java5/ataspectj/ataspectj/AroundInlineMungerTestAspects.java
+++ b/tests/java5/ataspectj/ataspectj/AroundInlineMungerTestAspects.java
@@ -23,7 +23,9 @@ import org.aspectj.lang.ProceedingJoinPoint;
 public class AroundInlineMungerTestAspects {
 
     public static class OpenBase {
-        protected void superMethod() {}
+        protected String superMethod(String s) {
+            return s;
+        }
     }
 
     public static class OpenSubBase extends OpenBase {}
@@ -43,7 +45,7 @@ public class AroundInlineMungerTestAspects {
         public Object around1(ProceedingJoinPoint jp) throws Throwable {
             aroundCount++;
             priv(1, 2L, 3);
-            super.superMethod();
+            super.superMethod("x");
             new Open.Inner().priv();//fails to be wrapped so this advice will not be inlined but previous call were still prepared
             return jp.proceed();
         }
@@ -64,7 +66,7 @@ public class AroundInlineMungerTestAspects {
         @SuppressAjWarnings
         public Object around2(ProceedingJoinPoint jp) throws Throwable {
             aroundCount++;
-            super.superMethod();
+            super.superMethod("x");
             new Open.Inner().priv();//fails to be wrapped so next calls won't be prepared but previous was
             priv(1, 2L, 3);
             return jp.proceed();

--- a/tests/src/test/java/org/aspectj/systemtest/ajc1920/Bugs1920Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc1920/Bugs1920Tests.java
@@ -26,6 +26,15 @@ public class Bugs1920Tests extends XMLBasedAjcTestCase {
     runTest("add correct annotations to multiple ITD methods with the same name and same number of arguments");
   }
 
+  /**
+   * Make sure to create one {@code ajc$inlineAccessMethod} for identically named (overloaded) private aspect methods.
+   * <p>
+   * See <a href="https://github.com/eclipse-aspectj/aspectj/issues/250">GitHub issue 250</a>.
+   */
+  public void test_GitHub_250() {
+    runTest("correctly handle overloaded private methods in aspects");
+  }
+
   public static Test suite() {
     return XMLBasedAjcTestCase.loadSuite(Bugs1920Tests.class);
   }

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1920/ajc1920.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1920/ajc1920.xml
@@ -190,4 +190,17 @@
 		</run>
 	</ajc-test>
 
+	<!-- https://github.com/eclipse-aspectj/aspectj/issues/250 -->
+	<ajc-test dir="bugs1920/github_250" vm="8" title="correctly handle overloaded private methods in aspects">
+		<compile files="MyAspect.aj" options="-8"/>
+		<run class="MyAspect">
+			<stdout>
+				<line text="execution(void Application.doSomething())"/>
+				<line text="1 / one"/>
+				<line text="execution(void Application.doSomething())"/>
+				<line text="2"/>
+			</stdout>
+		</run>
+	</ajc-test>
+
 </suite>

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/BcelAccessForInlineMunger.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/BcelAccessForInlineMunger.java
@@ -101,7 +101,11 @@ public class BcelAccessForInlineMunger extends BcelTypeMunger {
 	 */
 	@Override
 	public ResolvedMember getMatchingSyntheticMember(Member member) {
-		ResolvedMember rm = inlineAccessors.get(member.getName());// + member.getSignature());
+    String name = member.getName();
+    String signature = name.startsWith("ajc$superDispatch$")
+      ? member.getSignature()
+      : member.getSignature().replaceFirst("\\([^;]+;", "(");
+    ResolvedMember rm = inlineAccessors.get(name + signature);
 //		System.err.println("lookup for " + member.getName() + ":" + member.getSignature() + " = "
 //				+ (rm == null ? "" : rm.getName()));
 		return rm;
@@ -229,7 +233,7 @@ public class BcelAccessForInlineMunger extends BcelTypeMunger {
 	private ResolvedMember createOrGetInlineAccessorForMethod(ResolvedMember resolvedMember) {
 		String accessorName = NameMangler.inlineAccessMethodForMethod(resolvedMember.getName(), resolvedMember.getDeclaringType(),
 				aspectType);
-		String key = accessorName;// new StringBuilder(accessorName).append(resolvedMember.getSignature()).toString();
+		String key = accessorName + resolvedMember.getSignature();
 		ResolvedMember inlineAccessor = inlineAccessors.get(key);
 //		System.err.println(key + " accessor=" + inlineAccessor);
 		if (inlineAccessor == null) {
@@ -272,7 +276,7 @@ public class BcelAccessForInlineMunger extends BcelTypeMunger {
 	private ResolvedMember createOrGetInlineAccessorForSuperDispatch(ResolvedMember resolvedMember) {
 		String accessor = NameMangler.superDispatchMethod(aspectType, resolvedMember.getName());
 
-		String key = accessor;
+		String key = accessor + resolvedMember.getSignature();
 		ResolvedMember inlineAccessor = inlineAccessors.get(key);
 
 		if (inlineAccessor == null) {
@@ -316,7 +320,7 @@ public class BcelAccessForInlineMunger extends BcelTypeMunger {
 	private ResolvedMember createOrGetInlineAccessorForFieldGet(ResolvedMember resolvedMember) {
 		String accessor = NameMangler.inlineAccessMethodForFieldGet(resolvedMember.getName(), resolvedMember.getDeclaringType(),
 				aspectType);
-		String key = accessor;
+		String key = accessor + "()" + resolvedMember.getSignature();
 		ResolvedMember inlineAccessor = inlineAccessors.get(key);
 
 		if (inlineAccessor == null) {
@@ -357,7 +361,7 @@ public class BcelAccessForInlineMunger extends BcelTypeMunger {
 	private ResolvedMember createOrGetInlineAccessorForFieldSet(ResolvedMember resolvedMember) {
 		String accessor = NameMangler.inlineAccessMethodForFieldSet(resolvedMember.getName(), resolvedMember.getDeclaringType(),
 				aspectType);
-		String key = accessor;
+		String key = accessor + "(" + resolvedMember.getSignature() + ")V";
 		ResolvedMember inlineAccessor = inlineAccessors.get(key);
 
 		if (inlineAccessor == null) {

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/LazyClassGen.java
@@ -753,14 +753,20 @@ public final class LazyClassGen {
 		// are required (unless turning off the verifier)
 		if ((myGen.getMajor() == Constants.MAJOR_1_6 && world.shouldGenerateStackMaps()) || myGen.getMajor() > Constants.MAJOR_1_6) {
 			if (!AsmDetector.isAsmAround) {
-				// Fix https://github.com/eclipse-aspectj/aspectj/issues/251, using "replace('Ä', 'Ö')" to avoid non-relocated
-				// class names to be embedded into the error message during compile time, making it end up in the class constant
-				// pool unwantedly, as this clashes with post-compile ASM package relocation.
-				final String errorMessage = "Unable to find ASM classes (" +
-					AsmDetector.CLASS_READER.replace('Ä', 'Ö') + ", " + AsmDetector.CLASS_VISITOR.replace('Ä', 'Ö') + ") " +
-					"for stackmap generation. Stackmap generation for woven code is required to avoid verify errors " +
-					"on a Java 1.7 or higher runtime.";
-				throw new BCException(errorMessage, AsmDetector.reasonAsmIsMissing);
+				if (
+					AsmDetector.rootCause instanceof ClassNotFoundException ||
+						AsmDetector.rootCause instanceof NoClassDefFoundError
+				) {
+					// Fix https://github.com/eclipse-aspectj/aspectj/issues/251, using "replace('Ä', 'Ö')" to avoid
+					// non-relocated class names to be embedded into the error message during compile time, making it end up in
+					// the class constant pool unwantedly, as this clashes with post-compile ASM package relocation.
+					String errorMessage = "Unable to find ASM classes (" +
+						AsmDetector.CLASS_READER.replace('Ä', 'Ö') + ", " + AsmDetector.CLASS_VISITOR.replace('Ä', 'Ö') + ") " +
+						"for stackmap generation. Stackmap generation for woven code is required to avoid verify errors " +
+						"on a Java 1.7 or higher runtime.";
+					throw new BCException(errorMessage, AsmDetector.rootCause);
+				}
+				throw new BCException("Error processing class file", AsmDetector.rootCause);
 			}
 			wovenClassFileData = StackMapAdder.addStackMaps(world, myGen.getClassName(), wovenClassFileData);
 		}

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/asm/AsmDetector.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/asm/AsmDetector.java
@@ -20,7 +20,7 @@ public class AsmDetector {
 	public static final String CLASS_READER = "org.objectweb.asm.ClassReader";
 	public static final String CLASS_VISITOR = "org.objectweb.asm.ClassVisitor";
 	public static boolean isAsmAround;
-	public static Throwable reasonAsmIsMissing;
+	public static Throwable rootCause;
 
 	static {
 		try {
@@ -30,7 +30,7 @@ public class AsmDetector {
 			isAsmAround = true;
 		} catch (Exception e) {
 			isAsmAround = false;
-			reasonAsmIsMissing = e;
+			rootCause = e;
 		}
 		//System.out.println(isAsmAround ? "ASM detected" : "No ASM found");
 	}

--- a/weaver/src/main/java/org/aspectj/weaver/bcel/asm/StackMapAdder.java
+++ b/weaver/src/main/java/org/aspectj/weaver/bcel/asm/StackMapAdder.java
@@ -49,7 +49,7 @@ public class StackMapAdder {
 			System.err.println("AspectJ Internal Error: unable to add stackmap attributes to class '"+classname+"'. " + t.getMessage());
 			t.printStackTrace();
 			AsmDetector.isAsmAround = false;
-			AsmDetector.reasonAsmIsMissing = t;
+			AsmDetector.rootCause = t;
 			return data;
 		}
 	}


### PR DESCRIPTION
Make sure to create one `ajc$inlineAccessMethod` per identically named (overloaded) private aspect method in `BcelAccessForInlineMunger.createOrGetInlineAccessorForMethod`.

`Bugs1920Tests.test_GitHub_250` reproduces the original problem before the bugfix and serves as a regression test.

Also improve the error message in `LazyClassGen.getJavaClassBytesIncludingReweavable`, i.e. no longer report "Unable to find ASM classes", if simply an ASM processing error occurred. In that case, report "Error processing class file".

Fixes #250.