### PR TITLE
Per-classloader weaving cache fails for classes generated for around advice types

### DIFF
--- a/tests/features171/pr386341/X.aj
+++ b/tests/features171/pr386341/X.aj
@@ -6,15 +6,23 @@
  * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *
  * Contributors:
- *    Andy Clement - Repro test case
+ *    Andy Clement - repro test case
  *    Abraham Nevado
+ *    Alexander Kriegisch - repro for GitHub 314
  *******************************************************************************/
 
 aspect X {
   after(): execution(* *.*()) {
     System.out.println("It Worked-after");
   }
+
   before(): execution(* *.*()) {
-	 System.out.println("It Worked-before");
+    System.out.println("It Worked-before");
+  }
+
+  // Around advice reproduces GitHub 314 in connection with per-classloader cache
+  Object around(): execution(* *.*()) {
+    System.out.println("It Worked-around");
+    return proceed();
   }
 }

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc171/newfeatures-tests.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc171/newfeatures-tests.xml
@@ -2,40 +2,65 @@
 
 <!-- AspectJ v1.7.1 Features Tests -->
 <suite>
+
   <ajc-test dir="features171/pr386341" title="Test Shared Cache">
     <compile files="A.java" options="-1.5"/>
-    <compile files="X.aj" options="-1.5 -Xlint:ignore" />
-    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./ -Daj.weaving.cache.impl=shared" > 
-    <stdout>
-	    <line text="It Worked-before"/>
-	   	<line text="It Worked-after"/>
-    </stdout>
+    <compile files="X.aj" options="-1.5 -Xlint:ignore"/>
+    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./ -Daj.weaving.cache.impl=shared">
+      <stdout>
+        <line text="It Worked-before"/>
+        <line text="It Worked-around"/>
+        <line text="It Worked-after"/>
+      </stdout>
     </run>
-  </ajc-test>  
-  
-   <ajc-test dir="features171/pr386341" title="Test Per ClassLoader Cache">
+    <!-- Repeat run to actually re-use the cached files, reproducing GitHub issue 314 -->
+    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./ -Daj.weaving.cache.impl=shared">
+      <stdout>
+        <line text="It Worked-before"/>
+        <line text="It Worked-around"/>
+        <line text="It Worked-after"/>
+      </stdout>
+    </run>
+  </ajc-test>
+
+  <ajc-test dir="features171/pr386341" title="Test Per ClassLoader Cache">
     <compile files="A.java" options="-1.5"/>
-    <compile files="X.aj" options="-1.5 -Xlint:ignore" />
-    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./ -Daj.weaving.cache.impl=perloader" > 
-    <stdout>
-	    <line text="It Worked-before"/>
-	   	<line text="It Worked-after"/>
-    </stdout>
+    <compile files="X.aj" options="-1.5 -Xlint:ignore"/>
+    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./ -Daj.weaving.cache.impl=perloader">
+      <stdout>
+        <line text="It Worked-before"/>
+        <line text="It Worked-around"/>
+        <line text="It Worked-after"/>
+      </stdout>
     </run>
-  </ajc-test>  
-  
+    <!-- Repeat run to actually re-use the cached files, reproducing GitHub issue 314 -->
+    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./ -Daj.weaving.cache.impl=perloader">
+      <stdout>
+        <line text="It Worked-before"/>
+        <line text="It Worked-around"/>
+        <line text="It Worked-after"/>
+      </stdout>
+    </run>
+  </ajc-test>
+
   <ajc-test dir="features171/pr386341" title="Test Default Cache Per ClassLoader">
     <compile files="A.java" options="-1.5"/>
-    <compile files="X.aj" options="-1.5 -Xlint:ignore" />
-    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./" > 
-    <stdout>
-	    <line text="It Worked-before"/>
-	   	<line text="It Worked-after"/>
-    </stdout>
+    <compile files="X.aj" options="-1.5 -Xlint:ignore"/>
+    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./">
+      <stdout>
+        <line text="It Worked-before"/>
+        <line text="It Worked-around"/>
+        <line text="It Worked-after"/>
+      </stdout>
     </run>
-  </ajc-test> 
-  
-  
-  
- 
+    <!-- Repeat run to actually re-use the cached files, reproducing GitHub issue 314 -->
+    <run class="A" ltw="aop.xml" usefullltw="true" vmargs="-Daj.weaving.cache.enabled=true -Daj.weaving.cache.dir=./">
+      <stdout>
+        <line text="It Worked-before"/>
+        <line text="It Worked-around"/>
+        <line text="It Worked-after"/>
+      </stdout>
+    </run>
+  </ajc-test>
+
 </suite>


### PR DESCRIPTION
Relates to #314.