### PR TITLE
Harden DocumentParser against XXE attacks

### DIFF
--- a/loadtime/src/test/java/org/aspectj/weaver/loadtime/test/DocumentParserTest.java
+++ b/loadtime/src/test/java/org/aspectj/weaver/loadtime/test/DocumentParserTest.java
@@ -15,6 +15,7 @@ import java.net.URL;
 
 import org.aspectj.weaver.loadtime.definition.Definition;
 import org.aspectj.weaver.loadtime.definition.DocumentParser;
+import org.xml.sax.SAXException;
 
 import junit.framework.TestCase;
 
@@ -40,6 +41,16 @@ public class DocumentParserTest extends TestCase {
         assertEquals("@Whoo", def.getAspectIncludePatterns().get(0));
         assertEquals("foo..*", def.getDumpPatterns().get(0));
         assertEquals(true,def.shouldDumpBefore());
+    }
+
+    public void testExternalEntitiesAreDisabled() throws Throwable {
+        URL url = DocumentParserTest.class.getResource("evil.xml");
+        try {
+            DocumentParser.parse(url);
+            fail("Parsing XML with external entities must fail when secure parser features are enabled");
+        } catch (Throwable e) {
+            assertTrue("Expected SAXException or parser failure", e instanceof SAXException);
+        }
     }
 
 }

--- a/loadtime/src/test/resources/org/aspectj/weaver/loadtime/test/evil.xml
+++ b/loadtime/src/test/resources/org/aspectj/weaver/loadtime/test/evil.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE aspectj [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<aspectj>
+    <weaver options="&xxe;"/>
+</aspectj>

--- a/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/DocumentParser.java
+++ b/weaver/src/main/java/org/aspectj/weaver/loadtime/definition/DocumentParser.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Hashtable;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 
@@ -159,35 +160,60 @@ public class DocumentParser extends DefaultHandler {
 	}
 
 	private static XMLReader getXMLReader() throws SAXException, ParserConfigurationException {
-		XMLReader xmlReader = null;
-		/* Try this first for Java 5 */
-		try {
-			xmlReader = XMLReaderFactory.createXMLReader();
-		}
+	SAXParserFactory factory = SAXParserFactory.newInstance();
+	factory.setNamespaceAware(true);
+	factory.setValidating(false);
 
-		/* .. and ignore "System property ... not set" and then try this instead */
-		catch (SAXException ex) {
-			xmlReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
-		}
-		return xmlReader;
+	configureFactoryFeature(factory, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+	configureFactoryFeature(factory, "http://xml.org/sax/features/external-general-entities", false);
+	configureFactoryFeature(factory, "http://xml.org/sax/features/external-parameter-entities", false);
+	configureFactoryFeature(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+	XMLReader xmlReader;
+	try {
+		xmlReader = factory.newSAXParser().getXMLReader();
+	} catch (ParserConfigurationException | SAXException ex) {
+		xmlReader = XMLReaderFactory.createXMLReader();
 	}
+	configureReaderFeature(xmlReader, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+	configureReaderFeature(xmlReader, "http://xml.org/sax/features/external-general-entities", false);
+	configureReaderFeature(xmlReader, "http://xml.org/sax/features/external-parameter-entities", false);
+	configureReaderFeature(xmlReader, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+	return xmlReader;
+}
 
-	public InputSource resolveEntity(String publicId, String systemId) throws SAXException {
-		if (publicId.equals(DTD_PUBLIC_ID) || publicId.equals(DTD_PUBLIC_ID_ALIAS)) {
-			InputStream in = DocumentParser.class.getResourceAsStream("/aspectj_1_5_0.dtd");
-			if (in == null) {
-				System.err.println("AspectJ - WARN - could not read DTD " + publicId);
-				return null;
-			} else {
-				return new InputSource(in);
-			}
-		} else {
-			System.err.println("AspectJ - WARN - unknown DTD " + publicId + " - consider using " + DTD_PUBLIC_ID);
+private static void configureFactoryFeature(SAXParserFactory factory, String feature, boolean value) {
+	try {
+		factory.setFeature(feature, value);
+	} catch (ParserConfigurationException | SAXException e) {
+		// Ignore unsupported security feature on this parser implementation
+	}
+}
+
+private static void configureReaderFeature(XMLReader reader, String feature, boolean value) {
+	try {
+		reader.setFeature(feature, value);
+	} catch (SAXException e) {
+		// Ignore unsupported security feature on this XMLReader implementation
+	}
+}
+
+public InputSource resolveEntity(String publicId, String systemId) throws SAXException {
+	if (publicId.equals(DTD_PUBLIC_ID) || publicId.equals(DTD_PUBLIC_ID_ALIAS)) {
+		InputStream in = DocumentParser.class.getResourceAsStream("/aspectj_1_5_0.dtd");
+		if (in == null) {
+			System.err.println("AspectJ - WARN - could not read DTD " + publicId);
 			return null;
+		} else {
+			return new InputSource(in);
 		}
+	} else {
+		System.err.println("AspectJ - WARN - unknown DTD " + publicId + " - consider using " + DTD_PUBLIC_ID);
+		return null;
 	}
+}
 
-	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
 		if (ASPECT_ELEMENT.equals(qName)) {
 			String name = attributes.getValue(NAME_ATTRIBUTE);
 			String scopePattern = replaceXmlAnd(attributes.getValue(SCOPE_ATTRIBUTE));


### PR DESCRIPTION
Implemented XML parser hardening in DocumentParser to prevent external entity resolution during AspectJ load-time definition parsing.

Changes
- Enabled secure SAX parser processing
- Disabled:
  - external general entities
  - external parameter entities
  - external DTD loading
- Applied secure parser configuration to both SAXParserFactory and XMLReader
- Added regression test coverage for malicious XML containing external entity references
- Added evil.xml test fixture to validate secure parsing behavior