### PR TITLE
Fixes #343 withincode doesn't work as specified

### DIFF
--- a/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WithincodePointcut.java
+++ b/org.aspectj.matcher/src/main/java/org/aspectj/weaver/patterns/WithincodePointcut.java
@@ -41,6 +41,8 @@ public class WithincodePointcut extends Pointcut {
 		// these next two are needed for inlining of field initializers
 		flags |= Shadow.ConstructorExecution.bit;
 		flags |= Shadow.Initialization.bit;
+		// According to the documentation, method (and constructor) execution matches.
+		flags |= Shadow.MethodExecution.bit;
 		matchedShadowKinds = flags;
 	}
 

--- a/org.aspectj.matcher/src/test/java/org/aspectj/matcher/tools/CommonPointcutExpressionTests.java
+++ b/org.aspectj.matcher/src/test/java/org/aspectj/matcher/tools/CommonPointcutExpressionTests.java
@@ -226,8 +226,8 @@ public abstract class CommonPointcutExpressionTests extends TestCase {
 		ResolvedMember stringValueOfIntMethod = getMethod(jlString, "valueOf", "(I)Ljava/lang/String;");
 		ResolvedMember listAddMethod = getMethod(juList, "add", "(Ljava/lang/Object;)Z");
 
-		assertTrue(ex.matchesMethodExecution(stringSplitMethod).neverMatches());
-		assertTrue(ex.matchesMethodExecution(stringValueOfIntMethod).neverMatches());
+		assertTrue(ex.matchesMethodExecution(stringSplitMethod).alwaysMatches());
+		assertTrue(ex.matchesMethodExecution(stringValueOfIntMethod).alwaysMatches());
 		assertTrue(ex.matchesMethodExecution(listAddMethod).neverMatches());
 	}
 

--- a/org.aspectj.matcher/src/test/java/org/aspectj/weaver/patterns/PointcutRewriterTest.java
+++ b/org.aspectj.matcher/src/test/java/org/aspectj/weaver/patterns/PointcutRewriterTest.java
@@ -337,7 +337,8 @@ public class PointcutRewriterTest extends TestCase {
 		Set<Shadow.Kind> matches = Shadow.toSet(p.couldMatchKinds());
 		for (Shadow.Kind o : matches) {
 			assertFalse("No kinds that are themselves enclosing",
-					(o.isEnclosingKind() && o != Shadow.ConstructorExecution && o != Shadow.Initialization));
+					(o.isEnclosingKind() && o != Shadow.ConstructorExecution && o != Shadow.Initialization
+							&& o != Shadow.MethodExecution));
 		}
 		for (int i = 0; i < Shadow.SHADOW_KINDS.length; i++) {
 			if (!Shadow.SHADOW_KINDS[i].isEnclosingKind()) {
@@ -346,6 +347,7 @@ public class PointcutRewriterTest extends TestCase {
 		}
 		assertTrue("Need cons-exe for inlined field inits", matches.contains(Shadow.ConstructorExecution));
 		assertTrue("Need init for inlined field inits", matches.contains(Shadow.Initialization));
+		assertTrue("Needs method-exe to comply with the docs", matches.contains(Shadow.MethodExecution));
 		// + @
 		p = getPointcut("@withincode(Foo)");
 		matches = Shadow.toSet(p.couldMatchKinds());

--- a/tests/bugs150/Pr103097.aj
+++ b/tests/bugs150/Pr103097.aj
@@ -3,7 +3,7 @@ import java.io.IOException;
 public aspect Pr103097 {
     declare soft: IOException: 
     		within(Pr103097) && 
-    		!withincode(* *(..)) &&
+    		(!withincode(* *(..)) || execution(* *(..))) &&
     		!call(* *(..));
 
     before() : execution(* main(..)) {

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc150/ajc150.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc150/ajc150.xml
@@ -5207,7 +5207,9 @@
         <message kind="warning" line="38" text="erasure type matching in withincode ok"/>
         <message kind="warning" line="39" text="erasure type matching in withincode ok"/>
         <message kind="warning" line="42" text="erasure type matching in withincode ok"/>
+        <message kind="warning" line="61" text="withincode and parameterized method ok"/>
         <message kind="warning" line="62" text="withincode and parameterized method ok"/>
+        <message kind="warning" line="61" text="withincode and generic interface ok"/>
         <message kind="warning" line="62" text="withincode and generic interface ok"/>
         <message kind="warning" line="65" text="withincode and interface control test"/>
         <message kind="warning" line="35" text="match on parameterized args"/>
@@ -5218,16 +5220,27 @@
 
     <ajc-test dir="java5/generics/pointcuts" title="withincode with overriding of inherited generic members">
      <compile files="WithinCodeOverriding.aj" options="-1.8">
+        <message kind="warning" line="36" text="wildcard declaring type match on erasure"/>
         <message kind="warning" line="37" text="wildcard declaring type match on erasure"/>
+        <message kind="warning" line="49" text="wildcard declaring type match on erasure"/>
         <message kind="warning" line="50" text="wildcard declaring type match on erasure"/>
+        <message kind="warning" line="62" text="wildcard declaring type match on erasure"/>
         <message kind="warning" line="63" text="wildcard declaring type match on erasure"/>
+        <message kind="warning" line="36" text="base declaring type match on erasure"/>
         <message kind="warning" line="37" text="base declaring type match on erasure"/>
+        <message kind="warning" line="49" text="base declaring type match on erasure"/>
         <message kind="warning" line="50" text="base declaring type match on erasure"/>
+        <message kind="warning" line="62" text="base declaring type match on erasure"/>
         <message kind="warning" line="63" text="base declaring type match on erasure"/>
+        <message kind="warning" line="49" text="sub type match on erasure"/>
         <message kind="warning" line="50" text="sub type match on erasure"/>
+        <message kind="warning" line="62" text="parameterized match on erasure"/>
         <message kind="warning" line="63" text="parameterized match on erasure"/>
+        <message kind="warning" line="79" text="erasure match on base interface"/>
         <message kind="warning" line="80" text="erasure match on base interface"/>
+        <message kind="warning" line="79" text="wildcard match on erasure"/>
         <message kind="warning" line="80" text="wildcard match on erasure"/>
+        <message kind="warning" line="79" text="parameterized match"/>
         <message kind="warning" line="80" text="parameterized match"/>
      </compile>
     </ajc-test>
@@ -5445,7 +5458,9 @@
      <compile files="GenericMethods.aj" options="-1.8">
          <message kind="warning" line="19" text="static generic method match"/>
          <message kind="warning" line="34" text="static generic method match"/>
+         <message kind="warning" line="23" text="instance generic method match"/>
          <message kind="warning" line="24" text="instance generic method match"/>
+         <message kind="warning" line="38" text="instance generic method match"/>
          <message kind="warning" line="39" text="instance generic method match"/>
      </compile>
    </ajc-test>

--- a/tests/src/test/resources/org/aspectj/systemtest/ajc152/synchronization.xml
+++ b/tests/src/test/resources/org/aspectj/systemtest/ajc152/synchronization.xml
@@ -324,6 +324,7 @@
     <ajc-test dir="features152/synchronization" title="prevent double unlock weaving messages and model contents">
         <compile files="ThisJoinPointUnlock.java" options="-1.8 -Xjoinpoints:synchronization -showWeaveInfo -emacssym">
           <message kind="weave" text="Join point 'lock(void java.lang.Object.&lt;lock&gt;(java.lang.Object))' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:38) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
+          <message kind="weave" text="Join point 'method-execution(void ThisJoinPointUnlock.nonStaticMethod())' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:37) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
           <message kind="weave" text="Join point 'method-call(void ThisJoinPointUnlock.staticMethod())' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:39) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
           <message kind="weave" text="Join point 'unlock(void java.lang.Object.&lt;unlock&gt;(java.lang.Object))' in Type 'ThisJoinPointUnlock' (ThisJoinPointUnlock.java:38) advised by before advice from 'TJPAspect' (ThisJoinPointUnlock.java:4)"/>
         </compile>

--- a/weaver/src/test/java/org/aspectj/weaver/tools/PointcutExpressionTest.java
+++ b/weaver/src/test/java/org/aspectj/weaver/tools/PointcutExpressionTest.java
@@ -118,7 +118,7 @@ public class PointcutExpressionTest extends TestCase {
 
 		// withincode
 		ex = p.parsePointcutExpression("withincode(* a*(..))");
-		assertTrue("Should not match", ex.matchesMethodExecution(a).neverMatches());
+		assertTrue("Should match", ex.matchesMethodExecution(a).alwaysMatches());
 	}
 
 	public void testMatchesConstructorCall() {


### PR DESCRIPTION
Pointcuts of the form `withincode(MethodSignature)` don't match method-execution joinpoints, which is in contradiction with the documentation. Moreover, both constructor-execution and initialization joinpoints are matched by pointcuts of the form `withincode(ConstructorSignature)`. This agrees with the documentation, but is inconsistent with the behaviour regarding method execution.
This PR allows `withincode` pointcuts to match method-execution joinpoints and modifies the corresponding unit tests.