### PR TITLE
Weaver returns null instead of original bytes for unwoven classes

### DIFF
--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
@@ -569,7 +569,7 @@ public class ClassLoaderWeavingAdaptor extends WeavingAdaptor {
 
 			try {
 				byte[] newBytes = weaveClass(name, bytes, true);
-				this.generatedClassHandler.acceptClass(name, bytes, newBytes);
+				this.generatedClassHandler.acceptClass(name, bytes, newBytes == null ? bytes : newBytes);
 			} catch (IOException ex) {
 				trace.error("weaveAndDefineConceteAspects", ex);
 				error("exception weaving aspect '" + name + "'", ex);

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassPreProcessor.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassPreProcessor.java
@@ -24,7 +24,18 @@ public interface ClassPreProcessor {
 	 */
 	void initialize();
 
-	byte[] preProcess(String className, byte[] bytes, ClassLoader classLoader, ProtectionDomain protectionDomain);
+	/**
+	 * @param className        the name of the class in the internal form of fully qualified class and interface names as
+	 *                         defined in <i>The Java Virtual Machine Specification</i>. For example,
+	 *                         <code>"java/util/List"</code>.
+	 * @param bytes            the input byte buffer in class file format - must not be modified
+	 * @param classLoader      the defining loader of the class to be transformed, may be {@code null} if the bootstrap
+	 *                         loader
+	 * @param protectionDomain the protection domain of the class being defined or redefined
+	 *
+	 * @return a well-formed class file buffer (weaving result), or {@code null} if no weaving was performed
+	 */
+	byte[] preProcess(String className, final byte[] bytes, ClassLoader classLoader, ProtectionDomain protectionDomain);
 
 	void prepareForRedefinition(ClassLoader loader, String className);
 }

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassPreProcessorAgentAdapter.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassPreProcessorAgentAdapter.java
@@ -43,7 +43,7 @@ public class ClassPreProcessorAgentAdapter implements ClassFileTransformer {
 	 */
 	@Override
 	public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain,
-			byte[] bytes) throws IllegalClassFormatException {
+			final byte[] bytes) throws IllegalClassFormatException {
 		if (classBeingRedefined != null) {
 			System.err.println("INFO: (Enh120375):  AspectJ attempting reweave of '" + className + "'");
 			classPreProcessor.prepareForRedefinition(loader, className);

--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/WeavingURLClassLoader.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/WeavingURLClassLoader.java
@@ -136,6 +136,8 @@ public class WeavingURLClassLoader extends ExtensibleURLClassLoader implements W
 
 			try {
 				b = adaptor.weaveClass(name, b, false);
+				if (b == null)
+					b = orig;
 			} catch (AbortException ex) {
 				trace.error("defineClass", ex);
 				throw ex;
@@ -149,7 +151,7 @@ public class WeavingURLClassLoader extends ExtensibleURLClassLoader implements W
 		try {
 			clazz= super.defineClass(name, b, cs);
 		} catch (Throwable th) {
-			trace.error("Weaving class problem. Original class has been returned. The error was caused because of: " + th, th);
+			trace.error("Weaving class problem. Original class has been returned. Error cause: " + th, th);
 			clazz= super.defineClass(name, orig, cs);
 		}
 		if (trace.isTraceEnabled()) {

--- a/weaver/src/main/java/org/aspectj/weaver/tools/cache/SimpleCache.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/cache/SimpleCache.java
@@ -72,6 +72,7 @@ public class SimpleCache {
 		byte[] res = get(classname, bytes);
 
 		if (Arrays.equals(SAME_BYTES, res)) {
+			// TODO: Should we return null (means "not transformed") in this case?
 			return bytes;
 		} else {
 			if (res != null) {


### PR DESCRIPTION
This change makes sense independently of #277, but also enables using
```text
-cp "my.jar;aspectjweaver.jar" -XX:+AllowArchivingWithJavaAgent -javaagent:aspectjweaver.jar
```
while creating a CDS archive. Afterward, the application can be run in its woven state from the CDS archive even without `-javaagent`, because the byte code was archived in its woven state ("poor man's AJC"). See https://github.com/eclipse-aspectj/aspectj/issues/277#issuecomment-1931142753 for details.

Fixes #277.