### PR TITLE
Throw exception for minimal AJC runtime version violation

### DIFF
--- a/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
+++ b/org.aspectj.ajdt.core/src/main/java/org/aspectj/tools/ajc/Main.java
@@ -244,12 +244,8 @@ public class Main {
 		// will see ugly UnsupportedClassVersionError stack traces, which they might or might not interpret correctly.
 		// Therefore, interrupt AJC usage right here, even if it means that not even a usage page can be printed. It is
 		// better to save users from subsequent problems later.
-		if (SourceVersion.latest().ordinal() < MINIMAL_JRE_VERSION) {
-			System.err.println(MINIMAL_JRE_VERSION_ERROR);
-			if (doExit)
-				System.exit(-1);
-			return;
-		}
+		if (SourceVersion.latest().ordinal() < MINIMAL_JRE_VERSION)
+			throw new AbortException(MINIMAL_JRE_VERSION_ERROR);
 
 		// Urk - default no check for AJDT, enabled here for Ant, command-line
 		AjBuildManager.enableRuntimeVersionCheck(this);


### PR DESCRIPTION
When running AJC, throw an `AbortException(MINIMAL_JRE_VERSION)` instead of just logging an error, if the minimal JRE version requirement is violated. Otherwise, in-process compilation would not fail due to the skipped `System.exit(-1)` that was used before. In-process compilation is, for example, relevant for AspectJ Maven Plugin, but also for non-forked executions of Plexus AspectJ via Maven Compiler.

I am not 100% sure that `AbortException` is the appropriate exception type, because it was designed for an aborted compilation process and here compilation has not even started yet, but it seems to work fine.

Relates to #269.
Fixes #292.
Supersedes PR #293.