### PR TITLE
Fix incorrect matching for negated type patterns

### DIFF
--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NotTypePattern.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/NotTypePattern.java
@@ -70,7 +70,12 @@ public class NotTypePattern extends TypePattern {
 
 	@Override
 	protected boolean matchesArray(UnresolvedType type) {
-		return !negatedPattern.matchesArray(type);
+		// '!String' should match anything but String, no matter if it is an array or not,
+		// e.g. int, void, int[], String[], String[][].
+		//
+		// '!String[]' should match anything but String[], no matter if it is an array or not,
+		// e.g. int, void, int[], String, String[][].
+		return true;
 	}
 
 	@Override

--- a/tests/bugs1921/gh_257/NegatedTypeAspect.aj
+++ b/tests/bugs1921/gh_257/NegatedTypeAspect.aj
@@ -1,0 +1,124 @@
+import java.util.Arrays;
+
+public aspect NegatedTypeAspect {
+  before(): execution(!void get*()) {
+    System.out.println("[GETTER] " + thisJoinPoint);
+  }
+
+  before(): execution(!String get*()) {
+    System.out.println("[NON-STRING GETTER] " + thisJoinPoint);
+  }
+
+  before(): execution(String[] get*()) {
+    System.out.println("[STRING-ARRAY GETTER] " + thisJoinPoint);
+  }
+
+  before(): execution(!String[] get*()) {
+    System.out.println("[NON-STRING-ARRAY GETTER] " + thisJoinPoint);
+  }
+
+  before(): execution(!String[][] get*()) {
+    System.out.println("[NON-STRING-ARRAY-ARRAY GETTER] " + thisJoinPoint);
+  }
+
+  before(): execution(void set*(*)) {
+    System.out.println("[SETTER] " + thisJoinPoint);
+  }
+
+  public static void main(String[] args) {
+    Person person = new Person();
+    person.setId(11);
+    person.setFirstName("Marie");
+    person.setLastName("Curie");
+    System.out.println(person);
+    person.getId();
+    person.getFirstName();
+    person.getLastName();
+    System.out.println(person.getFullName(false));
+    person.setFullName("Albert Einstein");
+    person.setId(22);
+    System.out.println(person);
+    System.out.println(person.getFullName(true));
+    person.getVoid();
+    System.out.println(Arrays.deepToString(person.getStringArray()));
+    System.out.println(Arrays.deepToString(person.getStringArrayArray()));
+    System.out.println(person.setSomething("something"));
+  }
+}
+
+class Person {
+  private int id;
+  private String lastName;
+  private String firstName;
+
+  // Bean getters/setters, matched by aspect
+
+  // Non-string getter, matched by corresponding pointcut
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  // Non-string getter (String[] != String)
+  public String[] getStringArray() {
+    return new String[] {"Hello", "world"};
+  }
+
+  // Non-string, non-string-array getter (String[] != String, String[] != String[][])
+  public String[][] getStringArrayArray() {
+    return new String[][] {{"Hello", "world"}, {"Hallo", "Welt"}};
+  }
+
+  // Non-bean getters/setters, not matched by aspect
+
+  public String getFullName(boolean lastNameFirst) {
+    return lastNameFirst
+      ? lastName + ", " + firstName
+      : firstName + " " + lastName;
+  }
+
+  public void setFullName(String fullName) {
+    boolean lastNameFirst = fullName.contains(",");
+    String[] nameParts = fullName.split("[, ]+");
+    if (lastNameFirst) {
+      firstName = nameParts[1];
+      lastName = nameParts[0];
+    } else {
+      firstName = nameParts[0];
+      lastName = nameParts[1];
+    }
+  }
+
+  public String setSomething(String something) {
+    return "AspectJ rules!";
+  }
+
+  // Non-string getter, matched by corresponding pointcut
+  public void getVoid() {}
+
+  // Other methods, not matched by aspect
+
+  @Override
+  public String toString() {
+    return "Person(" + "id=" + id + ", lastName='" + lastName + '\'' + ", firstName='" + firstName + '\'' + ')';
+  }
+}

--- a/tests/src/test/java/org/aspectj/systemtest/ajc1920/Bugs1920Tests.java
+++ b/tests/src/test/java/org/aspectj/systemtest/ajc1920/Bugs1920Tests.java
@@ -79,6 +79,15 @@ public class Bugs1920Tests extends XMLBasedAjcTestCase {
     runTest("do not match bridge methods");
   }
 
+  /**
+   * In 1.9.20, a regression bug occurred, matching negated types like '!void' and '!String' incorrectly.
+   * <p>
+   * See <a href="https://github.com/eclipse-aspectj/aspectj/issues/257">GitHub issue 257</a>.
+   */
+  public void test_GitHub_257() {
+    runTest("handle negated type patterns correctly");
+  }
+
   public static Test suite() {
     return XMLBasedAjcTestCase.loadSuite(Bugs1920Tests.class);
   }

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc162/ajc162.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc162/ajc162.xml
@@ -251,8 +251,8 @@
     </ajc-test>
 
     <ajc-test dir="bugs162/pr240693" title="privileged generics">
-        <compile files="PayloadClass.java SomeInterface.java GenericClassInAdvice.java" options="-1.5">
-          <message kind="warning" text="advice defined in GenericClassInAdvice has not been applied [Xlint:adviceDidNotMatch]"/>
+        <compile files="PayloadClass.java SomeInterface.java GenericClassInAdvice.java" options="-1.5 -showWeaveInfo">
+          <message kind="weave" text="'method-call(java.lang.Object PayloadClass.getPayload())' in Type 'GenericClassInAdvice'"/>
         </compile>
     </ajc-test>
 

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc1920/ajc1920.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc1920/ajc1920.xml
@@ -434,4 +434,45 @@
 		</run>
 	</ajc-test>
 
+	<!-- https://github.com/eclipse-aspectj/aspectj/issues/257 -->
+	<ajc-test dir="bugs1921/gh_257" vm="8" title="handle negated type patterns correctly">
+		<compile files="NegatedTypeAspect.aj" options="-8"/>
+		<run class="NegatedTypeAspect">
+			<stdout>
+				<line text="[SETTER] execution(void Person.setId(int))"/>
+				<line text="[SETTER] execution(void Person.setFirstName(String))"/>
+				<line text="[SETTER] execution(void Person.setLastName(String))"/>
+				<line text="Person(id=11, lastName='Curie', firstName='Marie')"/>
+				<line text="[GETTER] execution(int Person.getId())"/>
+				<line text="[NON-STRING GETTER] execution(int Person.getId())"/>
+				<line text="[NON-STRING-ARRAY GETTER] execution(int Person.getId())"/>
+				<line text="[NON-STRING-ARRAY-ARRAY GETTER] execution(int Person.getId())"/>
+				<line text="[GETTER] execution(String Person.getFirstName())"/>
+				<line text="[NON-STRING-ARRAY GETTER] execution(String Person.getFirstName())"/>
+				<line text="[NON-STRING-ARRAY-ARRAY GETTER] execution(String Person.getFirstName())"/>
+				<line text="[GETTER] execution(String Person.getLastName())"/>
+				<line text="[NON-STRING-ARRAY GETTER] execution(String Person.getLastName())"/>
+				<line text="[NON-STRING-ARRAY-ARRAY GETTER] execution(String Person.getLastName())"/>
+				<line text="Marie Curie"/>
+				<line text="[SETTER] execution(void Person.setFullName(String))"/>
+				<line text="[SETTER] execution(void Person.setId(int))"/>
+				<line text="Person(id=22, lastName='Einstein', firstName='Albert')"/>
+				<line text="Einstein, Albert"/>
+				<line text="[NON-STRING GETTER] execution(void Person.getVoid())"/>
+				<line text="[NON-STRING-ARRAY GETTER] execution(void Person.getVoid())"/>
+				<line text="[NON-STRING-ARRAY-ARRAY GETTER] execution(void Person.getVoid())"/>
+				<line text="[GETTER] execution(String[] Person.getStringArray())"/>
+				<line text="[NON-STRING GETTER] execution(String[] Person.getStringArray())"/>
+				<line text="[STRING-ARRAY GETTER] execution(String[] Person.getStringArray())"/>
+				<line text="[NON-STRING-ARRAY-ARRAY GETTER] execution(String[] Person.getStringArray())"/>
+				<line text="[Hello, world]"/>
+				<line text="[GETTER] execution(String[][] Person.getStringArrayArray())"/>
+				<line text="[NON-STRING GETTER] execution(String[][] Person.getStringArrayArray())"/>
+				<line text="[NON-STRING-ARRAY GETTER] execution(String[][] Person.getStringArrayArray())"/>
+				<line text="[[Hello, world], [Hallo, Welt]]"/>
+				<line text="AspectJ rules!"/>
+			</stdout>
+		</run>
+	</ajc-test>
+
 </suite>


### PR DESCRIPTION
Fix matching problem for negated type patterns. The implementation for `boolean NotTypePattern.matchesArray(UnresolvedType type)` was buggy.
  * `!String` should match anything but `String`, no matter if it is an array or not, e.g. `int`, `void`, `int[]`, `String[]`, `String[][]`.
  * `!String[]` should match anything but `String[]`, no matter if it is an array or not, e.g. `int`, `void`, `int[]`, `String`, `String[][]`.

Fixes #257.