### PR TITLE
Workaround for defining classes during LTW

### DIFF
--- a/ajde.core/pom.xml
+++ b/ajde.core/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>asm</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>testing-util</artifactId>
       <version>${project.version}</version>

--- a/ajde/pom.xml
+++ b/ajde/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>asm</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>org.aspectj.ajdt.core</artifactId>
       <version>${project.version}</version>

--- a/ajdoc/pom.xml
+++ b/ajdoc/pom.xml
@@ -59,6 +59,10 @@
       <artifactId>asm</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>testing-util</artifactId>
       <version>${project.version}</version>

--- a/aspectjtools/pom.xml
+++ b/aspectjtools/pom.xml
@@ -365,6 +365,10 @@
 			<artifactId>asm</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-commons</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>runtime</artifactId>
 			<version>${project.version}</version>

--- a/aspectjweaver/aspectjweaver-assembly.xml
+++ b/aspectjweaver/aspectjweaver-assembly.xml
@@ -17,6 +17,7 @@
 			<useProjectArtifact>false</useProjectArtifact>
 			<includes>
 				<include>org.ow2.asm:asm</include>
+				<include>org.ow2.asm:asm-commons</include>
 			</includes>
 		</dependencySet>
 	</dependencySets>

--- a/aspectjweaver/pom.xml
+++ b/aspectjweaver/pom.xml
@@ -390,8 +390,17 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>loadtime</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-commons</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/loadtime/pom.xml
+++ b/loadtime/pom.xml
@@ -42,6 +42,10 @@
 			<artifactId>asm</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-commons</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>testing-util</artifactId>
 			<version>${project.version}</version>

--- a/org.aspectj.ajdt.core/pom.xml
+++ b/org.aspectj.ajdt.core/pom.xml
@@ -67,6 +67,10 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/Ajc.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/Ajc.java
@@ -38,8 +38,7 @@ import org.aspectj.util.FileUtil;
 
 import static java.io.File.pathSeparator;
 import static java.io.File.separator;
-import static org.aspectj.tools.ajc.AjcTestCase.CLASSPATH_ASM;
-import static org.aspectj.tools.ajc.AjcTestCase.CLASSPATH_JUNIT;
+import static org.aspectj.tools.ajc.AjcTestCase.*;
 
 /**
  * The Ajc class is intended for use as part of a unit-test suite, it drives the AspectJ compiler and lets you check the compilation
@@ -74,6 +73,7 @@ public class Ajc {
 			+ outputFolder("bcel-builder")
 			+ pathSeparator + CLASSPATH_JUNIT
 			+ pathSeparator + CLASSPATH_ASM
+			+ pathSeparator + CLASSPATH_ASM_COMMONS
 			+ outputFolder("bridge")
 			+ outputFolder("loadtime")
 			+ outputFolder("weaver")

--- a/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
+++ b/org.aspectj.ajdt.core/src/test/java/org/aspectj/tools/ajc/AjcTestCase.java
@@ -70,9 +70,15 @@ public abstract class AjcTestCase extends TestCase {
 	public static final String CLASSPATH_ASM =
 		Arrays.stream(System.getProperty("java.class.path")
 			.split(pathSeparator))
-			.filter(path -> path.replace('\\', '/').contains("org/ow2/asm/"))
+			.filter(path -> path.replace('\\', '/').contains("org/ow2/asm/asm/"))
 			.findFirst()
 			.orElseThrow(() -> new RuntimeException("ASM library not found on classpath"));
+	public static final String CLASSPATH_ASM_COMMONS =
+		Arrays.stream(System.getProperty("java.class.path")
+			.split(pathSeparator))
+			.filter(path -> path.replace('\\', '/').contains("org/ow2/asm/asm-commons/"))
+			.findFirst()
+			.orElseThrow(() -> new RuntimeException("ASM Commons library not found on classpath"));
 	public static final String CLASSPATH_JDT_CORE =
 		Arrays.stream(System.getProperty("java.class.path")
 			.split(pathSeparator))
@@ -102,6 +108,7 @@ public abstract class AjcTestCase extends TestCase {
 			+ pathSeparator + ".." + separator + "lib" + separator + "bcel" + separator + "bcel-verifier.jar"
 			+ pathSeparator + CLASSPATH_JDT_CORE
 			+ pathSeparator + CLASSPATH_ASM
+			+ pathSeparator + CLASSPATH_ASM_COMMONS
 			// hmmm, this next one should perhaps point to an aj-build jar...
 			+ pathSeparator + ".." + separator + "lib" + separator + "test" + separator + "aspectjrt.jar"
 		;

--- a/pom.xml
+++ b/pom.xml
@@ -556,6 +556,11 @@
 				<version>${asm.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.ow2.asm</groupId>
+				<artifactId>asm-commons</artifactId>
+				<version>${asm.version}</version>
+			</dependency>
+			<dependency>
 				<!-- All modules referencing files inside 'lib' need this dependency -->
 				<groupId>org.aspectj</groupId>
 				<artifactId>lib</artifactId>

--- a/run-all-junit-tests/pom.xml
+++ b/run-all-junit-tests/pom.xml
@@ -162,6 +162,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-commons</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>ajde</artifactId>
 			<version>${project.version}</version>

--- a/taskdefs/pom.xml
+++ b/taskdefs/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>asm</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
       <!-- Identical to lib/ant/lib/ant.jar, a former system-scoped dependency -->
       <groupId>ant</groupId>
       <artifactId>ant</artifactId>

--- a/testing-drivers/pom.xml
+++ b/testing-drivers/pom.xml
@@ -38,6 +38,10 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -53,6 +53,10 @@
       <artifactId>asm</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>testing-client</artifactId>
       <version>${project.version}</version>

--- a/testing/src/test/java/org/aspectj/testing/AntSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/AntSpec.java
@@ -98,9 +98,15 @@ public class AntSpec implements ITestStep {
 			// setup aj.dir "modules" folder
 			p.setUserProperty("aj.root", new File("..").getAbsolutePath());
 
-			// On Java 16+, LTW no longer works without this parameter. Add the argument here and not in AjcTestCase::run,
-			// because even if 'useLTW' and 'useFullLTW' are not set, we might in the future have tests for weaver attachment
-			// during runtime. See also docs/release/README-1.8.7.html.
+			// On Java 16+, LTW did not work on AspectJ 1.9.7 to 1.9.21 without this parameter. So, we added the argument here
+			// and not in AjcTestCase::run, because without 'useLTW' or 'useFullLTW', there might have been a need for weaver
+			// attachment during runtime. See also docs/release/README-1.8.7.adoc.
+			//
+			// Since AspectJ 1.9.21.1, '--add-opens' is no longer necessary, because we found a workaround for defining
+			// classes in arbitrary class loaders. But some tests, e.g. AtAjLTWTests.testLTWUnweavable, still use
+			// ClassLoader::defineClass to inject dynamically generated classes into the current class loader. Therefore, we
+			// still set the parameters, so they can be used on demand - not for LTW as such, but for class injection. See
+			// also tests/java5/ataspectj/ataspectj/UnweavableTest.java.
 			//
 			// Attention: Ant 1.6.3 under Linux neither likes "" (empty string) nor " " (space), on Windows it would not be
 			// a problem. So we use "_dummy" Java system properties, even though they pollute the command line.

--- a/testing/src/test/java/org/aspectj/testing/RunSpec.java
+++ b/testing/src/test/java/org/aspectj/testing/RunSpec.java
@@ -68,14 +68,21 @@ public class RunSpec implements ITestStep {
 
 			if (vmargs == null)
 				vmargs = "";
-			// On Java 16+, LTW no longer works without this parameter. Add the argument here and not in AjcTestCase::run,
-			// because even if 'useLTW' and 'useFullLTW' are not set, we might in the future have tests for weaver attachment
-			// during runtime. See also docs/release/README-1.8.7.html.
+			// On Java 16+, LTW did not work on AspectJ 1.9.7 to 1.9.21 without this parameter. So, we added the argument here
+			// and not in AjcTestCase::run, because without 'useLTW' or 'useFullLTW', there might have been a need for weaver
+			// attachment during runtime. See also docs/release/README-1.8.7.adoc.
+			//
+			// Since AspectJ 1.9.21.1, '--add-opens' is no longer necessary, because we found a workaround for defining
+			// classes in arbitrary class loaders. But some tests, e.g. AtAjLTWTests.testLTWUnweavable, still use
+			// ClassLoader::defineClass to inject dynamically generated classes into the current class loader. Therefore, we
+			// still set the parameters, so they can be used on demand - not for LTW as such, but for class injection. See
+			// also tests/java5/ataspectj/ataspectj/UnweavableTest.java.
 			//
 			// The reason for setting this parameter for Java 9+ instead of 16+ is that it helps to avoid the JVM printing
 			// unwanted illegal access warnings during weaving in 'useFullLTW' mode, either making existing tests fail or
 			// having to assert on the warning messages.
-			vmargs += is16VMOrGreater() ? " --add-opens java.base/java.lang=ALL-UNNAMED" : "";
+			//
+			// vmargs += is16VMOrGreater() ? " --add-opens java.base/java.lang=ALL-UNNAMED" : "";
 
 			AjcTestCase.RunResult rr = inTestCase.run(getClassToRun(), getModuleToRun(), args, vmargs, getClasspath(), getModulepath(), useLtw, "true".equalsIgnoreCase(usefullltw));
 

--- a/tests/bugs153/pr155033/ant.xml
+++ b/tests/bugs153/pr155033/ant.xml
@@ -15,8 +15,8 @@
             <jvmarg value="-Dorg.aspectj.weaver.Dump.condition=error"/>
         	<sysproperty key="org.aspectj.dump.directory" path="${aj.sandbox}"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
 <!--
             <jvmarg value="-Dorg.aspectj.tracing.enabled=true"/>

--- a/tests/bugs153/pr157474/ant-server.xml
+++ b/tests/bugs153/pr157474/ant-server.xml
@@ -19,8 +19,8 @@
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
             <jvmarg value="-Daj.weaving.verbose=true"/>
             <jvmarg value="-Dorg.aspectj.weaver.showWeaveInfo=true"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg value="-Dorg.aspectj.testing.server.debug=true"/>-->
         	<arg path="${aj.sandbox}"/>
         </java>

--- a/tests/bugs153/pr158957/ant.xml
+++ b/tests/bugs153/pr158957/ant.xml
@@ -20,8 +20,8 @@
             <jvmarg value="-Dorg.aspectj.tracing.enabled=true"/>
             <jvmarg value="-Dorg.aspectj.tracing.factory=default"/>
             <jvmarg value="-Dorg.aspectj.tracing.messages=true"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>

--- a/tests/java5/ataspectj/ajc-ant.xml
+++ b/tests/java5/ataspectj/ajc-ant.xml
@@ -24,8 +24,8 @@
             <!-- use META-INF/aop.xml style -->
             <classpath path="ataspectj/pathentry"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>
@@ -36,8 +36,8 @@
         <java fork="yes" classname="ataspectj.PerClauseTest" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>            -->
         </java>
     </target>
@@ -48,8 +48,8 @@
         <java fork="yes" classname="ataspectj.AroundInlineMungerTest" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
             <!--<jvmarg line="${jdwp}"/>--><!-- uncomment to debug with JDWP -->
         </java>
     </target>
@@ -60,8 +60,8 @@
         <java fork="yes" classname="ataspectj.AroundInlineMungerTest2" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -69,8 +69,8 @@
         <java fork="yes" classname="ataspectj.DumpTest" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -80,8 +80,8 @@
         <java fork="yes" classname="ataspectj.TestProxyGenerator" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -101,8 +101,8 @@
                 <pathelement path="${aj.sandbox}/main1.jar"/>
             </classpath>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -119,8 +119,8 @@
         <java fork="yes" classname="ataspectj.ltwlog.MainSilent" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
         <copy file="ataspectj/ltwlog/aop-verbsoe.xml"
               tofile="${aj.sandbox}/META-INF/aop.xml"
@@ -129,8 +129,8 @@
         <java fork="yes" classname="ataspectj.ltwlog.MainVerbose" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
         <copy file="ataspectj/ltwlog/aop-verboseandshow.xml"
               tofile="${aj.sandbox}/META-INF/aop.xml"
@@ -139,8 +139,8 @@
         <java fork="yes" classname="ataspectj.ltwlog.MainVerboseAndShow" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -160,6 +160,7 @@
                 <path refid="aj.path"/>
             </classpath>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
+            <!-- Necessary, because the test (not AspectJ itself!) uses ClassLoader::defineClass -->
             <jvmarg value="${aj.addOpensKey}"/>
             <jvmarg value="${aj.addOpensValue}"/>
         </java>
@@ -175,8 +176,8 @@
                 <path refid="aj.path"/>
             </classpath>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
 
         <copy file="ataspectj/aop-decptest.xml"
@@ -188,8 +189,8 @@
                 <path refid="aj.path"/>
             </classpath>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-          <jvmarg value="${aj.addOpensKey}"/>
-          <jvmarg value="${aj.addOpensValue}"/>
+<!--          <jvmarg value="${aj.addOpensKey}"/>-->
+<!--          <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -211,8 +212,8 @@
                 <path refid="aj.path"/>
             </classpath>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -230,8 +231,8 @@
             </classpath>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
             <jvmarg value="-DaspectDeclared=true"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
         <!--Now ensure that the error is not produced when the declaration is made.-->
         <copy file="ataspectj/ltwreweavable/aop-ltwreweavable-omitted.xml"
@@ -244,8 +245,8 @@
             </classpath>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
             <jvmarg value="-DaspectDeclared=false"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -273,8 +274,8 @@
             <classpath refid="aj.path"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
             <jvmarg value="-Daj.weaving.verbose=true"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
         </java>
     </target>
 
@@ -291,8 +292,8 @@
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
             <jvmarg value="-Daj.weaving.verbose=true"/>
             <jvmarg value="-Djava.util.logging.config.file=${aj.root}/weaver5/testdata/logging.properties"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>

--- a/tests/java5/ataspectj/ataspectj/UnweavableTest.java
+++ b/tests/java5/ataspectj/ataspectj/UnweavableTest.java
@@ -104,6 +104,8 @@ public class UnweavableTest extends TestCase {
 
         try {
             ClassLoader loader = this.getClass().getClassLoader();
+            // Needs "--add-opens java.base/java.lang=ALL-UNNAMED" on the JVM command line, injected in Ant build via
+            // aj.addOpensKey and aj.addOpensValue variables. See also AntSpec::execute.
             Method def = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
             def.setAccessible(true);
             Class<?> gen = (Class<?>) def.invoke(loader, "ataspectj.ISomeGen", cw.toByteArray(), 0, cw.toByteArray().length);
@@ -127,6 +129,8 @@ public class UnweavableTest extends TestCase {
 
         try {
             ClassLoader loader = this.getClass().getClassLoader();
+            // Needs "--add-opens java.base/java.lang=ALL-UNNAMED" on the JVM command line, injected in Ant build via
+            // aj.addOpensKey and aj.addOpensValue variables. See also AntSpec::execute.
             Method def = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
             def.setAccessible(true);
             Class<?> gen = (Class<?>) def.invoke(loader, "ataspectj.unmatched.Gen", cw.toByteArray(), 0, cw.toByteArray().length);

--- a/tests/ltw/ant-server.xml
+++ b/tests/ltw/ant-server.xml
@@ -14,8 +14,8 @@
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
             <jvmarg value="-Daj.weaving.verbose=true"/>
             <jvmarg value="-Dorg.aspectj.weaver.showWeaveInfo=true"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
             <!--<jvmarg value="-Dorg.aspectj.testing.server.debug=true"/>-->
             <sysproperty key="org.aspectj.dump.directory" path="${aj.sandbox}"/>
             <arg path="${aj.sandbox}"/>
@@ -30,8 +30,8 @@
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
             <jvmarg value="-Daj.weaving.verbose=true"/>
             <jvmarg value="-Dorg.aspectj.weaver.showWeaveInfo=true"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
             <!--<jvmarg value="-Dorg.aspectj.testing.server.debug=true"/>-->
             <sysproperty key="org.aspectj.dump.directory" path="${aj.sandbox}"/>
             <arg path="${aj.sandbox}"/>

--- a/tests/ltw/ant.xml
+++ b/tests/ltw/ant.xml
@@ -11,8 +11,8 @@
         <java fork="yes" classname="HelloWorldWithException" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-Djava.system.class.loader=org.aspectj.weaver.loadtime.WeavingURLClassLoader"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
             <jvmarg value="-Dorg.aspectj.tracing.debug=true"/>
 <!--
             <jvmarg value="-Daj.weaving.verbose=true"/>
@@ -29,8 +29,8 @@
         <java fork="yes" classname="HelloWorldWithException" failonerror="yes">
             <classpath refid="aj.path"/>
             <jvmarg value="-Djava.system.class.loader=org.aspectj.weaver.loadtime.WeavingURLClassLoader"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
             <jvmarg value="-Dorg.aspectj.tracing.debug=true"/>
 <!--
             <jvmarg value="-Daj.weaving.verbose=true"/>
@@ -62,8 +62,8 @@
             <jvmarg value="-Dorg.aspectj.tracing.messages=true"/>
             <!-- use META-INF/aop.xml style -->
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>
@@ -80,8 +80,8 @@
         	     to bootclasspath -->
         	<jvmarg value="-Xbootclasspath/p:${aj.sandbox}"/>
             <jvmarg value="-Xbootclasspath/a:${aj.bootpath}"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 
         	<classpath>
                 <pathelement path="${aj.sandbox}/hello.jar:${aj.sandbox}/handler.jar:${aj.sandbox}/security.jar"/>
@@ -109,8 +109,8 @@
             <classpath refid="aj.path"/>
             <!-- use META-INF/aop.xml style -->
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>
@@ -124,8 +124,8 @@
         	<sysproperty key="org.aspectj.dump.directory" path="${aj.sandbox}"/>
             <!-- use META-INF/aop.xml style -->
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
             <jvmarg value="-Dorg.aspectj.tracing.factory=default"/>
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -44,6 +44,10 @@
 			<artifactId>asm</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-commons</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>weaver</artifactId>
 			<version>${project.version}</version>

--- a/tests/profiling/build.xml
+++ b/tests/profiling/build.xml
@@ -290,8 +290,8 @@
 			<jvmarg value="${gc.args}"/>
 			<jvmarg value="${hprof.args}"/>
 			<jvmarg value="-javaagent:${aspectj.lib.dir}/aspectjweaver.jar"/>
-			<jvmarg value="${aj.addOpensKey}"/>
-			<jvmarg value="${aj.addOpensValue}"/>
+<!--			<jvmarg value="${aj.addOpensKey}"/>-->
+<!--			<jvmarg value="${aj.addOpensValue}"/>-->
 			<classpath>
 				<pathelement location="${results.dir}/ltw-app"/>
 				<pathelement location="${results.dir}/aspectlib.jar"/>
@@ -323,8 +323,8 @@
 			<arg value="${weave.injar}"/>
 			<jvmarg value="${gc.args}"/>
 			<jvmarg value="-javaagent:${aspectj.lib.dir}/aspectjweaver.jar"/>
-			<jvmarg value="${aj.addOpensKey}"/>
-			<jvmarg value="${aj.addOpensValue}"/>
+<!--			<jvmarg value="${aj.addOpensKey}"/>-->
+<!--			<jvmarg value="${aj.addOpensValue}"/>-->
 			<classpath>
 				<pathelement location="${results.dir}/ltw-app"/>
 				<pathelement location="${results.dir}/aspectlib.jar"/>

--- a/tests/tracing/ant.xml
+++ b/tests/tracing/ant.xml
@@ -33,8 +33,8 @@
             <jvmarg value="-Dorg.aspectj.tracing.messages=true"/>
             <!-- use META-INF/aop.xml style -->
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>
@@ -48,8 +48,8 @@
 <!--            <jvmarg value="-verbose:class"/>-->
             <!-- use META-INF/aop.xml style -->
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>
@@ -63,8 +63,8 @@
             <jvmarg value="-Djava.util.logging.config.file=logging.properties"/>
             <!-- use META-INF/aop.xml style -->
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg line="${jdwp}"/>-->
         </java>
     </target>
@@ -76,8 +76,8 @@
             <jvmarg value="-Dorg.aspectj.tracing.factory=default"/>
             <jvmarg value="-Dorg.aspectj.tracing.messages=true"/>
             <jvmarg value="-javaagent:${aj.root}/lib/test/loadtime5.jar"/>
-            <jvmarg value="${aj.addOpensKey}"/>
-            <jvmarg value="${aj.addOpensValue}"/>
+<!--            <jvmarg value="${aj.addOpensKey}"/>-->
+<!--            <jvmarg value="${aj.addOpensValue}"/>-->
 <!--            <jvmarg value="-verbose:class"/>-->
             <!-- use META-INF/aop.xml style -->
 <!--            <jvmarg line="${jdwp}"/>-->

--- a/weaver/pom.xml
+++ b/weaver/pom.xml
@@ -65,5 +65,9 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Overhaul `ClassLoaderWeavingAdaptor` to use statically initialised `Unsafe` instances and method handles pointing to their `defineClass` methods. Those now work universally on JDKs 8-21. In older JDKs, the method used to be in `sun.misc.Unsafe`, in more recent ones on `jdk.internal.misc.Unsafe`. It is challenging to fetch instances, especially as reflection protection and module boundaries have been increased in the JDK progressively. But finally, a solution was adapted from Byte Buddy (BB).
Kudos to BB author Rafael Winterhalter. The previous solution to use `ClassLoader::defineClass` and require `--add-opens` is no longer necessary for the first time since it became necessary in AspectJ 1.9.7 with Java 16 support.

Add `org.ow2.asm:asm-common` as a dependency everywhere `org.ow2.asm:asm` was used before. Maybe that is too many places, but no worse than before.

Add missing dependency on `loadtime` to `aspectjweaver`. This kept a build like `mvn install -am -pl aspectjweaver` from picking up changed `loadtime` classes.

Fixes #117.