### PR TITLE
Revert WeavingAdaptor generated class map optimisation

### DIFF
--- a/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
+++ b/loadtime/src/main/java/org/aspectj/weaver/loadtime/ClassLoaderWeavingAdaptor.java
@@ -1008,8 +1008,16 @@ public class ClassLoaderWeavingAdaptor extends WeavingAdaptor {
 	 * @param className a slashed classname (e.g. com/foo/Bar)
 	 */
 	public void flushGeneratedClassesFor(String className) {
-		String dottedClassName = className.replace('/', '.');
-		generatedClasses.remove(dottedClassName);
+		try {
+			String dottedClassName = className.replace('/', '.');
+			String dottedClassNameDollar = dottedClassName + "$"; // to pick up inner classes
+			generatedClasses.entrySet().removeIf(entry -> {
+				String generatedClassName = entry.getKey();
+				return generatedClassName.equals(dottedClassName) || generatedClassName.startsWith(dottedClassNameDollar);
+			});
+		} catch (Throwable t) {
+			new RuntimeException("Unexpected problem tidying up generated classes for " + className, t).printStackTrace();
+		}
 	}
 
 	private static final Object lock = new Object();

--- a/weaver/src/main/java/org/aspectj/weaver/tools/WeavingAdaptor.java
+++ b/weaver/src/main/java/org/aspectj/weaver/tools/WeavingAdaptor.java
@@ -939,6 +939,7 @@ public class WeavingAdaptor implements IMessageContext {
 						lacache.addGeneratedClassesNames(wovenClass.getClassName(), wovenClass.getBytes(), result.getClassName());
 					}
 
+					generatedClasses.put(className, result);
 					generatedClasses.put(wovenClass.getClassName(), wovenClass);
 					generatedClassHandler.acceptClass(className, null, resultBytes);
 				}


### PR DESCRIPTION
This was introduced in commit 8a4aa03845 of PR #278 contribution as part of the #279 fix. The contributor thought that the generated closure class entries were never used, but in fact AJDT class `OSGiWeavingAdaptor` relies on the presence of those entries.

To the best of my present knowledge, it looks as if this change was the root cause of https://github.com/eclipse-aspectj/ajdt/issues/57. Therefore, I reverted it, simultaneously refactoring `Iterator::remove` usage to delete entries from the map to `Collection::removeIf`.

Fixes #305.